### PR TITLE
docs: add README for Sample_Artifacts folder

### DIFF
--- a/Sample_Artifacts/README.md
+++ b/Sample_Artifacts/README.md
@@ -1,0 +1,46 @@
+# Sample Artifacts
+
+This folder contains example evidence artifacts that support CSF assessments.
+
+## What Goes Here
+
+Documents and records an auditor would collect as proof during an assessment. Examples include:
+
+- **Policies** - Information security, access management, incident response
+- **Procedures** - SOPs for security operations, change management
+- **Reports** - Phishing campaign results, vulnerability scans, audit reports
+- **Inventories** - Asset lists, user access matrices, vendor lists
+- **Tickets** - SOC tickets, incident records, change requests
+- **Screenshots** - Configuration evidence, dashboard exports
+
+## File Naming Convention
+
+```
+{Descriptive-Name}.md (or .xlsx, .csv for data files)
+
+Examples:
+- Access Management Policy.md
+- Third Party Risk Management Policy.md
+- SOC-Ticket-1001.md
+- 2025-05-26_Phish-1001-LI-Campaign-Data.xlsx
+```
+
+## Template
+
+For policy documents, include:
+
+- **Metadata table** - Policy ID, version, effective date, owner
+- **Purpose** - Why this policy exists
+- **Scope** - Who/what it applies to
+- **Roles & Responsibilities** - RACI or responsibility matrix
+- **Requirements** - The actual policy statements
+- **Related Documents** - Links to supporting procedures
+- **Version History** - Change log
+
+See existing files in this folder for standard formats.
+
+## Contributing
+
+1. Pick an unassigned CSF subcategory from the [Issues](https://github.com/CPAtoCybersecurity/csf_profile/issues)
+2. Create artifacts that would support assessment of that control
+3. Submit a Pull Request referencing the issue number


### PR DESCRIPTION
## Summary

Adds README.md to Sample_Artifacts folder for consistency with Sample_Observations and Test_Procedures folders.

## Content

- What goes in this folder (policies, procedures, reports, inventories, tickets, screenshots)
- File naming convention
- Template guidance for policy documents
- Contributing instructions

## Test plan

- [x] Follows same format as other folder READMEs