### PR TITLE
Fix: Add input validation for Atlassian configuration fields (CWE-20)

### DIFF
--- a/server/controllers/configController.js
+++ b/server/controllers/configController.js
@@ -164,26 +164,13 @@ export const getConfigStatus = (req, res) => {
 // POST /api/config/test - Test Atlassian connection using provided credentials
 export const testConnection = async (req, res) => {
   const { service, baseUrl, email, apiToken } = req.body;
-
-  if (!service || !baseUrl || !email || !apiToken) {
-    return res.status(400).json({
-      success: false,
-      error: "Missing required fields: service, baseUrl, email, apiToken"
-    });
-  }
-
-  if (!['jira', 'confluence'].includes(service)) {
-    return res.status(400).json({
-      success: false,
-      error: "Service must be 'jira' or 'confluence'"
-    });
-  }
+  const sanitizedBaseUrl = baseUrl.replace(/\/$/, "");
 
   try {
     const auth = Buffer.from(`${email}:${apiToken}`).toString('base64');
     const testUrl = service === 'jira'
-      ? `${baseUrl}/rest/api/3/myself`
-      : `${baseUrl}/wiki/rest/api/user/current`;
+      ? `${sanitizedBaseUrl}/rest/api/3/myself`
+      : `${sanitizedBaseUrl}/wiki/rest/api/user/current`;
 
     const response = await fetch(testUrl, {
       method: 'GET',
@@ -206,7 +193,9 @@ export const testConnection = async (req, res) => {
     } else {
       res.status(response.status).json({
         success: false,
-        error: "Connection failed. Please verify credentials and permissions."
+        error: response.status === 401
+          ? "Authentication failed. Check email/API token."
+          : "Connection failed. Verify URL and permissions."
       });
     }
   } catch (error) {

--- a/server/middlewares/validators/configValidator.js
+++ b/server/middlewares/validators/configValidator.js
@@ -1,0 +1,42 @@
+import { body } from "express-validator";
+
+export const atlassianConfigValidation = [
+    body("service")
+        .isIn(["jira", "confluence"])
+        .withMessage("Service must be 'jira' or 'confluence'"),
+
+    body("baseUrl")
+        .isString()
+        .trim()
+        .notEmpty()
+        .withMessage("baseUrl is required")
+        .isLength({ max: 2048 })
+        .withMessage("URL too long")
+        .isURL({ require_protocol: true })
+        .withMessage("Invalid URL format")
+        .custom((value) => {
+            if (!value.startsWith("https://")) {
+                throw new Error("Only HTTPS URLs are allowed");
+            }
+            return true;
+        }),
+
+    body("email")
+        .isString()
+        .trim()
+        .normalizeEmail()
+        .notEmpty()
+        .withMessage("Email is required")
+        .isEmail()
+        .withMessage("Invalid email format")
+        .isLength({ max: 254 })
+        .withMessage("Email too long"),
+
+    body("apiToken")
+        .isString()
+        .trim()
+        .notEmpty()
+        .withMessage("API token is required")
+        .isLength({ min: 10, max: 200 })
+        .withMessage("API token length invalid"),
+];

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -7,6 +7,8 @@ import {
   testConnection,
   saveAIConfig,
 } from "../controllers/configController.js";
+import { atlassianConfigValidation } from "../middlewares/validators/configValidator.js";
+import { validateRequest } from "../middlewares/validators/validateRequest.js";
 
 const router = express.Router();
 
@@ -16,7 +18,7 @@ router.use(configAuth);
 router.post("/jira", saveJiraConfig);
 router.post("/confluence", saveConfluenceConfig);
 router.get("/status", getConfigStatus);
-router.post("/test", testConnection);
+router.post("/test", atlassianConfigValidation, validateRequest, testConnection);
 router.post("/ai", saveAIConfig);
 
 export default router;  


### PR DESCRIPTION
Fixes #76

## Summary
This PR adds proper input validation for Atlassian configuration fields in the Settings page to address CWE-20 (Improper Input Validation).

## Changes
- Added validation middleware using express-validator for:
  - `service` (must be 'jira' or 'confluence')
  - `baseUrl` (valid URL, HTTPS-only, length limit)
  - `email` (valid email format, length limit)
  - `apiToken` (required with length constraints)
- Integrated validation into `/api/config/test` route
- Centralized validation error handling using existing `validateRequest` middleware
- Removed manual validation logic from controller
- Added backend sanitization for `baseUrl` (trailing slash normalization)
- Improved error messaging for authentication vs connection failures

## Security Impact
This prevents:
- Invalid email inputs
- Unsafe URL schemes (e.g. `javascript:`)
- Malformed or excessively large input payloads
- Direct API misuse bypassing frontend validation

## Notes
* Frontend validation may still be improved separately, but backend validation ensures security regardless of client behavior.
* Used ```express-validator``` instead of ```zod``` for consistency as other routes are already implemented with ```express-validator```.