### PR TITLE
docs: add Related Resources section (myctrl.tools, GRC Companion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ This tool is based on the NIST Cybersecurity Framework (CSF), developed by the N
 
 As a demonstration of how to conduct CSF profile assessment, fictional company "Alma Security" is used, inspired by Daniel Miessler's open source Telos project here: [https://github.com/danielmiessler/Telos/blob/main/corporate_telos.md](https://github.com/danielmiessler/Telos/blob/main/corporate_telos.md)
 
+## Related Resources
+
+While running an assessment in this tool, you may want to cross-reference a CSF subcategory against a related control in another framework (NIST 800-53, ISO 27001, PCI DSS, CMMC, and so on).
+
+* **[myctrl.tools](https://myctrl.tools)** by [Ethan Troy](https://github.com/ethanolivertroy): a free, fast search across 19,000+ security controls from 94+ frameworks including NIST CSF 2.0, NIST 800-53, NIST AI RMF, FedRAMP, CMMC, DOD STIGs, PCI DSS, ISO 27001, SOC 2, EU AI Act, and GDPR. No login required. Useful as a lookup companion while working through subcategories in this tool.
+
 ## Installation and Setup
 
 ### Walkthrough:

--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ As a demonstration of how to conduct CSF profile assessment, fictional company "
 
 ## Related Resources
 
-While running an assessment in this tool, you may want to cross-reference a CSF subcategory against a related control in another framework (NIST 800-53, ISO 27001, PCI DSS, CMMC, and so on).
+While running an assessment in this tool, you may want to cross-reference a CSF subcategory against a related control in another framework (NIST 800-53, ISO 27001, PCI DSS, CMMC, and so on). You may also want to deepen your GRC skill set as you work.
 
 * **[myctrl.tools](https://myctrl.tools)** by [Ethan Troy](https://github.com/ethanolivertroy): a free, fast search across 19,000+ security controls from 94+ frameworks including NIST CSF 2.0, NIST 800-53, NIST AI RMF, FedRAMP, CMMC, DOD STIGs, PCI DSS, ISO 27001, SOC 2, EU AI Act, and GDPR. No login required. Useful as a lookup companion while working through subcategories in this tool.
+* **[GRC Companion](https://github.com/grcengineering/companion)** by [Ayoub Fandi](https://github.com/grcengineering): a free, open-source AI learning companion for GRC engineers that installs into Claude Code, Cursor, Claude Projects, or Codex. Ships 31 knowledge cards and 14 learning skills (concept tutor, Socratic coach, recall quiz, Feynman explainer, lab builder, and more). Explicitly learning-only, so it does not approve vendors, sign off audits, write production policy, or score compliance programs. Useful for building GRC skill alongside running assessments here.
 
 ## Installation and Setup
 


### PR DESCRIPTION
## Summary

Adds a **Related Resources** section to the README pointing to two free open-source GRC tools:

1. [myctrl.tools](https://myctrl.tools) by Ethan Troy
2. [GRC Companion](https://github.com/grcengineering/companion) by Ayoub Fandi (GitLab GRC Engineering lead)

Addresses CPAtoCybersecurity/catalyst#80 and CPAtoCybersecurity/catalyst#81.

## Context

### myctrl.tools (catalyst#80)
Free, static, searchable reference indexing **19,000+ controls across 94+ frameworks**, including NIST CSF 2.0, NIST 800-53, NIST AI RMF, FedRAMP, CMMC, DOD STIGs, PCI DSS, ISO 27001, SOC 2, EU AI Act, and GDPR. No login, no paywall.

- **Workflow fit**: real gap for users running a CSF assessment in this tool who want to quickly cross-reference a subcategory against a related 800-53, ISO 27001, or PCI DSS control.
- **Complement, not competitor**: myctrl.tools is a reference lookup, csf_profile is an assessment workspace.

### GRC Companion (catalyst#81)
Free, open-source AI learning companion that installs into Claude Code, Cursor, Claude Projects, or Codex. 31 knowledge cards and 14 learning skills (concept tutor, Socratic coach, recall quiz, Feynman explainer, lab builder, etc.). Explicitly learning-only, so it does not approve vendors, sign off audits, write production policy, or score compliance programs.

- **Audience fit**: GRC engineers using csf_profile.
- **Different moment of use**: myctrl.tools is mid-assessment lookup. GRC Companion is an IDE-installed skill-building tool. Framed honestly as a learning companion rather than an assessment tool.

## Changes

* Added a 'Related Resources' section between the Alma Security note and Installation
* Two bullet points, each with attribution, scope, and the specific reason it complements this tool
