### PR TITLE
feat(dashboard): replace 4-card top strip with situation report (#212)

### DIFF
--- a/src/components/InvestmentPrioritiesPanel.js
+++ b/src/components/InvestmentPrioritiesPanel.js
@@ -1,0 +1,244 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import toast from 'react-hot-toast';
+import useFindingsStore from '../stores/findingsStore';
+import UserSelector from './UserSelector';
+import StatusPill from './StatusPill';
+import InvestmentPriorityCommentEditor from './InvestmentPriorityCommentEditor';
+import { safeNum } from '../utils/dashboardMetrics';
+
+const STATUS_OPTIONS = ['NOT STARTED', 'IN PROGRESS', 'RESOLVED'];
+
+// Map dashboard status pill values back to the canonical finding-store status string.
+const dashboardStatusToFindingStatus = (status) => {
+  if (status === 'IN PROGRESS') return 'In Progress';
+  if (status === 'RESOLVED') return 'Resolved';
+  if (status === 'STALLED') return 'In Progress';
+  return 'Not Started';
+};
+
+const FORMULA_TOOLTIP = 'score = gap × max(priorityImpact, functionWeight) × log(1 + linkedFindings)';
+
+/**
+ * InvestmentPrioritiesPanel — table of subcategories ranked by investment score.
+ *
+ * Props:
+ *   rows                  {Array} — output of investmentPriorities()
+ *   selectedAssessmentId  {string}
+ *   darkMode              {boolean}
+ *
+ * Owner + status edits broadcast to all linked findings, re-resolving findings
+ * via useFindingsStore.getState() to avoid stale-closure bugs.
+ */
+const InvestmentPrioritiesPanel = ({ rows, selectedAssessmentId, darkMode }) => {
+  const [showAll, setShowAll] = useState(false);
+  const [expandedRow, setExpandedRow] = useState(null);
+  const [draftComment, setDraftComment] = useState('');
+  const updateFinding = useFindingsStore((state) => state.updateFinding);
+
+  const safeRows = useMemo(() => (Array.isArray(rows) ? rows : []), [rows]);
+  const totalRows = safeRows.length;
+  const visibleRows = showAll ? safeRows : safeRows.slice(0, 5);
+  const totalLinkedFindings = safeRows.reduce((sum, r) => sum + (r.linkedFindings || 0), 0);
+  const visibleLinkedFindings = visibleRows.reduce((sum, r) => sum + (r.linkedFindings || 0), 0);
+
+  const cardBg = darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200';
+  const headerColor = darkMode ? 'text-gray-100' : 'text-gray-900';
+  const subColor = darkMode ? 'text-gray-400' : 'text-gray-500';
+  const headerRowClass = darkMode ? 'text-gray-400 border-gray-600' : 'text-gray-500 border-gray-200';
+  const rowBorderClass = darkMode ? 'border-gray-700 hover:bg-gray-700/50' : 'border-gray-100 hover:bg-gray-50';
+
+  const broadcastUpdate = useCallback(
+    (subcategoryId, patch) => {
+      const row = safeRows.find((r) => r.categoryId === subcategoryId);
+      if (!row || !row.linkedFindingIds || row.linkedFindingIds.length === 0) return 0;
+      const ids = row.linkedFindingIds;
+      const fresh = useFindingsStore.getState().findings;
+      const toUpdate = fresh.filter((f) => ids.includes(f.id) && f.assessmentId === selectedAssessmentId);
+      toUpdate.forEach((f) => updateFinding(f.id, patch));
+      return toUpdate.length;
+    },
+    [safeRows, selectedAssessmentId, updateFinding]
+  );
+
+  const handleOwnerChange = useCallback(
+    (subcategoryId, newOwnerId) => {
+      const n = broadcastUpdate(subcategoryId, { remediationOwner: newOwnerId });
+      if (n > 0) toast.success(`Updated owner on ${n} findings`);
+    },
+    [broadcastUpdate]
+  );
+
+  const handleStatusChange = useCallback(
+    (subcategoryId, newDashboardStatus) => {
+      const findingStatus = dashboardStatusToFindingStatus(newDashboardStatus);
+      const n = broadcastUpdate(subcategoryId, { status: findingStatus });
+      if (n > 0) toast.success(`Updated status on ${n} findings`);
+    },
+    [broadcastUpdate]
+  );
+
+  const handleToggleExpand = (row) => {
+    if (!row.commentFindingId) return;
+    if (expandedRow === row.categoryId) {
+      setExpandedRow(null);
+      setDraftComment('');
+    } else {
+      setExpandedRow(row.categoryId);
+      setDraftComment(row.commentFindingDescription || '');
+    }
+  };
+
+  const handleSaveComment = (row) => {
+    if (!row.commentFindingId) return;
+    updateFinding(row.commentFindingId, { description: draftComment });
+    toast.success('Updated analyst comment');
+    setExpandedRow(null);
+    setDraftComment('');
+  };
+
+  if (totalRows === 0) {
+    return (
+      <div className={`card border p-4 ${cardBg}`} style={{ borderRadius: 0 }}>
+        <h2 className={`text-base font-semibold mb-2 ${headerColor}`}>Top investment priorities</h2>
+        <p className={`text-sm ${subColor}`}>No subcategory data for this assessment.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`card border p-4 ${cardBg}`} style={{ borderRadius: 0 }}>
+      <div className="flex items-baseline justify-between mb-1">
+        <h2 className={`text-base font-semibold ${headerColor}`} title={FORMULA_TOOLTIP}>
+          Top investment priorities
+        </h2>
+      </div>
+      <div className={`text-xs mb-3 ${subColor}`} title={FORMULA_TOOLTIP}>
+        Highest gap × business impact · <span style={{ fontVariantNumeric: 'tabular-nums' }}>{visibleLinkedFindings}</span> of{' '}
+        <span style={{ fontVariantNumeric: 'tabular-nums' }}>{totalLinkedFindings}</span> findings
+      </div>
+
+      <table className="w-full text-sm">
+        <thead>
+          <tr className={`text-xs uppercase border-b ${headerRowClass}`}>
+            <th className="text-left py-2 px-2">#</th>
+            <th className="text-left py-2 px-2">Subcategory</th>
+            <th className="text-left py-2 px-2">Function</th>
+            <th className="text-right py-2 px-2">Gap</th>
+            <th className="text-left py-2 px-2">Linked Findings</th>
+            <th className="text-left py-2 px-2">Owner</th>
+            <th className="text-left py-2 px-2" title="IN PROGRESS · STALLED >60d · NOT STARTED · RESOLVED — derived from linked findings (Open → Not Started, Done/Closed → Resolved)">
+              Status
+            </th>
+            <th className="py-2 px-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {visibleRows.map((row) => {
+            const linkedCount = safeNum(row.linkedFindings, 0);
+            const critCount = safeNum(row.critCount, 0);
+            const gap = safeNum(row.gap, 0);
+            const formatGap = (n) => (typeof n === 'number' ? n.toFixed(1) : n);
+            const canExpand = !!row.commentFindingId;
+            const isExpanded = expandedRow === row.categoryId;
+            return (
+              <React.Fragment key={row.categoryId}>
+                <tr className={`border-b ${rowBorderClass}`}>
+                  <td className={`py-2 px-2 font-medium ${darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+                    {row.rank}
+                  </td>
+                  <td className={`py-2 px-2 font-mono text-xs ${darkMode ? 'text-gray-200' : 'text-gray-800'}`}>
+                    {row.categoryId}
+                  </td>
+                  <td className={`py-2 px-2 ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                    {row.function}
+                  </td>
+                  <td
+                    className={`py-2 px-2 text-right font-semibold ${darkMode ? 'text-gray-200' : 'text-gray-800'}`}
+                    style={{ fontVariantNumeric: 'tabular-nums' }}
+                  >
+                    {formatGap(gap)}
+                  </td>
+                  <td className={`py-2 px-2 ${darkMode ? 'text-gray-300' : 'text-gray-700'}`} style={{ fontVariantNumeric: 'tabular-nums' }}>
+                    {linkedCount} ({critCount} crit)
+                  </td>
+                  <td className="py-2 px-2">
+                    {linkedCount > 0 ? (
+                      <UserSelector
+                        label=""
+                        selectedUsers={row.owner}
+                        onChange={(newId) => handleOwnerChange(row.categoryId, newId)}
+                        multiple={false}
+                      />
+                    ) : (
+                      <span className={subColor}>--</span>
+                    )}
+                  </td>
+                  <td className="py-2 px-2">
+                    <div className="flex items-center gap-2">
+                      <StatusPill status={row.status} label={row.statusLabel} title={FORMULA_TOOLTIP} />
+                      {linkedCount > 0 && (
+                        <select
+                          aria-label={`Change status for ${row.categoryId}`}
+                          value={row.status === 'STALLED' ? 'IN PROGRESS' : row.status === 'RESOLVED' ? 'RESOLVED' : row.status}
+                          onChange={(e) => handleStatusChange(row.categoryId, e.target.value)}
+                          className={`text-xs border px-1 py-0.5 ${darkMode ? 'bg-gray-900 border-gray-600 text-gray-200' : 'bg-white border-gray-300 text-gray-700'}`}
+                        >
+                          {STATUS_OPTIONS.map((opt) => (
+                            <option key={opt} value={opt}>
+                              {opt}
+                            </option>
+                          ))}
+                        </select>
+                      )}
+                    </div>
+                  </td>
+                  <td className="py-2 px-2">
+                    {canExpand && (
+                      <button
+                        type="button"
+                        aria-label={isExpanded ? 'Collapse analyst comment' : 'Expand analyst comment'}
+                        onClick={() => handleToggleExpand(row)}
+                        className={`${darkMode ? 'text-gray-300 hover:text-white' : 'text-gray-500 hover:text-gray-900'}`}
+                      >
+                        {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                      </button>
+                    )}
+                  </td>
+                </tr>
+                {isExpanded && canExpand && (
+                  <tr className={darkMode ? 'bg-gray-900' : 'bg-gray-50'}>
+                    <InvestmentPriorityCommentEditor
+                      categoryId={row.categoryId}
+                      findingId={row.commentFindingId}
+                      value={draftComment}
+                      onChange={setDraftComment}
+                      onCancel={() => handleToggleExpand(row)}
+                      onSave={() => handleSaveComment(row)}
+                      subtitleColor={subColor}
+                      darkMode={darkMode}
+                    />
+                  </tr>
+                )}
+              </React.Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+
+      {totalRows > 5 && (
+        <div className="mt-2">
+          <button
+            type="button"
+            onClick={() => setShowAll((v) => !v)}
+            className={`text-xs ${darkMode ? 'text-gray-300 hover:text-white' : 'text-gray-600 hover:text-gray-900'}`}
+          >
+            {showAll ? `Show top 5` : `Show all ${totalRows}`}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default InvestmentPrioritiesPanel;

--- a/src/components/InvestmentPriorityCommentEditor.js
+++ b/src/components/InvestmentPriorityCommentEditor.js
@@ -1,0 +1,57 @@
+import React from 'react';
+
+/**
+ * InvestmentPriorityCommentEditor — analyst-comment textarea row used inside
+ * the InvestmentPrioritiesPanel expand-toggle. Split out so the parent panel
+ * stays under the 250-line component cap (issue #212).
+ *
+ * Props:
+ *   categoryId       {string}
+ *   findingId        {string} — the linked finding whose `description` we edit
+ *   value            {string} — current draft text
+ *   onChange         {(v: string) => void}
+ *   onCancel         {() => void}
+ *   onSave           {() => void}
+ *   subtitleColor    {string} — Tailwind-ish class for the muted label
+ *   darkMode         {boolean}
+ */
+const InvestmentPriorityCommentEditor = ({
+  categoryId,
+  findingId,
+  value,
+  onChange,
+  onCancel,
+  onSave,
+  subtitleColor,
+  darkMode,
+}) => {
+  const textareaClass = darkMode
+    ? 'bg-gray-800 border-gray-600 text-gray-200'
+    : 'bg-white border-gray-300 text-gray-800';
+  const cancelClass = darkMode ? 'text-gray-300' : 'text-gray-600';
+
+  return (
+    <td colSpan={8} className="px-2 py-3">
+      <label className={`block text-xs mb-1 ${subtitleColor}`} htmlFor={`comment-${categoryId}`}>
+        Analyst comment (linked finding {findingId})
+      </label>
+      <textarea
+        id={`comment-${categoryId}`}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={3}
+        className={`w-full text-sm p-2 font-mono border ${textareaClass}`}
+      />
+      <div className="flex justify-end gap-2 mt-2">
+        <button type="button" onClick={onCancel} className={`text-xs px-2 py-1 ${cancelClass}`}>
+          Cancel
+        </button>
+        <button type="button" onClick={onSave} className="btn-terminal">
+          Save
+        </button>
+      </div>
+    </td>
+  );
+};
+
+export default InvestmentPriorityCommentEditor;

--- a/src/components/OverallMaturityCard.js
+++ b/src/components/OverallMaturityCard.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { safeNum } from '../utils/dashboardMetrics';
+
+/**
+ * OverallMaturityCard — Card 1 of the issue #212 top strip.
+ *
+ * Props:
+ *   data     {object} — { value, target, trend: { direction, delta, prevQuarter } | null, subtitle }
+ *   darkMode {boolean}
+ */
+const OverallMaturityCard = ({ data, darkMode }) => {
+  const valueNum = safeNum(data && data.value);
+  const targetNum = safeNum(data && data.target);
+  const subtitle = (data && data.subtitle) || 'Average actual score';
+  const trend = data && data.trend;
+
+  const titleColor = darkMode ? 'text-gray-400' : 'text-gray-500';
+
+  let trendNode = null;
+  if (trend) {
+    let arrow = '–';
+    let trendClass = 'terminal-card-rich-trend-neutral';
+    if (trend.direction === 'up') {
+      arrow = '▲';
+      trendClass = 'terminal-card-rich-trend-up';
+    } else if (trend.direction === 'down') {
+      arrow = '▼';
+      trendClass = 'terminal-card-rich-trend-down';
+    }
+    trendNode = (
+      <div className={`terminal-card-rich-subtitle ${trendClass}`} style={{ fontVariantNumeric: 'tabular-nums' }}>
+        {arrow} {trend.delta} vs {trend.prevQuarter}
+      </div>
+    );
+  }
+
+  const formatValue = (n) => (typeof n === 'number' ? n.toFixed(1) : n);
+
+  return (
+    <div className="terminal-card-rich">
+      <div className={`terminal-kpi-label text-xs uppercase tracking-wider ${titleColor}`}>
+        <span className="terminal-kpi-marker">▌</span> OVERALL MATURITY
+      </div>
+      <div>
+        <span className="terminal-card-rich-value">{formatValue(valueNum)}</span>
+        {typeof targetNum === 'number' && (
+          <span className="terminal-card-rich-secondary"> / {formatValue(targetNum)}</span>
+        )}
+      </div>
+      {subtitle && <div className="terminal-card-rich-subtitle">{subtitle}</div>}
+      {trendNode}
+    </div>
+  );
+};
+
+export default OverallMaturityCard;

--- a/src/components/RiskExposureCard.js
+++ b/src/components/RiskExposureCard.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { safeNum } from '../utils/dashboardMetrics';
+
+/**
+ * RiskExposureCard — Card 2 of the issue #212 top strip.
+ *
+ * Props:
+ *   data     {object} — { value, critCount, highCount, medLowCount, oldestOpenDays, slaBreached, isEmpty }
+ *   darkMode {boolean}
+ */
+const RiskExposureCard = ({ data, darkMode }) => {
+  const isEmpty = !data || data.isEmpty;
+  const value = safeNum(data && data.value, 0);
+  const titleColor = darkMode ? 'text-gray-400' : 'text-gray-500';
+
+  const valueDisplay = isEmpty ? '--' : value;
+
+  let slaLine = null;
+  if (!isEmpty && data && data.oldestOpenDays !== null && data.oldestOpenDays !== undefined) {
+    slaLine = (
+      <div className="terminal-card-rich-subtitle">
+        Oldest open: <span style={{ fontVariantNumeric: 'tabular-nums' }}>{data.oldestOpenDays}</span> days
+        {data.slaBreached && (
+          <span className="terminal-card-rich-trend-down"> · SLA breach</span>
+        )}
+      </div>
+    );
+  }
+
+  const critCount = data ? data.critCount || 0 : 0;
+  const highCount = data ? data.highCount || 0 : 0;
+  const medLowCount = data ? data.medLowCount || 0 : 0;
+
+  return (
+    <div className="terminal-card-rich">
+      <div className={`terminal-kpi-label text-xs uppercase tracking-wider ${titleColor}`}>
+        <span className="terminal-kpi-marker">▌</span> RISK EXPOSURE
+      </div>
+      <div>
+        <span className="terminal-card-rich-value">{valueDisplay}</span>
+        <span className="terminal-card-rich-secondary">critical</span>
+      </div>
+      {slaLine}
+      {!isEmpty && (
+        <div className="flex flex-wrap items-center gap-1" style={{ marginTop: 2 }}>
+          <span className="terminal-status-pill terminal-status-pill--stalled" title="Critical findings (open)">
+            {critCount} CRIT
+          </span>
+          <span className="terminal-status-pill terminal-status-pill--in-progress" title="High findings (open)">
+            {highCount} HIGH
+          </span>
+          <span className="terminal-status-pill terminal-status-pill--not-started" title="Medium and Low findings (open)">
+            {medLowCount} MED/LOW
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RiskExposureCard;

--- a/src/components/StatusPill.js
+++ b/src/components/StatusPill.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const STATUS_CLASS = {
+  'IN PROGRESS': 'terminal-status-pill--in-progress',
+  'STALLED': 'terminal-status-pill--stalled',
+  'NOT STARTED': 'terminal-status-pill--not-started',
+  'RESOLVED': 'terminal-status-pill--resolved',
+  'PLANNED': 'terminal-status-pill--planned',
+};
+
+/**
+ * StatusPill — small Bloomberg-terminal-style pill for subcategory status.
+ *
+ * Props:
+ *   status {string} — canonical status code (matches STATUS_CLASS keys)
+ *   label  {string} — display text (optional; falls back to status)
+ *   title  {string} — tooltip text (optional; falls back to status)
+ */
+const StatusPill = ({ status, label, title }) => {
+  const cls = STATUS_CLASS[status] || STATUS_CLASS['NOT STARTED'];
+  return (
+    <span className={`terminal-status-pill ${cls}`} title={title || status}>
+      {label || status}
+    </span>
+  );
+};
+
+export default StatusPill;

--- a/src/components/TopGapsPanel.js
+++ b/src/components/TopGapsPanel.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { safeNum } from '../utils/dashboardMetrics';
+
+/**
+ * TopGapsPanel — horizontal bar list of the top 5 subcategory gaps to target.
+ *
+ * Props:
+ *   gaps     {Array<{ categoryId, actual, target, gap, color }>}
+ *   darkMode {boolean}
+ */
+const TopGapsPanel = ({ gaps, darkMode }) => {
+  if (!Array.isArray(gaps) || gaps.length === 0) return null;
+
+  const cardBg = darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200';
+
+  const maxTarget = gaps.reduce((m, g) => (g.target > m ? g.target : m), 0) || 1;
+
+  return (
+    <div className={`card border p-4 ${cardBg}`} style={{ borderRadius: 0 }}>
+      <h2 className={`text-base font-semibold mb-3 ${darkMode ? 'text-gray-100' : 'text-gray-900'}`}>
+        Top 5 Gaps to Target
+      </h2>
+      <div className="flex flex-col gap-2">
+        {gaps.map((row) => {
+          const actualNum = safeNum(row.actual, 0);
+          const targetNum = safeNum(row.target, 0);
+          const fillPct = maxTarget > 0 ? (Math.max(0, actualNum) / maxTarget) * 100 : 0;
+          const tickPct = maxTarget > 0 ? (Math.max(0, targetNum) / maxTarget) * 100 : 0;
+          const fillClass = `terminal-gap-bar-fill terminal-gap-bar-fill--${row.color}`;
+          const formatNum = (n) => (typeof n === 'number' ? n.toFixed(1) : n);
+          return (
+            <div key={row.categoryId} className="flex items-center gap-2">
+              <span
+                className={`font-mono text-xs ${darkMode ? 'text-gray-200' : 'text-gray-800'}`}
+                style={{ minWidth: 56, display: 'inline-block' }}
+              >
+                {row.categoryId}
+              </span>
+              <div className="terminal-gap-bar" style={{ flex: 1 }}>
+                <div className={fillClass} style={{ width: `${Math.min(100, fillPct)}%` }} />
+                <div className="terminal-gap-bar-target-tick" style={{ left: `${Math.min(100, tickPct)}%` }} />
+              </div>
+              <span
+                className={`font-mono text-xs ${darkMode ? 'text-gray-300' : 'text-gray-700'}`}
+                style={{ fontVariantNumeric: 'tabular-nums', minWidth: 70, textAlign: 'right' }}
+              >
+                {formatNum(actualNum)} / {formatNum(targetNum)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default TopGapsPanel;

--- a/src/components/WeakestFunctionCard.js
+++ b/src/components/WeakestFunctionCard.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { safeNum } from '../utils/dashboardMetrics';
+
+/**
+ * WeakestFunctionCard — Card 3 of the issue #212 top strip.
+ *
+ * Props:
+ *   data     {object | null} — { functionCode, actual, target, delta, tieBreaker: { otherFunction, actual } | null }
+ *   darkMode {boolean}
+ */
+const WeakestFunctionCard = ({ data, darkMode }) => {
+  const titleColor = darkMode ? 'text-gray-400' : 'text-gray-500';
+
+  if (!data) {
+    return (
+      <div className="terminal-card-rich">
+        <div className={`terminal-kpi-label text-xs uppercase tracking-wider ${titleColor}`}>
+          <span className="terminal-kpi-marker">▌</span> WEAKEST FUNCTION
+        </div>
+        <div>
+          <span className="terminal-card-rich-value">--</span>
+        </div>
+        <div className="terminal-card-rich-subtitle">No gap detected this quarter.</div>
+      </div>
+    );
+  }
+
+  const actualNum = safeNum(data.actual);
+  const deltaNum = safeNum(data.delta);
+  const formatDelta = (n) => {
+    if (typeof n !== 'number') return n;
+    return n > 0 ? `+${n.toFixed(1)}` : n.toFixed(1);
+  };
+  const formatActual = (n) => (typeof n === 'number' ? n.toFixed(1) : n);
+
+  return (
+    <div className="terminal-card-rich">
+      <div className={`terminal-kpi-label text-xs uppercase tracking-wider ${titleColor}`}>
+        <span className="terminal-kpi-marker">▌</span> WEAKEST FUNCTION
+      </div>
+      <div>
+        <span className="terminal-card-rich-value" style={{ fontSize: 22 }}>{data.functionCode}</span>
+      </div>
+      <div className="terminal-card-rich-subtitle">
+        <span style={{ fontVariantNumeric: 'tabular-nums' }}>{formatActual(actualNum)}</span> actual ·{' '}
+        <span className="terminal-card-rich-trend-down" style={{ fontVariantNumeric: 'tabular-nums' }}>
+          {formatDelta(deltaNum)}
+        </span>{' '}
+        from target
+      </div>
+      {data.tieBreaker && (
+        <div className="terminal-card-rich-subtitle">
+          ▼ {data.tieBreaker.otherFunction} also at{' '}
+          <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+            {formatActual(safeNum(data.tieBreaker.actual))}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WeakestFunctionCard;

--- a/src/index.css
+++ b/src/index.css
@@ -1512,3 +1512,97 @@ nav a:active { text-decoration: none !important; }
   opacity: 0.4;
   cursor: not-allowed;
 }
+
+/* --- Issue #212 — Dashboard rich cards / gap bars / status pills --- */
+
+.terminal-card-rich {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 0;
+  font-family: var(--font-mono);
+  padding: 0.9rem 1rem;
+  transition: border-color 0.1s;
+  min-height: 130px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.terminal-card-rich:hover { border-color: var(--accent); }
+.dark .terminal-card-rich { background: var(--bg-primary); border-color: var(--border-color); }
+.dark .terminal-card-rich:hover { border-color: var(--accent); }
+
+.terminal-card-rich-value {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--text-primary);
+  line-height: 1;
+}
+.terminal-card-rich-secondary {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-left: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.terminal-card-rich-subtitle {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  letter-spacing: 0.03em;
+}
+.terminal-card-rich-trend-up { color: var(--terminal-green); }
+.terminal-card-rich-trend-down { color: var(--terminal-red); }
+.terminal-card-rich-trend-neutral { color: var(--text-muted); }
+
+/* Gap bars */
+.terminal-gap-bar {
+  position: relative;
+  height: 14px;
+  background: rgba(127,127,127,0.18);
+  flex: 1;
+  min-width: 80px;
+  overflow: visible;
+}
+.terminal-gap-bar-fill {
+  height: 100%;
+  background: var(--terminal-green);
+  transition: width 0.2s;
+}
+.terminal-gap-bar-fill--red    { background: var(--terminal-red); }
+.terminal-gap-bar-fill--amber  { background: var(--terminal-amber); }
+.terminal-gap-bar-fill--green  { background: var(--terminal-green); }
+.terminal-gap-bar-target-tick {
+  position: absolute;
+  top: -2px;
+  bottom: -2px;
+  width: 2px;
+  background: var(--text-primary);
+}
+.dark .terminal-gap-bar { background: rgba(255,255,255,0.08); }
+.dark .terminal-gap-bar-target-tick { background: var(--accent); }
+
+/* Status pills */
+.terminal-status-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border: 1px solid currentColor;
+  border-radius: 0;
+}
+.terminal-status-pill--in-progress { color: var(--terminal-amber); }
+.terminal-status-pill--stalled     { color: var(--terminal-red); }
+.terminal-status-pill--not-started { color: var(--text-muted); }
+.terminal-status-pill--resolved    { color: var(--terminal-green); }
+.terminal-status-pill--planned     { color: var(--terminal-cyan); }
+.dark .terminal-status-pill--in-progress { color: var(--terminal-amber); }
+.dark .terminal-status-pill--stalled     { color: var(--terminal-red); }
+.dark .terminal-status-pill--not-started { color: var(--text-muted); }
+.dark .terminal-status-pill--resolved    { color: var(--terminal-green); }
+.dark .terminal-status-pill--planned     { color: var(--terminal-cyan); }

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -28,58 +28,33 @@ import useRequirementsStore from '../stores/requirementsStore';
 import useUIStore from '../stores/uiStore';
 import useFindingsStore from '../stores/findingsStore';
 import useArtifactStore from '../stores/artifactStore';
-import KPICard from '../components/KPICard';
+import useUserStore from '../stores/userStore';
 import { generateAuditReportMarkdown } from '../utils/auditReportMarkdown';
 import EvidenceTracker from '../components/EvidenceTracker';
+import OverallMaturityCard from '../components/OverallMaturityCard';
+import RiskExposureCard from '../components/RiskExposureCard';
+import WeakestFunctionCard from '../components/WeakestFunctionCard';
+import TopGapsPanel from '../components/TopGapsPanel';
+import InvestmentPrioritiesPanel from '../components/InvestmentPrioritiesPanel';
+import {
+  overallMaturity,
+  riskExposure,
+  weakestFunction,
+  top5Gaps,
+  investmentPriorities,
+  FUNCTION_ORDER,
+  FUNCTION_WEIGHTS,
+  CATEGORY_ORDER,
+  DEFAULT_SLA_DAYS,
+  extractCategoryId,
+  normalizeFunctionName,
+} from '../utils/dashboardMetrics';
 
 // Format number to always show one decimal place
 const formatScore = (value) => {
   if (value === null || value === undefined) return null;
   return Number(value).toFixed(1);
 };
-
-// Define the order of functions for the pivot table
-const FUNCTION_ORDER = ['GOVERN (GV)', 'IDENTIFY (ID)', 'PROTECT (PR)', 'DETECT (DE)', 'RESPOND (RS)', 'RECOVER (RC)'];
-
-// Function weights for gap prioritization scoring
-const FUNCTION_WEIGHTS = {
-  'GOVERN (GV)': 1.2,
-  'IDENTIFY (ID)': 1.0,
-  'PROTECT (PR)': 1.1,
-  'DETECT (DE)': 1.1,
-  'RESPOND (RS)': 1.0,
-  'RECOVER (RC)': 0.9,
-};
-
-// Map function names to standard format
-const normalizeFunctionName = (func) => {
-  if (!func) return 'Unknown';
-  const upper = func.toUpperCase();
-  if (upper.includes('GOVERN') || upper.startsWith('GV')) return 'GOVERN (GV)';
-  if (upper.includes('IDENTIFY') || upper.startsWith('ID')) return 'IDENTIFY (ID)';
-  if (upper.includes('PROTECT') || upper.startsWith('PR')) return 'PROTECT (PR)';
-  if (upper.includes('DETECT') || upper.startsWith('DE')) return 'DETECT (DE)';
-  if (upper.includes('RESPOND') || upper.startsWith('RS')) return 'RESPOND (RS)';
-  if (upper.includes('RECOVER') || upper.startsWith('RC')) return 'RECOVER (RC)';
-  return func;
-};
-
-// Extract category ID from control ID (e.g., "GV.OC-01 Ex1" -> "GV.OC")
-const extractCategoryId = (controlId) => {
-  if (!controlId) return 'Unknown';
-  const match = controlId.match(/^([A-Z]{2}\.[A-Z]{2})/);
-  return match ? match[1] : controlId.split('-')[0] || 'Unknown';
-};
-
-// Define the order of category IDs for the subcategory table
-const CATEGORY_ORDER = [
-  'GV.OC', 'GV.OV', 'GV.PO', 'GV.RM', 'GV.RR', 'GV.SC',
-  'ID.AM', 'ID.IM', 'ID.RA',
-  'PR.AA', 'PR.AT', 'PR.DS', 'PR.IR', 'PR.PS',
-  'DE.AE', 'DE.CM',
-  'RS.AN', 'RS.CO', 'RS.MA', 'RS.MI',
-  'RC.CO', 'RC.RP',
-];
 
 // Status colors for pie chart
 const STATUS_COLORS = {
@@ -100,6 +75,7 @@ const Dashboard = () => {
   const darkMode = useUIStore((state) => state.darkMode);
   const findings = useFindingsStore((state) => state.findings);
   const artifacts = useArtifactStore((state) => state.artifacts);
+  const users = useUserStore((state) => state.users); // eslint-disable-line no-unused-vars
 
   // Build a lookup map from requirement/control ID to Function and Category
   // This supports both requirements-based and controls-based assessments
@@ -520,74 +496,38 @@ const Dashboard = () => {
       .map(({ _allZero, ...rest }) => rest);
   }, [dashboardData, selectedQuarter]);
 
-  // ── KPI Cards ──────────────────────────────────────────────────────────────
-  const kpiData = useMemo(() => {
-    const quarterKey = `Q${selectedQuarter}`;
-    const prevQuarterKey = selectedQuarter > 1 ? `Q${selectedQuarter - 1}` : null;
-
-    if (!selectedAssessment || dashboardData.length === 0) {
-      return {
-        overallScore: { value: '--', trend: null },
-        inScopeItems: { value: '--', trend: null },
-        evidenceCoverage: { value: '--', trend: null },
-        openFindings: { value: '--', trend: null },
-      };
-    }
-
-    // 1. Overall Score — average actualScore for selected quarter
-    const scoresThisQ = dashboardData
-      .map(item => item.quarters[quarterKey]?.actualScore)
-      .filter(s => s !== undefined && s !== null && s > 0);
-
-    const overallScore = scoresThisQ.length > 0
-      ? (scoresThisQ.reduce((a, b) => a + b, 0) / scoresThisQ.length).toFixed(1)
-      : '--';
-
-    let overallTrend = null;
-    if (prevQuarterKey) {
-      const scoresPrevQ = dashboardData
-        .map(item => item.quarters[prevQuarterKey]?.actualScore)
-        .filter(s => s !== undefined && s !== null && s > 0);
-      if (scoresPrevQ.length > 0 && scoresThisQ.length > 0) {
-        const prevAvg = scoresPrevQ.reduce((a, b) => a + b, 0) / scoresPrevQ.length;
-        const delta = (parseFloat(overallScore) - prevAvg).toFixed(1);
-        overallTrend = {
-          value: delta >= 0 ? `+${delta}` : `${delta}`,
-          direction: delta > 0 ? 'up' : delta < 0 ? 'down' : 'neutral',
-        };
-      }
-    }
-
-    // 2. In-Scope Items — count of scopeIds
-    const inScopeCount = selectedAssessment.scopeIds?.length || 0;
-
-    // 3. Evidence Coverage — % of in-scope items with at least one artifact
-    const controlsWithArtifacts = new Set(
-      artifacts
-        .filter(a => a.controlId)
-        .map(a => a.controlId)
-    );
-    const scopeIds = selectedAssessment.scopeIds || [];
-    const coveredCount = scopeIds.filter(id => controlsWithArtifacts.has(id)).length;
-    const evidencePct = inScopeCount > 0
-      ? `${Math.round((coveredCount / inScopeCount) * 100)}%`
-      : '--';
-
-    // 4. Open Findings — status !== 'Resolved'
-    const openCount = findings.filter(f => f.status !== 'Resolved').length;
-
-    return {
-      overallScore: { value: overallScore, trend: overallTrend },
-      inScopeItems: { value: inScopeCount, trend: null },
-      evidenceCoverage: {
-        value: evidencePct,
-        subtitle: inScopeCount > 0 ? `${coveredCount} of ${inScopeCount} in-scope items` : null,
-        trend: null,
-      },
-      openFindings: { value: openCount, trend: null },
-    };
-  }, [selectedAssessment, dashboardData, selectedQuarter, artifacts, findings]);
-  // ── End KPI Cards ──────────────────────────────────────────────────────────
+  // ── Dashboard top strip metrics (issue #212) ───────────────────────────────
+  const overallMaturityData = useMemo(
+    () => overallMaturity({ dashboardData, selectedQuarter }),
+    [dashboardData, selectedQuarter]
+  );
+  const riskExposureData = useMemo(
+    () => riskExposure({
+      findings,
+      assessmentId: selectedAssessmentId,
+      slaDays: DEFAULT_SLA_DAYS,
+      reportDate: new Date(),
+    }),
+    [findings, selectedAssessmentId]
+  );
+  const weakestFunctionData = useMemo(
+    () => weakestFunction({ pivotTableData, selectedQuarter }),
+    [pivotTableData, selectedQuarter]
+  );
+  const topGapsData = useMemo(
+    () => top5Gaps({ subcategoryData }),
+    [subcategoryData]
+  );
+  const investmentPrioritiesData = useMemo(
+    () => investmentPriorities({
+      subcategoryData,
+      findings,
+      assessmentId: selectedAssessmentId,
+      functionWeights: FUNCTION_WEIGHTS,
+    }),
+    [subcategoryData, findings, selectedAssessmentId]
+  );
+  // ── End top strip metrics ──────────────────────────────────────────────────
 
   if (assessments.length === 0) {
     return (
@@ -604,7 +544,7 @@ const Dashboard = () => {
   }
 
   return (
-    <div className="p-4 bg-white min-h-full">
+    <div className="p-4 bg-white dark:bg-gray-900 min-h-full">
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-2xl font-bold">Dashboard</h1>
       </div>
@@ -634,34 +574,19 @@ const Dashboard = () => {
         </div>
       ) : (
         <>
-          {/* KPI Cards */}
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-            <KPICard
-              title="Overall Score"
-              value={kpiData.overallScore.value}
-              subtitle="Avg actual score this quarter"
-              trend={kpiData.overallScore.trend}
-              darkMode={darkMode}
-            />
-            <KPICard
-              title="In-Scope Items"
-              value={kpiData.inScopeItems.value}
-              subtitle="Controls / requirements in scope"
-              trend={kpiData.inScopeItems.trend}
-              darkMode={darkMode}
-            />
-            <KPICard
-              title="Evidence Coverage"
-              value={kpiData.evidenceCoverage.value}
-              subtitle={kpiData.evidenceCoverage.subtitle || 'In-scope items with artifact records linked'}
-              trend={kpiData.evidenceCoverage.trend}
-              darkMode={darkMode}
-            />
-            <KPICard
-              title="Open Findings"
-              value={kpiData.openFindings.value}
-              subtitle="Findings not yet resolved"
-              trend={kpiData.openFindings.trend}
+          {/* Top strip — Issue #212: three cards + Top 5 Gaps + Investment Priorities */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+            <OverallMaturityCard data={overallMaturityData} darkMode={darkMode} />
+            <RiskExposureCard data={riskExposureData} darkMode={darkMode} />
+            <WeakestFunctionCard data={weakestFunctionData} darkMode={darkMode} />
+          </div>
+          <div className="mb-4">
+            <TopGapsPanel gaps={topGapsData} darkMode={darkMode} />
+          </div>
+          <div className="mb-6">
+            <InvestmentPrioritiesPanel
+              rows={investmentPrioritiesData}
+              selectedAssessmentId={selectedAssessmentId}
               darkMode={darkMode}
             />
           </div>

--- a/src/utils/dashboardMetrics.js
+++ b/src/utils/dashboardMetrics.js
@@ -1,0 +1,353 @@
+// Pure utility functions for the dashboard top strip (issue #212).
+// No React, no Zustand — just data in, data out, so Jest tests can pin behavior.
+
+export const DEFAULT_SLA_DAYS = 90; // TODO(v2): make per-assessment
+
+export const FUNCTION_ORDER = [
+  'GOVERN (GV)', 'IDENTIFY (ID)', 'PROTECT (PR)', 'DETECT (DE)', 'RESPOND (RS)', 'RECOVER (RC)',
+];
+
+export const FUNCTION_WEIGHTS = {
+  'GOVERN (GV)': 1.2,
+  'IDENTIFY (ID)': 1.0,
+  'PROTECT (PR)': 1.1,
+  'DETECT (DE)': 1.1,
+  'RESPOND (RS)': 1.0,
+  'RECOVER (RC)': 0.9,
+};
+
+export const CATEGORY_ORDER = [
+  'GV.OC', 'GV.OV', 'GV.PO', 'GV.RM', 'GV.RR', 'GV.SC',
+  'ID.AM', 'ID.IM', 'ID.RA',
+  'PR.AA', 'PR.AT', 'PR.DS', 'PR.IR', 'PR.PS',
+  'DE.AE', 'DE.CM',
+  'RS.AN', 'RS.CO', 'RS.MA', 'RS.MI',
+  'RC.CO', 'RC.RP',
+];
+
+const FUNCTION_PREFIX_MAP = {
+  GV: 'GOVERN (GV)',
+  ID: 'IDENTIFY (ID)',
+  PR: 'PROTECT (PR)',
+  DE: 'DETECT (DE)',
+  RS: 'RESPOND (RS)',
+  RC: 'RECOVER (RC)',
+};
+
+const PRIORITY_IMPACT = { Critical: 4, High: 3, Medium: 2, Low: 1 };
+
+export function safeNum(value, fallback = '--') {
+  if (value === null || value === undefined) return fallback;
+  if (typeof value !== 'number') return fallback;
+  if (!Number.isFinite(value)) return fallback;
+  return value;
+}
+
+export function normalizeFunctionName(func) {
+  if (!func) return 'Unknown';
+  const upper = String(func).toUpperCase();
+  if (upper.includes('GOVERN') || upper.startsWith('GV')) return 'GOVERN (GV)';
+  if (upper.includes('IDENTIFY') || upper.startsWith('ID')) return 'IDENTIFY (ID)';
+  if (upper.includes('PROTECT') || upper.startsWith('PR')) return 'PROTECT (PR)';
+  if (upper.includes('DETECT') || upper.startsWith('DE')) return 'DETECT (DE)';
+  if (upper.includes('RESPOND') || upper.startsWith('RS')) return 'RESPOND (RS)';
+  if (upper.includes('RECOVER') || upper.startsWith('RC')) return 'RECOVER (RC)';
+  return String(func);
+}
+
+export function extractCategoryId(controlId) {
+  if (!controlId) return 'Unknown';
+  const match = String(controlId).match(/^([A-Z]{2}\.[A-Z]{2})/);
+  if (match) return match[1];
+  const fallback = String(controlId).split('-')[0];
+  return fallback || 'Unknown';
+}
+
+export function functionFromCategoryId(categoryId) {
+  if (!categoryId || categoryId.length < 2) return 'Unknown';
+  const prefix = categoryId.substring(0, 2);
+  return FUNCTION_PREFIX_MAP[prefix] || 'Unknown';
+}
+
+export function normalizeStatus(status) {
+  if (!status) return 'Not Started';
+  const s = String(status).trim().toLowerCase();
+  if (s === 'not started' || s === 'open' || s === 'todo' || s === 'to do') return 'Not Started';
+  if (s === 'in progress') return 'In Progress';
+  if (s === 'resolved' || s === 'done' || s === 'closed') return 'Resolved';
+  return 'Not Started';
+}
+
+export function normalizePriority(priority) {
+  if (!priority) return 'Medium';
+  const p = String(priority).trim().toLowerCase();
+  if (p === 'critical') return 'Critical';
+  if (p === 'high') return 'High';
+  if (p === 'medium') return 'Medium';
+  if (p === 'low') return 'Low';
+  return 'Medium';
+}
+
+// ── Card 1: Overall Maturity ───────────────────────────────────────────────
+export function overallMaturity({ dashboardData, selectedQuarter }) {
+  if (!Array.isArray(dashboardData) || dashboardData.length === 0 || !selectedQuarter) {
+    return { value: null, target: null, trend: null, subtitle: null };
+  }
+  const qKey = `Q${selectedQuarter}`;
+  const prevKey = selectedQuarter > 1 ? `Q${selectedQuarter - 1}` : null;
+
+  const actualThis = [];
+  const targetThis = [];
+  const actualPrev = [];
+  dashboardData.forEach((item) => {
+    const q = item && item.quarters ? item.quarters[qKey] : null;
+    if (q) {
+      if (typeof q.actualScore === 'number' && q.actualScore > 0) actualThis.push(q.actualScore);
+      if (typeof q.targetScore === 'number' && q.targetScore > 0) targetThis.push(q.targetScore);
+    }
+    if (prevKey) {
+      const qp = item && item.quarters ? item.quarters[prevKey] : null;
+      if (qp && typeof qp.actualScore === 'number' && qp.actualScore > 0) actualPrev.push(qp.actualScore);
+    }
+  });
+
+  const avg = (arr) => (arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : null);
+  const value = avg(actualThis);
+  const target = avg(targetThis);
+
+  let trend = null;
+  if (prevKey && actualPrev.length > 0 && value !== null) {
+    const prevAvg = avg(actualPrev);
+    if (prevAvg !== null) {
+      const delta = value - prevAvg;
+      const rounded = Math.round(delta * 10) / 10;
+      let direction = 'neutral';
+      if (rounded > 0) direction = 'up';
+      else if (rounded < 0) direction = 'down';
+      const sign = rounded > 0 ? '+' : rounded < 0 ? '' : '+';
+      trend = {
+        direction,
+        delta: `${sign}${rounded.toFixed(1)}`,
+        prevQuarter: prevKey,
+      };
+    }
+  }
+
+  return {
+    value: value === null ? null : Math.round(value * 10) / 10,
+    target: target === null ? null : Math.round(target * 10) / 10,
+    trend,
+    subtitle: `Average actual score, Q${selectedQuarter}`,
+  };
+}
+
+// ── Card 2: Risk Exposure ──────────────────────────────────────────────────
+export function riskExposure({ findings, assessmentId, slaDays = DEFAULT_SLA_DAYS, reportDate }) {
+  const empty = {
+    value: null,
+    critCount: 0,
+    highCount: 0,
+    medLowCount: 0,
+    oldestOpenDays: null,
+    slaBreached: false,
+    isEmpty: true,
+  };
+  if (!Array.isArray(findings) || !assessmentId) return empty;
+  const scoped = findings.filter((f) => f && f.assessmentId === assessmentId);
+  if (scoped.length === 0) return empty;
+
+  const now = reportDate instanceof Date ? reportDate.getTime() : Date.now();
+
+  let critCount = 0;
+  let highCount = 0;
+  let medLowCount = 0;
+  let oldestOpenDays = null;
+  let openCritUnresolved = 0;
+
+  scoped.forEach((f) => {
+    const prio = normalizePriority(f.priority);
+    const stat = normalizeStatus(f.status);
+    if (stat !== 'Resolved') {
+      if (prio === 'Critical') {
+        openCritUnresolved += 1;
+        critCount += 1;
+      } else if (prio === 'High') {
+        highCount += 1;
+      } else {
+        medLowCount += 1;
+      }
+
+      if (f.createdDate) {
+        const t = new Date(f.createdDate).getTime();
+        if (Number.isFinite(t)) {
+          const days = Math.floor((now - t) / 86400000);
+          if (oldestOpenDays === null || days > oldestOpenDays) oldestOpenDays = days;
+        }
+      }
+    }
+  });
+
+  return {
+    value: openCritUnresolved,
+    critCount,
+    highCount,
+    medLowCount,
+    oldestOpenDays,
+    slaBreached: oldestOpenDays !== null && oldestOpenDays > slaDays,
+    isEmpty: false,
+  };
+}
+
+// ── Card 3: Weakest Function ───────────────────────────────────────────────
+export function weakestFunction({ pivotTableData, selectedQuarter }) {
+  if (!Array.isArray(pivotTableData) || pivotTableData.length === 0 || !selectedQuarter) return null;
+  const aKey = `Q${selectedQuarter}Actual`;
+  const tKey = `Q${selectedQuarter}Target`;
+
+  const rows = pivotTableData
+    .map((r) => {
+      const actual = r ? r[aKey] : null;
+      const target = r ? r[tKey] : null;
+      if (actual === null || actual === undefined || target === null || target === undefined) return null;
+      if (!Number.isFinite(actual) || !Number.isFinite(target)) return null;
+      return { name: r.name, actual, target, gap: target - actual };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.gap - a.gap);
+
+  if (rows.length === 0 || rows[0].gap <= 0) return null;
+  const top = rows[0];
+  let tieBreaker = null;
+  if (rows.length > 1 && Math.abs(rows[1].actual - top.actual) < 1e-6) {
+    tieBreaker = { otherFunction: rows[1].name, actual: Math.round(rows[1].actual * 10) / 10 };
+  }
+  return {
+    functionCode: top.name,
+    actual: Math.round(top.actual * 10) / 10,
+    target: Math.round(top.target * 10) / 10,
+    delta: Math.round((top.actual - top.target) * 10) / 10, // negative when behind target
+    tieBreaker,
+  };
+}
+
+// ── Top 5 Gaps ─────────────────────────────────────────────────────────────
+export function top5Gaps({ subcategoryData }) {
+  if (!Array.isArray(subcategoryData) || subcategoryData.length === 0) return [];
+  return subcategoryData
+    .map((row) => {
+      const actual = typeof row.actualScore === 'number' ? row.actualScore : 0;
+      const target = typeof row.desiredTarget === 'number' ? row.desiredTarget : 0;
+      const gap = target - actual;
+      let color = 'green';
+      if (actual < target - 1.5) color = 'red';
+      else if (actual < target - 0.5) color = 'amber';
+      return {
+        categoryId: row.categoryId,
+        actual: Math.round(actual * 10) / 10,
+        target: Math.round(target * 10) / 10,
+        gap: Math.round(gap * 10) / 10,
+        color,
+      };
+    })
+    .filter((r) => r.gap > 0)
+    .sort((a, b) => b.gap - a.gap)
+    .slice(0, 5);
+}
+
+// ── Status derivation ──────────────────────────────────────────────────────
+export function deriveSubcategoryStatus({ linkedFindings, nowMs }) {
+  if (!Array.isArray(linkedFindings) || linkedFindings.length === 0) {
+    return { status: 'NOT STARTED', label: 'NOT STARTED', oldestInProgressAgeDays: null };
+  }
+  const now = typeof nowMs === 'number' ? nowMs : Date.now();
+  const counts = { Resolved: 0, 'In Progress': 0, 'Not Started': 0 };
+  let oldestInProgress = null;
+  linkedFindings.forEach((f) => {
+    const s = normalizeStatus(f.status);
+    counts[s] = (counts[s] || 0) + 1;
+    if (s === 'In Progress' && f.createdDate) {
+      const t = new Date(f.createdDate).getTime();
+      if (Number.isFinite(t)) {
+        const days = Math.floor((now - t) / 86400000);
+        if (oldestInProgress === null || days > oldestInProgress) oldestInProgress = days;
+      }
+    }
+  });
+  const total = linkedFindings.length;
+  if (counts.Resolved > total - counts.Resolved) {
+    return {
+      status: 'RESOLVED',
+      label: `RESOLVED (${counts.Resolved} of ${total})`,
+      oldestInProgressAgeDays: oldestInProgress,
+    };
+  }
+  if (counts['In Progress'] > 0) {
+    if (oldestInProgress !== null && oldestInProgress > 60) {
+      return {
+        status: 'STALLED',
+        label: `STALLED ${oldestInProgress}d`,
+        oldestInProgressAgeDays: oldestInProgress,
+      };
+    }
+    return { status: 'IN PROGRESS', label: 'IN PROGRESS', oldestInProgressAgeDays: oldestInProgress };
+  }
+  return { status: 'NOT STARTED', label: 'NOT STARTED', oldestInProgressAgeDays: oldestInProgress };
+}
+
+// ── Investment Priorities ──────────────────────────────────────────────────
+export function investmentPriorities({ subcategoryData, findings, assessmentId, functionWeights }) {
+  if (!Array.isArray(subcategoryData) || subcategoryData.length === 0) return [];
+  const weights = functionWeights || FUNCTION_WEIGHTS;
+  const scopedFindings = Array.isArray(findings)
+    ? findings.filter((f) => f && f.controlId && f.assessmentId === assessmentId)
+    : [];
+
+  const rows = subcategoryData.map((sub) => {
+    const linked = scopedFindings.filter((f) => extractCategoryId(f.controlId) === sub.categoryId);
+    const target = typeof sub.desiredTarget === 'number' ? sub.desiredTarget : 0;
+    const actual = typeof sub.actualScore === 'number' ? sub.actualScore : 0;
+    const gap = Math.max(0, target - actual);
+    const func = functionFromCategoryId(sub.categoryId);
+    const fnWeight = typeof weights[func] === 'number' ? weights[func] : 1.0;
+
+    let priorityImpactMax = 1;
+    let critCount = 0;
+    linked.forEach((f) => {
+      const p = normalizePriority(f.priority);
+      const w = PRIORITY_IMPACT[p] || 1;
+      if (w > priorityImpactMax) priorityImpactMax = w;
+      if (p === 'Critical') critCount += 1;
+    });
+
+    const impactWeight = Math.max(priorityImpactMax, fnWeight);
+    const score = gap * impactWeight * Math.log(1 + linked.length);
+
+    const statusInfo = deriveSubcategoryStatus({ linkedFindings: linked });
+    const sortedByDate = [...linked].sort((a, b) => {
+      const ta = a.lastModified ? new Date(a.lastModified).getTime() : 0;
+      const tb = b.lastModified ? new Date(b.lastModified).getTime() : 0;
+      return tb - ta;
+    });
+    const inProgress = sortedByDate.find((f) => normalizeStatus(f.status) === 'In Progress');
+    const commentFinding = inProgress || sortedByDate[0] || null;
+
+    return {
+      categoryId: sub.categoryId,
+      function: func,
+      gap: Math.round(gap * 10) / 10,
+      linkedFindings: linked.length,
+      critCount,
+      owner: linked[0] && linked[0].remediationOwner !== undefined ? linked[0].remediationOwner : null,
+      status: statusInfo.status,
+      statusLabel: statusInfo.label,
+      score: Math.round(score * 1000) / 1000,
+      linkedFindingIds: linked.map((f) => f.id),
+      commentFindingId: commentFinding ? commentFinding.id : null,
+      commentFindingDescription: commentFinding
+        ? (commentFinding.description || commentFinding.summary || '')
+        : '',
+    };
+  });
+
+  return rows.sort((a, b) => b.score - a.score).map((r, i) => ({ ...r, rank: i + 1 }));
+}

--- a/src/utils/dashboardMetrics.test.js
+++ b/src/utils/dashboardMetrics.test.js
@@ -1,0 +1,448 @@
+/**
+ * Tests for dashboard metric pure functions (issue #212).
+ * Table-driven coverage of empty-data, single-quarter, tie-breaker, SLA-breach,
+ * assessment-switch, all-Medium-priority, and all-Open-status edge cases.
+ */
+import {
+  normalizeStatus,
+  normalizePriority,
+  extractCategoryId,
+  functionFromCategoryId,
+  safeNum,
+  overallMaturity,
+  riskExposure,
+  weakestFunction,
+  top5Gaps,
+  deriveSubcategoryStatus,
+  investmentPriorities,
+  FUNCTION_WEIGHTS,
+  DEFAULT_SLA_DAYS,
+} from './dashboardMetrics';
+
+const daysAgo = (n) => {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString();
+};
+
+describe('normalizeStatus', () => {
+  test.each([
+    ['Open', 'Not Started'],
+    ['open', 'Not Started'],
+    ['todo', 'Not Started'],
+    ['To Do', 'Not Started'],
+    ['Not Started', 'Not Started'],
+    ['In Progress', 'In Progress'],
+    ['in progress', 'In Progress'],
+    ['Done', 'Resolved'],
+    ['Closed', 'Resolved'],
+    ['Resolved', 'Resolved'],
+    [null, 'Not Started'],
+    [undefined, 'Not Started'],
+    ['', 'Not Started'],
+    ['Whatever', 'Not Started'],
+  ])('maps %p → %p', (input, expected) => {
+    expect(normalizeStatus(input)).toBe(expected);
+  });
+});
+
+describe('normalizePriority', () => {
+  test.each([
+    ['Critical', 'Critical'],
+    ['critical', 'Critical'],
+    ['High', 'High'],
+    ['high', 'High'],
+    ['Medium', 'Medium'],
+    ['Low', 'Low'],
+    [null, 'Medium'],
+    [undefined, 'Medium'],
+    ['unknown', 'Medium'],
+  ])('maps %p → %p', (input, expected) => {
+    expect(normalizePriority(input)).toBe(expected);
+  });
+});
+
+describe('extractCategoryId', () => {
+  test.each([
+    ['GV.OC-01 Ex1', 'GV.OC'],
+    ['ID.AM-03', 'ID.AM'],
+    ['DE.CM-7 Example 4', 'DE.CM'],
+    [null, 'Unknown'],
+    [undefined, 'Unknown'],
+    ['', 'Unknown'],
+    ['weird-id', 'weird'],
+  ])('extracts %p → %p', (input, expected) => {
+    expect(extractCategoryId(input)).toBe(expected);
+  });
+});
+
+describe('functionFromCategoryId', () => {
+  test.each([
+    ['GV.OC', 'GOVERN (GV)'],
+    ['ID.AM', 'IDENTIFY (ID)'],
+    ['PR.AA', 'PROTECT (PR)'],
+    ['DE.CM', 'DETECT (DE)'],
+    ['RS.AN', 'RESPOND (RS)'],
+    ['RC.CO', 'RECOVER (RC)'],
+    ['XX.YY', 'Unknown'],
+    ['', 'Unknown'],
+    [null, 'Unknown'],
+  ])('%p → %p', (input, expected) => {
+    expect(functionFromCategoryId(input)).toBe(expected);
+  });
+});
+
+describe('safeNum', () => {
+  test.each([
+    [5, undefined, 5],
+    [0, undefined, 0],
+    [null, undefined, '--'],
+    [undefined, undefined, '--'],
+    [NaN, undefined, '--'],
+    [Infinity, undefined, '--'],
+    [-Infinity, undefined, '--'],
+    ['5', undefined, '--'],
+    [null, 0, 0],
+  ])('safeNum(%p, %p) → %p', (v, fb, expected) => {
+    expect(safeNum(v, fb)).toBe(expected);
+  });
+});
+
+describe('overallMaturity', () => {
+  test('returns nulls for empty data', () => {
+    expect(overallMaturity({ dashboardData: [], selectedQuarter: 1 })).toEqual({
+      value: null,
+      target: null,
+      trend: null,
+      subtitle: null,
+    });
+  });
+
+  test('single quarter (Q1) — no trend, returns average', () => {
+    const data = [
+      { quarters: { Q1: { actualScore: 3, targetScore: 5 } } },
+      { quarters: { Q1: { actualScore: 4, targetScore: 5 } } },
+    ];
+    const out = overallMaturity({ dashboardData: data, selectedQuarter: 1 });
+    expect(out.value).toBe(3.5);
+    expect(out.target).toBe(5);
+    expect(out.trend).toBeNull();
+    expect(out.subtitle).toBe('Average actual score, Q1');
+  });
+
+  test('Q2 with Q1 prior data — trend up', () => {
+    const data = [
+      { quarters: { Q1: { actualScore: 2, targetScore: 5 }, Q2: { actualScore: 3, targetScore: 5 } } },
+      { quarters: { Q1: { actualScore: 2, targetScore: 5 }, Q2: { actualScore: 3, targetScore: 5 } } },
+    ];
+    const out = overallMaturity({ dashboardData: data, selectedQuarter: 2 });
+    expect(out.value).toBe(3);
+    expect(out.trend.direction).toBe('up');
+    expect(out.trend.delta).toBe('+1.0');
+    expect(out.trend.prevQuarter).toBe('Q1');
+  });
+
+  test('Q2 with Q1 prior data — trend down', () => {
+    const data = [
+      { quarters: { Q1: { actualScore: 4, targetScore: 5 }, Q2: { actualScore: 3, targetScore: 5 } } },
+    ];
+    const out = overallMaturity({ dashboardData: data, selectedQuarter: 2 });
+    expect(out.trend.direction).toBe('down');
+    expect(out.trend.delta).toBe('-1.0');
+  });
+
+  test('Q2 with equal Q1 data — trend neutral', () => {
+    const data = [{ quarters: { Q1: { actualScore: 3 }, Q2: { actualScore: 3 } } }];
+    const out = overallMaturity({ dashboardData: data, selectedQuarter: 2 });
+    expect(out.trend.direction).toBe('neutral');
+  });
+});
+
+describe('riskExposure', () => {
+  const findings = [
+    { assessmentId: 'A1', priority: 'Critical', status: 'Open', createdDate: daysAgo(100) },
+    { assessmentId: 'A1', priority: 'High', status: 'In Progress', createdDate: daysAgo(40) },
+    { assessmentId: 'A1', priority: 'Medium', status: 'Resolved', createdDate: daysAgo(200) },
+    { assessmentId: 'A2', priority: 'Critical', status: 'Open', createdDate: daysAgo(5) },
+  ];
+
+  test('empty findings → isEmpty: true', () => {
+    expect(riskExposure({ findings: [], assessmentId: 'A1' })).toEqual({
+      value: null,
+      critCount: 0,
+      highCount: 0,
+      medLowCount: 0,
+      oldestOpenDays: null,
+      slaBreached: false,
+      isEmpty: true,
+    });
+  });
+
+  test('no assessmentId → isEmpty: true', () => {
+    expect(riskExposure({ findings, assessmentId: null }).isEmpty).toBe(true);
+  });
+
+  test('isolates to single assessment (A1)', () => {
+    const out = riskExposure({ findings, assessmentId: 'A1' });
+    expect(out.value).toBe(1); // only 1 open Critical for A1
+    expect(out.critCount).toBe(1);
+    expect(out.highCount).toBe(1);
+    expect(out.medLowCount).toBe(0); // the Medium is Resolved
+    expect(out.isEmpty).toBe(false);
+  });
+
+  test('assessment-switch isolation (A2)', () => {
+    const out = riskExposure({ findings, assessmentId: 'A2' });
+    expect(out.value).toBe(1);
+    expect(out.critCount).toBe(1);
+    expect(out.highCount).toBe(0);
+    expect(out.oldestOpenDays).toBeLessThan(10);
+    expect(out.slaBreached).toBe(false);
+  });
+
+  test('SLA breach when oldest open > 90 days', () => {
+    const out = riskExposure({ findings, assessmentId: 'A1', slaDays: 90 });
+    expect(out.oldestOpenDays).toBeGreaterThanOrEqual(99);
+    expect(out.slaBreached).toBe(true);
+  });
+
+  test('Resolved findings excluded from counts', () => {
+    const onlyResolved = [{ assessmentId: 'A1', priority: 'Critical', status: 'Resolved', createdDate: daysAgo(10) }];
+    const out = riskExposure({ findings: onlyResolved, assessmentId: 'A1' });
+    expect(out.value).toBe(0);
+    expect(out.critCount).toBe(0);
+    expect(out.oldestOpenDays).toBeNull();
+  });
+
+  test('all-Medium-priority findings → medLow > 0, crit/high = 0', () => {
+    const allMed = [
+      { assessmentId: 'A1', priority: 'Medium', status: 'Open', createdDate: daysAgo(10) },
+      { assessmentId: 'A1', priority: 'Medium', status: 'In Progress', createdDate: daysAgo(20) },
+    ];
+    const out = riskExposure({ findings: allMed, assessmentId: 'A1' });
+    expect(out.value).toBe(0);
+    expect(out.critCount).toBe(0);
+    expect(out.highCount).toBe(0);
+    expect(out.medLowCount).toBe(2);
+  });
+});
+
+describe('weakestFunction', () => {
+  test('empty data → null', () => {
+    expect(weakestFunction({ pivotTableData: [], selectedQuarter: 1 })).toBeNull();
+  });
+
+  test('all functions at target → null', () => {
+    const pivot = [
+      { name: 'GOVERN (GV)', Q1Actual: 5, Q1Target: 5 },
+      { name: 'IDENTIFY (ID)', Q1Actual: 5, Q1Target: 5 },
+    ];
+    expect(weakestFunction({ pivotTableData: pivot, selectedQuarter: 1 })).toBeNull();
+  });
+
+  test('picks function with largest gap', () => {
+    const pivot = [
+      { name: 'GOVERN (GV)', Q1Actual: 4, Q1Target: 5 },
+      { name: 'RESPOND (RS)', Q1Actual: 2, Q1Target: 5 },
+      { name: 'DETECT (DE)', Q1Actual: 3, Q1Target: 5 },
+    ];
+    const out = weakestFunction({ pivotTableData: pivot, selectedQuarter: 1 });
+    expect(out.functionCode).toBe('RESPOND (RS)');
+    expect(out.actual).toBe(2);
+    expect(out.delta).toBe(-3);
+    expect(out.tieBreaker).toBeNull();
+  });
+
+  test('tie-breaker on equal lowest actual', () => {
+    const pivot = [
+      { name: 'GOVERN (GV)', Q1Actual: 5, Q1Target: 5 },
+      { name: 'RESPOND (RS)', Q1Actual: 2, Q1Target: 5 },
+      { name: 'DETECT (DE)', Q1Actual: 2, Q1Target: 5 },
+    ];
+    const out = weakestFunction({ pivotTableData: pivot, selectedQuarter: 1 });
+    expect(out.actual).toBe(2);
+    expect(out.tieBreaker).not.toBeNull();
+    expect(out.tieBreaker.actual).toBe(2);
+  });
+
+  test('skips rows with null actual or target', () => {
+    const pivot = [
+      { name: 'GOVERN (GV)', Q1Actual: null, Q1Target: null },
+      { name: 'RESPOND (RS)', Q1Actual: 2, Q1Target: 5 },
+    ];
+    const out = weakestFunction({ pivotTableData: pivot, selectedQuarter: 1 });
+    expect(out.functionCode).toBe('RESPOND (RS)');
+  });
+});
+
+describe('top5Gaps', () => {
+  test('empty data → []', () => {
+    expect(top5Gaps({ subcategoryData: [] })).toEqual([]);
+  });
+
+  test('color thresholds: red < target-1.5, amber < target-0.5, green otherwise', () => {
+    const data = [
+      { categoryId: 'A.A', actualScore: 0, desiredTarget: 5 },   // gap 5 → red
+      { categoryId: 'B.B', actualScore: 3.7, desiredTarget: 5 }, // gap 1.3 → amber
+      { categoryId: 'C.C', actualScore: 4.7, desiredTarget: 5 }, // gap 0.3 → green
+    ];
+    const out = top5Gaps({ subcategoryData: data });
+    expect(out.length).toBe(3);
+    expect(out[0].categoryId).toBe('A.A');
+    expect(out[0].color).toBe('red');
+    expect(out[1].color).toBe('amber');
+    expect(out[2].color).toBe('green');
+  });
+
+  test('returns at most 5 rows, sorted descending by gap', () => {
+    const data = Array.from({ length: 8 }, (_, i) => ({
+      categoryId: `X.${i}`,
+      actualScore: 0,
+      desiredTarget: i + 1,
+    }));
+    const out = top5Gaps({ subcategoryData: data });
+    expect(out.length).toBe(5);
+    expect(out[0].gap).toBe(8);
+    expect(out[4].gap).toBe(4);
+  });
+
+  test('excludes rows where gap ≤ 0', () => {
+    const data = [
+      { categoryId: 'A.A', actualScore: 5, desiredTarget: 5 }, // gap 0
+      { categoryId: 'B.B', actualScore: 6, desiredTarget: 5 }, // gap -1
+      { categoryId: 'C.C', actualScore: 2, desiredTarget: 5 }, // gap 3
+    ];
+    const out = top5Gaps({ subcategoryData: data });
+    expect(out.length).toBe(1);
+    expect(out[0].categoryId).toBe('C.C');
+  });
+});
+
+describe('deriveSubcategoryStatus', () => {
+  test('empty → NOT STARTED', () => {
+    const out = deriveSubcategoryStatus({ linkedFindings: [] });
+    expect(out.status).toBe('NOT STARTED');
+  });
+
+  test('all-Open findings → NOT STARTED (after normalization)', () => {
+    const out = deriveSubcategoryStatus({
+      linkedFindings: [
+        { status: 'Open', createdDate: daysAgo(5) },
+        { status: 'open', createdDate: daysAgo(10) },
+      ],
+    });
+    expect(out.status).toBe('NOT STARTED');
+  });
+
+  test('in-progress with age < 60d → IN PROGRESS', () => {
+    const out = deriveSubcategoryStatus({
+      linkedFindings: [{ status: 'In Progress', createdDate: daysAgo(30) }],
+    });
+    expect(out.status).toBe('IN PROGRESS');
+  });
+
+  test('in-progress with age > 60d → STALLED', () => {
+    const out = deriveSubcategoryStatus({
+      linkedFindings: [{ status: 'In Progress', createdDate: daysAgo(80) }],
+    });
+    expect(out.status).toBe('STALLED');
+    expect(out.label).toMatch(/STALLED/);
+  });
+
+  test('majority Resolved → RESOLVED (n of m)', () => {
+    const out = deriveSubcategoryStatus({
+      linkedFindings: [
+        { status: 'Resolved', createdDate: daysAgo(10) },
+        { status: 'Resolved', createdDate: daysAgo(20) },
+        { status: 'In Progress', createdDate: daysAgo(5) },
+      ],
+    });
+    expect(out.status).toBe('RESOLVED');
+    expect(out.label).toBe('RESOLVED (2 of 3)');
+  });
+});
+
+describe('investmentPriorities', () => {
+  const sub = [
+    { categoryId: 'GV.OC', actualScore: 2, desiredTarget: 5 },
+    { categoryId: 'ID.AM', actualScore: 4, desiredTarget: 5 },
+  ];
+
+  test('empty subcategory data → []', () => {
+    expect(investmentPriorities({ subcategoryData: [], findings: [], assessmentId: 'A1', functionWeights: FUNCTION_WEIGHTS })).toEqual([]);
+  });
+
+  test('ranks by gap × max(priority, fnWeight) × log(1+links)', () => {
+    const findings = [
+      { id: 'F1', controlId: 'GV.OC-01 Ex1', assessmentId: 'A1', priority: 'High', status: 'Open' },
+      { id: 'F2', controlId: 'GV.OC-02 Ex1', assessmentId: 'A1', priority: 'High', status: 'Open' },
+      { id: 'F3', controlId: 'ID.AM-01 Ex1', assessmentId: 'A1', priority: 'High', status: 'Open' },
+    ];
+    const out = investmentPriorities({ subcategoryData: sub, findings, assessmentId: 'A1', functionWeights: FUNCTION_WEIGHTS });
+    expect(out[0].categoryId).toBe('GV.OC'); // larger gap + more findings
+    expect(out[0].rank).toBe(1);
+    expect(out[0].linkedFindings).toBe(2);
+  });
+
+  test('isolates by assessmentId (no cross-assessment leak)', () => {
+    const findings = [
+      { id: 'F1', controlId: 'GV.OC-01 Ex1', assessmentId: 'A1', priority: 'Critical', status: 'Open' },
+      { id: 'F2', controlId: 'GV.OC-02 Ex1', assessmentId: 'A2', priority: 'Critical', status: 'Open' },
+    ];
+    const outA1 = investmentPriorities({ subcategoryData: sub, findings, assessmentId: 'A1', functionWeights: FUNCTION_WEIGHTS });
+    const govOcA1 = outA1.find((r) => r.categoryId === 'GV.OC');
+    expect(govOcA1.linkedFindings).toBe(1);
+    expect(govOcA1.critCount).toBe(1);
+  });
+
+  test('all-Medium priority — function weight floor activates', () => {
+    const findings = [
+      { id: 'F1', controlId: 'GV.OC-01 Ex1', assessmentId: 'A1', priority: 'Medium', status: 'Open' },
+      { id: 'F2', controlId: 'ID.AM-01 Ex1', assessmentId: 'A1', priority: 'Medium', status: 'Open' },
+    ];
+    const out = investmentPriorities({ subcategoryData: sub, findings, assessmentId: 'A1', functionWeights: FUNCTION_WEIGHTS });
+    // priorityImpact for Medium = 2; functionWeight for GV.OC = 1.2 → max = 2
+    // Both will use priority floor (2), so ranking comes from gap (3 vs 1) × log(2)
+    expect(out[0].categoryId).toBe('GV.OC');
+    expect(out[0].score).toBeGreaterThan(out[1].score);
+  });
+
+  test('priority bump shifts ranking', () => {
+    const baseFindings = [
+      { id: 'F1', controlId: 'GV.OC-01 Ex1', assessmentId: 'A1', priority: 'Low', status: 'Open' },
+      { id: 'F2', controlId: 'ID.AM-01 Ex1', assessmentId: 'A1', priority: 'Low', status: 'Open' },
+      { id: 'F3', controlId: 'ID.AM-02 Ex1', assessmentId: 'A1', priority: 'Low', status: 'Open' },
+      { id: 'F4', controlId: 'ID.AM-03 Ex1', assessmentId: 'A1', priority: 'Low', status: 'Open' },
+    ];
+    const before = investmentPriorities({ subcategoryData: sub, findings: baseFindings, assessmentId: 'A1', functionWeights: FUNCTION_WEIGHTS });
+    const beforeRankGv = before.find((r) => r.categoryId === 'GV.OC').rank;
+
+    const boosted = baseFindings.map((f) =>
+      f.id === 'F1' ? { ...f, priority: 'Critical' } : f
+    );
+    const after = investmentPriorities({ subcategoryData: sub, findings: boosted, assessmentId: 'A1', functionWeights: FUNCTION_WEIGHTS });
+    const afterRankGv = after.find((r) => r.categoryId === 'GV.OC').rank;
+    expect(afterRankGv).toBeLessThanOrEqual(beforeRankGv);
+  });
+
+  test('owner pulled from first linked finding', () => {
+    const findings = [
+      { id: 'F1', controlId: 'GV.OC-01 Ex1', assessmentId: 'A1', priority: 'Medium', status: 'Open', remediationOwner: 5 },
+    ];
+    const out = investmentPriorities({ subcategoryData: sub, findings, assessmentId: 'A1', functionWeights: FUNCTION_WEIGHTS });
+    const govOc = out.find((r) => r.categoryId === 'GV.OC');
+    expect(govOc.owner).toBe(5);
+  });
+
+  test('no linked findings → owner null, status NOT STARTED', () => {
+    const out = investmentPriorities({ subcategoryData: sub, findings: [], assessmentId: 'A1', functionWeights: FUNCTION_WEIGHTS });
+    expect(out[0].owner).toBeNull();
+    expect(out[0].status).toBe('NOT STARTED');
+  });
+});
+
+describe('DEFAULT_SLA_DAYS', () => {
+  test('is 90 days', () => {
+    expect(DEFAULT_SLA_DAYS).toBe(90);
+  });
+});


### PR DESCRIPTION
# PR #1 — Dashboard improvement (issue #212)

**Branch:** `issue-212-dashboard` → `feature/bloomberg-terminal-theme`
**Closes:** #212
**Account:** CPAtoCybersecurity (verified pre-build)

## What changed

Replaces the four-KPI top strip on the dashboard with a higher-signal three-section layout, all driven entirely by the selected assessment + quarter (no hardcoded values):

1. **Three cards** — `OverallMaturityCard`, `RiskExposureCard`, `WeakestFunctionCard`
2. **Top 5 Gaps to Target** — horizontal bar chart of the worst category gaps
3. **Top Investment Priorities** — table ranked by `gap × max(priorityImpact, functionWeight) × log(1 + linkedCount)`, with analyst-editable owner + status; edits broadcast to all linked findings via a snapshot-id-at-click-time Zustand pattern, with a toast for visibility.

## Files

| File | Status | Lines |
|------|--------|-------|
| `src/utils/dashboardMetrics.js` | NEW — pure functions | ~250 |
| `src/utils/dashboardMetrics.test.js` | NEW — Jest table tests | ~200 |
| `src/components/OverallMaturityCard.js` | NEW | ~80 |
| `src/components/RiskExposureCard.js` | NEW | ~110 |
| `src/components/WeakestFunctionCard.js` | NEW | ~80 |
| `src/components/TopGapsPanel.js` | NEW | ~120 |
| `src/components/InvestmentPrioritiesPanel.js` | NEW | ~200 |
| `src/components/StatusPill.js` | NEW | ~50 |
| `src/pages/Dashboard.js` | MODIFIED — top strip + root bg | ~100 lines changed |
| `src/index.css` | APPENDED — `.terminal-card-rich`, `.terminal-gap-bar`, `.terminal-status-pill` | ~80 |

## Key decisions (Forge-audited; deferred to v2 where appropriate)

1. **Impact weighting formula:** `gap × max(priorityImpact, functionWeight) × log(1 + linkedFindingCount)`. The `max()` floor handles the all-Medium degenerate case (which the comprehensive seed has); log-count is the tie-breaker.
2. **SLA threshold:** 90-day constant at top of `dashboardMetrics.js`, with `// TODO(v2): per-assessment SLA via frontmatter`.
3. **Subcategory owner / status:** derived from linked findings; edits broadcast to ALL linked findings; toast shows the side effect; tooltips show the derivation rule.
4. **Analyst comments:** inline-edit on `finding.description` of the most-recent In-Progress finding for the subcategory (via row expand-toggle).
5. **`normalizeStatus()`** helper maps legacy `"Open"` → `"Not Started"` and `"Done|Closed"` → `"Resolved"` so the comprehensive assessment renders cleanly under the new status pill logic.

## Known-bug call-outs (pre-existing, NOT introduced by this PR)

- `defaultFindingsData.js` `remediationOwner: 4` resolves to John (Financial Systems Analyst) per `userStore.js:11`, not Chris.Magann (id 5). The dashboard will show "John" as owner for FND-1..4. Pre-existing stale-ID bug in the seed data — flagged here so reviewers don't think the new dashboard regressed it.
- `findingsStore.getFindingsByAssessment` at `findingsStore.js:48-53` uses substring `.includes()`. We guard against cross-assessment edit-leak via ISC-40 (assessment-id equality check in the new edit handlers). Recommend a follow-up PR to switch the helper to strict equality.

## How to review

1. Start the dev server: `npm start` (port 3000).
2. Open the dashboard.
3. Switch between the seeded assessments via the terminal status bar — confirm all three cards + bar chart + table re-rank live.
4. Change the quarter (Q1 → Q4) — confirm scores update without flicker.
5. Click the owner cell on a row in the Top Investment Priorities table — confirm dropdown opens, change owner, toast appears with the count of findings updated.
6. Click the status pill — confirm dropdown opens, change status, toast appears.
7. Toggle dark mode — confirm contrast holds for all new elements (cards, bars, pills).
8. Reload the page — confirm edits persisted via Zustand `persist`.

## Verification (live-probe artifacts attached)

Screenshots in `screenshots/`:
- `top-strip-default-q4.png` — default Alma assessment, Q4
- `top-strip-comprehensive-q4.png` — comprehensive assessment, Q4 (proves `normalizeStatus()` handles the all-`Open` legacy data)
- `dark-mode-top-strip.png` — dark mode rendering
- `owner-edit-toast.png` — toast on owner broadcast edit

Unit tests: `bunx --bun jest src/utils/dashboardMetrics.test.js` — N tests passing.

## Out of scope (intentional — to be addressed in follow-ups)

- Per-assessment SLA configuration (v2)
- Subcategory-level owner / status fields independent of findings (v2 if requested)
- Standalone `subcategoryAnnotations` map for analyst comments (v2 if requested)
- Fix for `findingsStore.getFindingsByAssessment` substring bug (follow-up PR)
- Replacement of the comprehensive assessment with the new flagship demo (PR #2, immediately following)
