### PR TITLE
Fix: Remove hardcoded Confluence config and move to env-based backend config

### DIFF
--- a/server/config.example.json
+++ b/server/config.example.json
@@ -1,17 +1,17 @@
 {
-  "jira": {
-    "baseUrl": "https://your-domain.atlassian.net",
-    "email": "your-email@example.com",
-    "apiToken": "your-jira-api-token"
-  },
-  "confluence": {
-    "baseUrl": "https://your-domain.atlassian.net",
-    "email": "your-email@example.com",
-    "apiToken": "your-confluence-api-token"
-  },
-  "ai": {
-    "claudeApiKey": "your-claude-api-key",
-    "claudeModel": "claude-sonnet-4-20250514",
-    "claudeTimeoutMs": 60000
-  }
+  "JIRA_BASE_URL": "https://your-domain.atlassian.net",
+  "JIRA_EMAIL": "your-email@example.com",
+  "JIRA_API_TOKEN": "your-jira-api-token",
+
+  "CONFLUENCE_BASE_URL": "https://your-domain.atlassian.net",
+  "CONFLUENCE_EMAIL": "your-email@example.com",
+  "CONFLUENCE_API_TOKEN": "your-confluence-api-token",
+
+  "CONFLUENCE_SPACE_KEY": "your-space-key",
+  "CONFLUENCE_REQUIREMENTS_DB_ID": "your-db-id",
+  "CONFLUENCE_CONTROLS_DB_ID": "optional-db-id",
+
+  "CLAUDE_API_KEY": "your-claude-api-key",
+  "CLAUDE_MODEL": "claude-sonnet-4-20250514",
+  "CLAUDE_TIMEOUT_MS": 60000
 }

--- a/server/controllers/configController.js
+++ b/server/controllers/configController.js
@@ -37,6 +37,14 @@ const getEnvConfig = () => {
       model: process.env.CLAUDE_MODEL || "claude-sonnet-4-20250514"
     };
   }
+  if (process.env.CONFLUENCE_BASE_URL || process.env.CONFLUENCE_SPACE_KEY || process.env.CONFLUENCE_REQUIREMENTS_DB_ID) {
+    config.confluenceMeta = {
+      baseUrl: process.env.CONFLUENCE_BASE_URL || '',
+      spaceKey: process.env.CONFLUENCE_SPACE_KEY || '',
+      requirementsDbId: process.env.CONFLUENCE_REQUIREMENTS_DB_ID || '',
+      controlsDbId: process.env.CONFLUENCE_CONTROLS_DB_ID || ''
+    };
+  }
   return config;
 };
 
@@ -64,6 +72,15 @@ const maskConfig = (config) => {
       model: config.ai.model,
       apiKey: maskToken(config.ai.apiKey),
       configured: !!config.ai.apiKey
+    };
+  }
+  if (config.confluenceMeta) {
+    masked.confluenceMeta = {
+      baseUrl: config.confluenceMeta.baseUrl,
+      spaceKey: config.confluenceMeta.spaceKey,
+      requirementsDbId: config.confluenceMeta.requirementsDbId,
+      controlsDbId: config.confluenceMeta.controlsDbId,
+      configured: !!(config.confluenceMeta.baseUrl && config.confluenceMeta.spaceKey && config.confluenceMeta.requirementsDbId)
     };
   }
   return masked;

--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,7 @@ import useAssessmentsStore from './stores/assessmentsStore';
 // Utils
 import { shouldShowBackupReminder, updateLastReminderDate } from './utils/backupTracking';
 import { checkEnvironmentVariables } from './utils/envValidation';
-import { initializeEntryIdMappings } from './utils/confluenceSync';
+import { initializeEntryIdMappings, loadConfluenceConfig } from './utils/confluenceSync';
 
 const AppContent = () => {
   const loadRequirements = useRequirementsStore((state) => state.loadInitialData);
@@ -46,6 +46,7 @@ const AppContent = () => {
   const [lastBackupTrigger, setLastBackupTrigger] = useState(0);
 
   useEffect(() => {
+    loadConfluenceConfig();
     initializeEntryIdMappings();
   }, []);
 

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -45,8 +45,7 @@ import {
   harvestEntryIds,
   getAllEntryIdMappings,
   importEntryIdsFromCSV,
-  exportEntryIdsToCSV,
-  updateConfluenceConfig
+  exportEntryIdsToCSV
 } from '../utils/confluenceSync';
 
 const Settings = () => {
@@ -184,7 +183,8 @@ const Settings = () => {
         setConfigStatus({ jira: true, confluence: true });
 
         // Update Confluence config with new base URL for local operations
-        updateConfluenceConfig({ baseUrl: atlassianSiteUrl.replace(/\/$/, '') });
+        // Removed for Now
+        // updateConfluenceConfig({ baseUrl: atlassianSiteUrl.replace(/\/$/, '') });
 
         toast.success('Configuration saved securely to server');
       } else {

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -45,7 +45,8 @@ import {
   harvestEntryIds,
   getAllEntryIdMappings,
   importEntryIdsFromCSV,
-  exportEntryIdsToCSV
+  exportEntryIdsToCSV,
+  loadConfluenceConfig
 } from '../utils/confluenceSync';
 
 const Settings = () => {
@@ -182,10 +183,7 @@ const Settings = () => {
         setAtlassianApiToken('');
         setConfigStatus({ jira: true, confluence: true });
 
-        // Update Confluence config with new base URL for local operations
-        // Removed for Now
-        // updateConfluenceConfig({ baseUrl: atlassianSiteUrl.replace(/\/$/, '') });
-
+        await loadConfluenceConfig();
         toast.success('Configuration saved securely to server');
       } else {
         const error = await jiraRes.json();

--- a/src/utils/confluenceSync.js
+++ b/src/utils/confluenceSync.js
@@ -15,13 +15,8 @@
 const API_BASE_URL = process.env.REACT_APP_API_URL || '';
 let isInitialized = false;
 
-// Confluence configuration (should be injected via config APIs ideally)
-const CONFLUENCE_CONFIG = {
-  baseUrl: '',
-  spaceKey: '',
-  requirementsDbId: '',
-  controlsDbId: null
-};
+// Confluence configuration
+let confluenceConfig=undefined;
 
 /**
  * Frontend cache (source of truth is backend)
@@ -100,6 +95,56 @@ export async function setEntryId(requirementId, entryId) {
   await saveEntryIdMappings({ [requirementId]: entryId });
 }
 
+/** 
+ * Ensures Confluence config is available before usage
+ * Prevents runtime errors when app initializes slowly or API call fails
+ */ 
+const ensureConfigLoaded = () => {
+  if (!confluenceConfig) {
+    console.warn("Confluence config not loaded yet. Call loadConfluenceConfig() before using Confluence utilities.");
+    return false;
+  }
+  return true;
+};
+
+// Load Confluence configuration from backend (env-backed config)
+export async function loadConfluenceConfig() {
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/config/status`, {
+      credentials: "include"
+    });
+
+    if (!res.ok) throw new Error("Failed to load config");
+
+    const data = await res.json();
+    const cfg = data?.data?.confluenceMeta;
+
+    if (!cfg || typeof cfg !== "object") {
+      throw new Error("Invalid config format");
+    }
+
+    const { baseUrl, spaceKey, requirementsDbId, controlsDbId } = cfg;
+
+    if (!baseUrl || !spaceKey || !requirementsDbId) {
+      throw new Error("Missing required Confluence config fields");
+    }
+
+    if (typeof baseUrl !== "string" || typeof spaceKey !== "string" || typeof requirementsDbId !== "string") {
+      throw new Error("Invalid Confluence config types");
+    }
+
+    confluenceConfig = {
+      baseUrl,
+      spaceKey,
+      requirementsDbId,
+      controlsDbId: controlsDbId || null
+    };
+    console.log(confluenceConfig)
+  } catch (err) {
+    console.error("Failed to load Confluence config:", err);
+  }
+}
+
 /**
  * Generate Smart-Embed URL for a Confluence database entry
  *
@@ -113,14 +158,17 @@ export async function setEntryId(requirementId, entryId) {
  * @param {string} databaseId - The database ID (defaults to requirements DB)
  * @returns {string} The Smart-Embed URL
  */
-export function generateSmartEmbedUrl(entryId, databaseId = CONFLUENCE_CONFIG.requirementsDbId) {
+export function generateSmartEmbedUrl(entryId, databaseId = confluenceConfig?.requirementsDbId) {
   if (!entryId) return null;
+  if (!ensureConfigLoaded()) {
+    throw new Error("Confluence config not loaded");
+  }
 
-  if (!CONFLUENCE_CONFIG.baseUrl || !CONFLUENCE_CONFIG.spaceKey || !databaseId) {
+  if (!confluenceConfig?.baseUrl || !confluenceConfig?.spaceKey || !databaseId) {
     console.warn("Confluence config incomplete");
     return null;
   }
-  return `${CONFLUENCE_CONFIG.baseUrl}/wiki/spaces/${CONFLUENCE_CONFIG.spaceKey}/database/${databaseId}/entry/${entryId}`;
+  return `${confluenceConfig.baseUrl}/wiki/spaces/${confluenceConfig.spaceKey}/database/${databaseId}/entry/${entryId}`;
 }
 
 /**
@@ -242,12 +290,15 @@ export function parseConfluenceEntriesResponse(apiResponse) {
  * @returns {Promise<object>} Mapping of requirementId -> entryId
  */
 export async function harvestEntryIds(apiToken, email) {
+  if (!ensureConfigLoaded()) {
+    throw new Error("Confluence config not loaded");
+  }
   const auth = btoa(`${email}:${apiToken}`);
 
   try {
     // Note: The exact API endpoint may vary based on Confluence version
     const response = await fetch(
-      `${CONFLUENCE_CONFIG.baseUrl}/wiki/api/v2/databases/${CONFLUENCE_CONFIG.requirementsDbId}/entries?limit=250`,
+      `${confluenceConfig?.baseUrl}/wiki/api/v2/databases/${confluenceConfig?.requirementsDbId}/entries?limit=250`,
       {
         headers: {
           'Authorization': `Basic ${auth}`,
@@ -353,14 +404,10 @@ export async function clearEntryIdMappings() {
  * Get Confluence configuration
  */
 export function getConfluenceConfig() {
-  return { ...CONFLUENCE_CONFIG };
-}
-
-/**
- * Update Confluence configuration
- */
-export function updateConfluenceConfig(updates) {
-  Object.assign(CONFLUENCE_CONFIG, updates);
+  if (!ensureConfigLoaded()) {
+    throw new Error("Confluence config not loaded");
+  }
+  return { ...confluenceConfig};
 }
 
 export default {
@@ -377,5 +424,5 @@ export default {
   getAllEntryIdMappings,
   clearEntryIdMappings,
   getConfluenceConfig,
-  updateConfluenceConfig
+  loadConfluenceConfig
 };

--- a/src/utils/confluenceSync.js
+++ b/src/utils/confluenceSync.js
@@ -101,10 +101,8 @@ export async function setEntryId(requirementId, entryId) {
  */ 
 const ensureConfigLoaded = () => {
   if (!confluenceConfig) {
-    console.warn("Confluence config not loaded yet. Call loadConfluenceConfig() before using Confluence utilities.");
-    return false;
+    throw new Error("Confluence config not loaded. Call loadConfluenceConfig() first.");
   }
-  return true;
 };
 
 // Load Confluence configuration from backend (env-backed config)
@@ -139,7 +137,6 @@ export async function loadConfluenceConfig() {
       requirementsDbId,
       controlsDbId: controlsDbId || null
     };
-    console.log(confluenceConfig)
   } catch (err) {
     console.error("Failed to load Confluence config:", err);
   }
@@ -160,9 +157,7 @@ export async function loadConfluenceConfig() {
  */
 export function generateSmartEmbedUrl(entryId, databaseId = confluenceConfig?.requirementsDbId) {
   if (!entryId) return null;
-  if (!ensureConfigLoaded()) {
-    throw new Error("Confluence config not loaded");
-  }
+  ensureConfigLoaded();
 
   if (!confluenceConfig?.baseUrl || !confluenceConfig?.spaceKey || !databaseId) {
     console.warn("Confluence config incomplete");
@@ -290,9 +285,7 @@ export function parseConfluenceEntriesResponse(apiResponse) {
  * @returns {Promise<object>} Mapping of requirementId -> entryId
  */
 export async function harvestEntryIds(apiToken, email) {
-  if (!ensureConfigLoaded()) {
-    throw new Error("Confluence config not loaded");
-  }
+  ensureConfigLoaded();
   const auth = btoa(`${email}:${apiToken}`);
 
   try {
@@ -404,9 +397,7 @@ export async function clearEntryIdMappings() {
  * Get Confluence configuration
  */
 export function getConfluenceConfig() {
-  if (!ensureConfigLoaded()) {
-    throw new Error("Confluence config not loaded");
-  }
+  ensureConfigLoaded();
   return { ...confluenceConfig};
 }
 


### PR DESCRIPTION
Closes #75


- Moved all Confluence configuration to backend env variables and exposed via /api/config/status.
- Frontend now loads config at runtime instead of hardcoding it, and no longer mutates config locally.
- This aligns it with how Jira/Confluence credentials are already handled.