### PR TITLE
fix(security): add helmet middleware to server/index.js (VULN-009)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@ import "./env.js";
 import express from "express";
 import cors from "cors";
 import bodyParser from "body-parser";
+import helmet from "helmet";
 
 import jiraRoutes from "./routes/jira.js";
 import confluenceRoutes from "./routes/confluence.js";
@@ -10,6 +11,24 @@ import apiLimiter from "./utils/rateLimiter.js";
 
 const app = express();
 const PORT = process.env.PORT || 4000;
+
+// Security headers
+app.use(helmet({
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      imgSrc: ["'self'", "data:", "https:"],
+    }
+  },
+  hsts: {
+    maxAge: 31536000,
+    includeSubDomains: true,
+  },
+  frameguard: { action: 'deny' },
+  crossOriginEmbedderPolicy: false,
+}));
 
 app.use(cors());
 app.use(bodyParser.json());

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,7 +14,8 @@
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "express-rate-limit": "^8.2.1",
-        "express-validator": "^7.3.1"
+        "express-validator": "^7.3.1",
+        "helmet": "^8.1.0"
       }
     },
     "node_modules/accepts": {
@@ -576,6 +577,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "express-rate-limit": "^8.2.1",
-    "express-validator": "^7.3.1"
+    "express-validator": "^7.3.1",
+    "helmet": "^8.1.0"
   }
 }


### PR DESCRIPTION
# Pull Request: Fix VULN-009 - Add Security Headers using Helmet

## Summary

This PR resolves medium-severity vulnerability VULN-009 by adding Helmet middleware to `server/index.js`, setting essential security headers including Content-Security-Policy (CSP), X-Frame-Options, and HSTS. This protects the backend from clickjacking, XSS, and man-in-the-middle attacks.

## Changes Included

### 🚀 Backend Security Enhancements

* Added Helmet middleware globally in `server/index.js`.
* Configured CSP to allow only trusted sources for scripts, styles, and images.
* Enforced HSTS to require HTTPS and include subdomains.
* Set `X-Frame-Options` to deny framing to prevent clickjacking.
* Default Helmet headers applied for additional security (X-Content-Type-Options, Referrer-Policy, etc.).

### 🧪 Testing & Verification

* Verified that all responses include the new security headers using Postman and curl.
* Manual testing confirms mitigation of XSS and clickjacking risks.

## Impact

* ✅ Vulnerability Mitigated: Backend now sets proper security headers addressing VULN-009.
* ✅ Increased Security: Protects against XSS, clickjacking, and MITM attacks.
* ✅ Production Ready: Ensures the Express server follows security best practices.
