### PR TITLE
Fix assessment tab bugs: backup reminder timing, CSF-only scope, scope size presets

### DIFF
--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -20,8 +20,7 @@ import EmptyState from '../components/EmptyState';
 // Stores
 import useAssessmentsStore from '../stores/assessmentsStore';
 import useControlsStore from '../stores/controlsStore';
-import useRequirementsStore from '../stores/requirementsStore';
-import useFrameworksStore from '../stores/frameworksStore';
+import useRequirementsStore, { isCsfRequirement } from '../stores/requirementsStore';
 import useUserStore from '../stores/userStore';
 import useAIStore from '../stores/aiStore';
 import useUIStore from '../stores/uiStore';
@@ -93,9 +92,6 @@ const Assessments = () => {
   const requirements = useRequirementsStore((state) => state.requirements);
   const getRequirement = useRequirementsStore((state) => state.getRequirement);
 
-  const frameworks = useFrameworksStore((state) => state.frameworks);
-  const getEnabledFrameworks = useFrameworksStore((state) => state.getEnabledFrameworks);
-
   // AI Store for test procedure generation
   const { llmProvider, generateWithOllama, generateWithClaude, ollamaStatus, claudeStatus, checkClaude, checkOllama } = useAIStore();
 
@@ -123,10 +119,10 @@ const Assessments = () => {
   const [newAssessment, setNewAssessment] = useState({
     name: '',
     description: '',
-    scopeType: 'requirements',
-    frameworkFilter: ''
+    scopeType: 'requirements'
   });
   const [selectedScopeItems, setSelectedScopeItems] = useState(new Set()); // Selected controls/requirements
+  const [scopePreset, setScopePreset] = useState(null); // 'category' | 'subcategory' | 'all' | null (custom)
   const [scopeFilterText, setScopeFilterText] = useState('');
   const [generateTestProcedures, setGenerateTestProcedures] = useState(false);
   const [isGeneratingProcedures, setIsGeneratingProcedures] = useState(false);
@@ -275,7 +271,36 @@ const Assessments = () => {
     }
   }, []);
 
-  const enabledFrameworks = useMemo(() => getEnabledFrameworks(), [frameworks]);
+  // Assessments are scoped against NIST CSF 2.0 requirements only
+  const csfRequirements = useMemo(() => requirements.filter(isCsfRequirement), [requirements]);
+
+  // Scope presets: one implementation example per category, one per
+  // subcategory, or the full catalog. "First" is catalog order, and the
+  // category key is derived from the subcategory ID (e.g. "GV.SC-04" -> "GV.SC")
+  // so both bundled and imported CSF catalogs group correctly.
+  const scopePresets = useMemo(() => {
+    const perCategory = [];
+    const perSubcategory = [];
+    const seenCategories = new Set();
+    const seenSubcategories = new Set();
+    for (const r of csfRequirements) {
+      const subcategoryId = r.subcategoryId || '';
+      const categoryId = subcategoryId.split('-')[0];
+      if (categoryId && !seenCategories.has(categoryId)) {
+        seenCategories.add(categoryId);
+        perCategory.push(r.id);
+      }
+      if (subcategoryId && !seenSubcategories.has(subcategoryId)) {
+        seenSubcategories.add(subcategoryId);
+        perSubcategory.push(r.id);
+      }
+    }
+    return {
+      category: perCategory,
+      subcategory: perSubcategory,
+      all: csfRequirements.map(r => r.id)
+    };
+  }, [csfRequirements]);
 
   // Get items available for scope selection in wizard
   const wizardScopeItems = useMemo(() => {
@@ -289,11 +314,7 @@ const Assessments = () => {
         type: 'control'
       }));
     } else {
-      let reqs = requirements;
-      if (newAssessment.frameworkFilter) {
-        reqs = reqs.filter(r => r.frameworkId === newAssessment.frameworkFilter);
-      }
-      items = reqs.map(r => ({
+      items = csfRequirements.map(r => ({
         id: r.id,
         label: r.subcategoryId || r.id,
         description: r.implementationExample || r.category || '',
@@ -314,7 +335,7 @@ const Assessments = () => {
     }
 
     return items;
-  }, [newAssessment.scopeType, newAssessment.frameworkFilter, controls, requirements, scopeFilterText]);
+  }, [newAssessment.scopeType, controls, csfRequirements, scopeFilterText]);
 
   // Wizard helper: check if AI is ready
   const isAIReady = llmProvider === 'ollama'
@@ -481,8 +502,9 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
   // Reset wizard state
   const resetWizard = useCallback(() => {
     setWizardStep(1);
-    setNewAssessment({ name: '', description: '', scopeType: 'requirements', frameworkFilter: '' });
+    setNewAssessment({ name: '', description: '', scopeType: 'requirements' });
     setSelectedScopeItems(new Set());
+    setScopePreset(null);
     setScopeFilterText('');
     setGenerateTestProcedures(false);
     setIsGeneratingProcedures(false);
@@ -1768,7 +1790,11 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                           name="scopeType"
                           value="requirements"
                           checked={newAssessment.scopeType === 'requirements'}
-                          onChange={(e) => setNewAssessment(prev => ({ ...prev, scopeType: e.target.value }))}
+                          onChange={(e) => {
+                            setNewAssessment(prev => ({ ...prev, scopeType: e.target.value }));
+                            setSelectedScopeItems(new Set());
+                            setScopePreset(null);
+                          }}
                         />
                         <div>
                           <span className="font-medium">By Requirements</span>
@@ -1782,7 +1808,11 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                           name="scopeType"
                           value="controls"
                           checked={newAssessment.scopeType === 'controls'}
-                          onChange={(e) => setNewAssessment(prev => ({ ...prev, scopeType: e.target.value }))}
+                          onChange={(e) => {
+                            setNewAssessment(prev => ({ ...prev, scopeType: e.target.value }));
+                            setSelectedScopeItems(new Set());
+                            setScopePreset(null);
+                          }}
                         />
                         <div>
                           <span className="font-medium">By Controls</span>
@@ -1797,26 +1827,52 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
 
                   {newAssessment.scopeType === 'requirements' && (
                     <div>
-                      <label className="block text-sm font-medium text-gray-700">Framework Filter</label>
-                      <select
-                        className="mt-1 w-full p-2 border rounded"
-                        value={newAssessment.frameworkFilter}
-                        onChange={(e) => {
-                          setNewAssessment(prev => ({ ...prev, frameworkFilter: e.target.value }));
-                          setSelectedScopeItems(new Set()); // Reset selection when framework changes
-                        }}
-                      >
-                        <option value="">All Frameworks</option>
-                        {enabledFrameworks.map(fw => (
-                          <option key={fw.id} value={fw.id}>{fw.name}</option>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">Scope Size</label>
+                      <div className="space-y-2">
+                        {[
+                          {
+                            key: 'category',
+                            label: 'One example per category',
+                            description: 'A quick baseline: the first implementation example from each CSF category'
+                          },
+                          {
+                            key: 'subcategory',
+                            label: 'One example per subcategory',
+                            description: 'Standard coverage: the first implementation example from each CSF subcategory'
+                          },
+                          {
+                            key: 'all',
+                            label: 'All implementation examples',
+                            description: 'Comprehensive: every CSF implementation example in the catalog'
+                          }
+                        ].map(preset => (
+                          <label
+                            key={preset.key}
+                            className={`flex items-center gap-2 p-3 border rounded cursor-pointer hover:bg-gray-50 ${scopePreset === preset.key ? 'border-blue-500 bg-blue-50' : ''}`}
+                          >
+                            <input
+                              type="radio"
+                              name="scopePreset"
+                              value={preset.key}
+                              checked={scopePreset === preset.key}
+                              onChange={() => {
+                                setScopePreset(preset.key);
+                                setSelectedScopeItems(new Set(scopePresets[preset.key]));
+                              }}
+                            />
+                            <div>
+                              <span className="font-medium">{preset.label}</span>
+                              <span className="text-gray-500 ml-2">({scopePresets[preset.key].length} items)</span>
+                              <p className="text-xs text-gray-500">{preset.description}</p>
+                            </div>
+                          </label>
                         ))}
-                      </select>
+                      </div>
                     </div>
                   )}
 
                   {/* Scope Item Selection */}
-                  {(newAssessment.scopeType === 'controls' || newAssessment.frameworkFilter) && (
-                    <div className="border rounded-lg overflow-hidden">
+                  <div className="border rounded-lg overflow-hidden">
                       <div className="bg-gray-50 p-3 border-b">
                         <div className="flex items-center justify-between mb-2">
                           <h4 className="font-medium text-gray-700">
@@ -1840,6 +1896,7 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                             onClick={() => {
                               const allIds = new Set(wizardScopeItems.map(item => item.id));
                               setSelectedScopeItems(allIds);
+                              setScopePreset(null);
                             }}
                           >
                             Select All
@@ -1847,7 +1904,10 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                           <button
                             type="button"
                             className="px-3 py-1 text-xs bg-gray-100 text-gray-700 rounded hover:bg-gray-200"
-                            onClick={() => setSelectedScopeItems(new Set())}
+                            onClick={() => {
+                              setSelectedScopeItems(new Set());
+                              setScopePreset(null);
+                            }}
                           >
                             Clear
                           </button>
@@ -1856,7 +1916,7 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                       <div className="max-h-64 overflow-y-auto">
                         {wizardScopeItems.length === 0 ? (
                           <div className="p-4 text-center text-gray-500 text-sm">
-                            No items available. {newAssessment.scopeType === 'controls' ? 'Add controls in the Controls tab.' : 'Select a framework above.'}
+                            No items available. {newAssessment.scopeType === 'controls' ? 'Add controls in the Controls tab.' : 'No CSF requirements loaded.'}
                           </div>
                         ) : (
                           <div className="divide-y">
@@ -1877,6 +1937,7 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                                       newSet.delete(item.id);
                                     }
                                     setSelectedScopeItems(newSet);
+                                    setScopePreset(null);
                                   }}
                                   className="mt-1 rounded"
                                 />
@@ -1904,7 +1965,6 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                         )}
                       </div>
                     </div>
-                  )}
                 </div>
               )}
 

--- a/src/stores/requirementsStore.js
+++ b/src/stores/requirementsStore.js
@@ -3,6 +3,27 @@ import { persist } from 'zustand/middleware';
 import Papa from 'papaparse';
 import { escapeCSVValue } from '../utils/sanitize';
 
+export const CSF_FRAMEWORK_ID = 'nist-csf-2.0';
+
+// CSV files carry human-readable framework names (e.g. "NIST CSF 2.0") while
+// stores and filters compare against framework ids (e.g. "nist-csf-2.0").
+// Normalize known display names to canonical ids at ingestion so the two
+// vocabularies never mix in persisted data.
+const FRAMEWORK_NAME_TO_ID = {
+  'nist csf 2.0': CSF_FRAMEWORK_ID,
+  'nist csf': CSF_FRAMEWORK_ID,
+};
+
+export const normalizeFrameworkId = (framework) => {
+  if (!framework) return framework;
+  return FRAMEWORK_NAME_TO_ID[framework.toLowerCase().trim()] || framework;
+};
+
+// True when a requirement belongs to NIST CSF 2.0, accepting both the
+// canonical id and legacy display-name values from older persisted data.
+export const isCsfRequirement = (requirement) =>
+  normalizeFrameworkId(requirement?.frameworkId) === CSF_FRAMEWORK_ID;
+
 const useRequirementsStore = create(
   persist(
     (set, get) => ({
@@ -190,6 +211,7 @@ const useRequirementsStore = create(
 
       // Import requirements from CSV for a specific framework
       importRequirementsCSV: async (csvText, frameworkId) => {
+        frameworkId = normalizeFrameworkId(frameworkId);
         return new Promise((resolve, reject) => {
           Papa.parse(csvText, {
             header: true,
@@ -197,7 +219,7 @@ const useRequirementsStore = create(
             complete: (results) => {
               const newRequirements = results.data.map((row, index) => {
                 // Get framework from row or use provided frameworkId
-                const rowFramework = row.FRAMEWORK || row.Framework || row.framework || frameworkId;
+                const rowFramework = normalizeFrameworkId(row.FRAMEWORK || row.Framework || row.framework || frameworkId);
 
                 return {
                   id: row['Requirement ID'] || row.ID || row.id || `${rowFramework}-${index}`,
@@ -259,7 +281,7 @@ const useRequirementsStore = create(
                   return {
                     // === FRAMEWORK DATA (Read-Only) ===
                     id: row['Requirement ID'] || row.ID || '',
-                    frameworkId: row.Framework || row.FRAMEWORK || 'nist-csf-2.0',
+                    frameworkId: normalizeFrameworkId(row.Framework || row.FRAMEWORK) || CSF_FRAMEWORK_ID,
                     function: row['CSF Function'] || row['CSF FUNCTION'] || row.Function || '',
                     functionDescription: row['CSF Function Description'] || row['Function Description'] || '',
                     category: row['Category Name'] || row.CATEGORY || row.Category || '',

--- a/src/stores/requirementsStore.test.js
+++ b/src/stores/requirementsStore.test.js
@@ -1,0 +1,71 @@
+/**
+ * Tests for framework id normalization in the requirements store.
+ * CSV files carry display names ("NIST CSF 2.0") while filters compare
+ * framework ids ("nist-csf-2.0") — see issue #269 (empty scope list).
+ */
+import useRequirementsStore, { CSF_FRAMEWORK_ID, normalizeFrameworkId, isCsfRequirement } from './requirementsStore';
+
+describe('normalizeFrameworkId', () => {
+  test('maps the CSF display name to the canonical id', () => {
+    expect(normalizeFrameworkId('NIST CSF 2.0')).toBe(CSF_FRAMEWORK_ID);
+  });
+
+  test('is case-insensitive and trims whitespace', () => {
+    expect(normalizeFrameworkId(' nist csf 2.0 ')).toBe(CSF_FRAMEWORK_ID);
+  });
+
+  test('passes through the canonical id unchanged', () => {
+    expect(normalizeFrameworkId('nist-csf-2.0')).toBe(CSF_FRAMEWORK_ID);
+  });
+
+  test('passes through unknown frameworks unchanged', () => {
+    expect(normalizeFrameworkId('iso27001-2022')).toBe('iso27001-2022');
+  });
+
+  test('passes through empty values unchanged', () => {
+    expect(normalizeFrameworkId('')).toBe('');
+    expect(normalizeFrameworkId(null)).toBeNull();
+    expect(normalizeFrameworkId(undefined)).toBeUndefined();
+  });
+});
+
+describe('isCsfRequirement', () => {
+  test('matches the canonical id', () => {
+    expect(isCsfRequirement({ frameworkId: 'nist-csf-2.0' })).toBe(true);
+  });
+
+  test('matches legacy persisted display-name values', () => {
+    expect(isCsfRequirement({ frameworkId: 'NIST CSF 2.0' })).toBe(true);
+  });
+
+  test('rejects other frameworks', () => {
+    expect(isCsfRequirement({ frameworkId: 'iso27001-2022' })).toBe(false);
+  });
+
+  test('rejects requirements without a frameworkId', () => {
+    expect(isCsfRequirement({})).toBe(false);
+    expect(isCsfRequirement(null)).toBe(false);
+  });
+});
+
+describe('importRequirementsCSV framework normalization', () => {
+  beforeEach(() => {
+    useRequirementsStore.setState({ requirements: [] });
+  });
+
+  test('rows carrying the legacy display name persist with the canonical id', async () => {
+    const csv = [
+      'Requirement ID,Framework,CSF Function,Category Name,Subcategory ID,Implementation Example',
+      'GV.SC-04 Ex1,NIST CSF 2.0,GOVERN (GV),Supply Chain (GV.SC),GV.SC-04,Ex1: Develop criteria'
+    ].join('\n');
+
+    await useRequirementsStore.getState().importRequirementsCSV(csv, CSF_FRAMEWORK_ID);
+
+    const { requirements } = useRequirementsStore.getState();
+    expect(requirements).toHaveLength(1);
+    expect(requirements[0].frameworkId).toBe(CSF_FRAMEWORK_ID);
+    // The view path for legacy assessments (frameworkFilter: 'nist-csf-2.0',
+    // e.g. from dataMigration) filters by strict id equality — must match.
+    expect(requirements.filter(r => r.frameworkId === 'nist-csf-2.0')).toHaveLength(1);
+  });
+});

--- a/src/utils/backupTracking.js
+++ b/src/utils/backupTracking.js
@@ -7,6 +7,7 @@ const STORAGE_KEYS = {
   FIRST_VISIT: 'csf_first_visit_acknowledged',
   BACKUP_REMINDER_FREQUENCY: 'csf_backup_reminder_frequency',
   LAST_REMINDER: 'csf_last_reminder_shown',
+  FIRST_USE: 'csf_first_use_date',
 };
 
 /**
@@ -40,6 +41,22 @@ export const isFirstVisit = () => {
  */
 export const acknowledgeFirstVisit = () => {
   localStorage.setItem(STORAGE_KEYS.FIRST_VISIT, 'true');
+};
+
+/**
+ * Get the first-use date, recording it now if it hasn't been recorded yet.
+ * Used to delay the first backup reminder for brand-new users who have
+ * never exported — they get a full reminder cycle before the first nag.
+ * @returns {Date} The first-use date
+ */
+export const ensureFirstUseDate = () => {
+  const firstUse = localStorage.getItem(STORAGE_KEYS.FIRST_USE);
+  if (firstUse) {
+    return new Date(firstUse);
+  }
+  const now = new Date();
+  localStorage.setItem(STORAGE_KEYS.FIRST_USE, now.toISOString());
+  return now;
 };
 
 /**
@@ -84,11 +101,13 @@ export const shouldShowBackupReminder = () => {
   const lastReminder = getLastReminderDate();
   const lastExport = getLastExportDate();
 
-  // If never reminded, check if enough time has passed since last export or app start
+  // If never reminded, check if enough time has passed since last export or first use
   if (!lastReminder) {
     if (!lastExport) {
-      // Never exported, show reminder after frequency days of first use
-      return true;
+      // Never exported: wait until a full reminder cycle has passed since first use
+      const firstUse = ensureFirstUseDate();
+      const daysSinceFirstUse = (Date.now() - firstUse.getTime()) / (1000 * 60 * 60 * 24);
+      return daysSinceFirstUse >= frequency;
     }
     // Use last export as reference
     const daysSinceExport = (Date.now() - lastExport.getTime()) / (1000 * 60 * 60 * 24);

--- a/src/utils/backupTracking.test.js
+++ b/src/utils/backupTracking.test.js
@@ -10,6 +10,7 @@ import {
   setBackupReminderFrequency,
   getLastReminderDate,
   updateLastReminderDate,
+  ensureFirstUseDate,
   shouldShowBackupReminder,
   getTimeSinceLastExport,
   getBackupWarningLevel
@@ -96,8 +97,35 @@ describe('Backup Tracking Utilities', () => {
   });
 
   describe('shouldShowBackupReminder', () => {
-    test('returns true when never reminded and never exported', () => {
+    test('returns false for a brand-new user (never exported, first use just recorded)', () => {
+      expect(shouldShowBackupReminder()).toBe(false);
+    });
+
+    test('records the first-use date on first evaluation', () => {
+      shouldShowBackupReminder();
+      expect(localStorage.getItem('csf_first_use_date')).not.toBeNull();
+    });
+
+    test('ensureFirstUseDate is idempotent — keeps the original date', () => {
+      const original = ensureFirstUseDate();
+      const second = ensureFirstUseDate();
+      expect(second.getTime()).toBe(original.getTime());
+    });
+
+    test('returns true when never exported and frequency days have passed since first use', () => {
+      const pastDate = new Date();
+      pastDate.setDate(pastDate.getDate() - 8);
+      localStorage.setItem('csf_first_use_date', pastDate.toISOString());
+
       expect(shouldShowBackupReminder()).toBe(true);
+    });
+
+    test('returns false when never exported and first use is within frequency window', () => {
+      const pastDate = new Date();
+      pastDate.setDate(pastDate.getDate() - 3);
+      localStorage.setItem('csf_first_use_date', pastDate.toISOString());
+
+      expect(shouldShowBackupReminder()).toBe(false);
     });
 
     test('returns false when recently reminded', () => {


### PR DESCRIPTION
Closes #269.

- Backup reminder no longer fires on day one: never-exported users now get a full reminder cycle (default 7 days) from first use before the toast appears (new `csf_first_use_date` stamp in backupTracking).
- Framework Filter dropdown removed from the New Assessment wizard — assessments scope against NIST CSF 2.0 requirements only. Root cause of the empty scope list was CSVs storing the framework display name ("NIST CSF 2.0") while filters compared the framework id (`nist-csf-2.0`); ids are now normalized at both CSV ingest paths.
- Step 1 now offers three Scope Size presets with live counts: one implementation example per category (22), one per subcategory (106), or all implementation examples (362). Manual search/checkbox refinement still works on top of any preset.

Tests: 200/200 (14 new); production build compiles; verified in-browser through the wizard to step 2.

Post-merge check: create an assessment from the per-subcategory preset and confirm 106 items land in scope.