### PR TITLE
Org profile: optional skippable tailoring with hard privacy guards

### DIFF
--- a/PRIVATE_DATA.md
+++ b/PRIVATE_DATA.md
@@ -96,6 +96,41 @@ metric_id,name,type,csf_subcategory_ids,description,formula,unit,target,directio
   include-private opt-in does not override it, because redistributing such content would
   violate its license. Backup exports (your own machine) always include everything.
 
+## Organization profile — private data too
+
+The optional organization profile (Settings → Organization Profile: business type, size,
+key systems, security tools, **crown jewels**) is the most sensitive record the app holds —
+the crown-jewel list plus your tooling reads like an attacker's shopping list. Its handling:
+
+- **Lives only in this browser's localStorage** (`csf-org-profile-storage`). Never in the repo,
+  never uploaded anywhere by the app.
+- **Never in shareable exports — unconditionally.** The include-private opt-in restores pack
+  data, but NOT the profile.
+- **The derived-text leak path is closed too.** Tailoring bakes profile facts (org name,
+  crown-jewel references) into procedure text on observations. Shared exports swap every
+  tailored procedure back to the **pristine community version** using its provenance
+  (`procedureSource.bankId`); if the bank entry can't be resolved, the text is dropped, never
+  leaked. Only the include-private opt-in keeps tailored text.
+- **Complete backups DO carry it** (that is their job — restore must round-trip your setup).
+  Password-protect backup files that carry a profile.
+- **Cloud AI consent gate.** Profile text goes to the local Ollama provider freely (nothing
+  leaves your machine). Sending it to a cloud provider (Claude API) requires the explicit
+  consent checkbox in Settings — off by default, and stored consent can be revoked any time.
+- **Own-data exports are NOT scrubbed.** The assessment CSV exports, Jira CSVs, and
+  "Export Assessments Only" JSON are your-own-data files: they keep tailored procedure text
+  as-is (that is what makes them useful to you). The scrubbed artifact is the **Share
+  export** only — hand people `csf_share_*.json`, not a CSV, when org context must stay out.
+
+### Procedure provenance and staleness (v1 non-goal)
+
+Attached community procedures are **copies** (`copy-on-attach`) with a provenance object:
+`procedureSource: { bank, bankId, bankVersion, attachedAt, modified, tailored }`. When the
+community bank ships a corrected procedure, already-attached copies are NOT auto-updated —
+`bankVersion` and `modified` exist for auditability and the share-export swap, not for
+re-sync. The manual refresh affordance is **Reset to community version** on the requirement's
+detail panel; `modified` is what makes a future safe re-sync possible without clobbering
+user edits.
+
 ## Sharing safely
 
 The Settings export card offers two intents:

--- a/src/components/OrgProfileWizard.js
+++ b/src/components/OrgProfileWizard.js
@@ -1,0 +1,267 @@
+import React, { useState } from 'react';
+import { X, Building2, Server, Shield, Gem, ChevronLeft, ChevronRight } from 'lucide-react';
+import toast from 'react-hot-toast';
+import useOrgProfileStore, { EMPTY_PROFILE } from '../stores/orgProfileStore';
+
+/**
+ * Optional org-profile mini-wizard. Five questions, every one skippable,
+ * "Skip all" always visible — this NEVER gates any other flow. Answers are
+ * stored only in this browser and are excluded from share exports
+ * unconditionally (see PRIVATE_DATA.md).
+ */
+
+const SIZE_BANDS = ['1–49', '50–249', '250–999', '1,000–4,999', '5,000+'];
+
+const INFRA_PRESETS = [
+  'AWS', 'Azure', 'Google Cloud', 'On-premises data center', 'SaaS-heavy',
+  'Kubernetes / containers', 'OT / ICS', 'Remote-first endpoints'
+];
+
+const TOOL_PRESETS = [
+  'EDR', 'SIEM', 'IdP / SSO', 'MFA', 'Vulnerability scanner', 'DLP', 'Backup / DR', 'Firewall / SASE'
+];
+
+const ChipPicker = ({ presets, value, onChange, placeholder }) => {
+  const [draft, setDraft] = useState('');
+  const add = (chip) => {
+    const c = chip.trim();
+    if (c && !value.includes(c)) onChange([...value, c]);
+    setDraft('');
+  };
+  return (
+    <div>
+      <div className="flex flex-wrap gap-2 mb-2">
+        {presets.filter((p) => !value.includes(p)).map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => add(p)}
+            className="px-2 py-1 text-xs rounded-full border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+          >
+            + {p}
+          </button>
+        ))}
+      </div>
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-2 mb-2">
+          {value.map((chip) => (
+            <span key={chip} className="px-2 py-1 text-xs rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 flex items-center gap-1">
+              {chip}
+              <button type="button" onClick={() => onChange(value.filter((c) => c !== chip))} aria-label={`Remove ${chip}`}>
+                <X size={11} />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      <input
+        type="text"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            add(draft);
+          }
+        }}
+        placeholder={placeholder}
+        className="w-full p-2 text-sm border dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-white"
+      />
+    </div>
+  );
+};
+
+const OrgProfileWizard = ({ onClose }) => {
+  const savedProfile = useOrgProfileStore((s) => s.profile);
+  const saveProfile = useOrgProfileStore((s) => s.saveProfile);
+  const [step, setStep] = useState(1);
+  const [draft, setDraft] = useState({ ...EMPTY_PROFILE, ...(savedProfile || {}) });
+
+  const patch = (fields) => setDraft((d) => ({ ...d, ...fields }));
+
+  const finish = () => {
+    saveProfile(draft);
+    toast.success('Organization profile saved (stored only in this browser)');
+    onClose();
+  };
+
+  const steps = [
+    {
+      icon: Building2,
+      title: 'What kind of business is it?',
+      body: (
+        <div className="space-y-3">
+          <div>
+            <label className="text-sm text-gray-600 dark:text-gray-300 block mb-1">Organization name</label>
+            <input
+              type="text"
+              value={draft.orgName}
+              onChange={(e) => patch({ orgName: e.target.value })}
+              placeholder="e.g. Northwind Insurance"
+              className="w-full p-2 text-sm border dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-white"
+            />
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Used to substitute the case study's fictional "Alma Security" in attached procedures.
+            </p>
+          </div>
+          <div>
+            <label className="text-sm text-gray-600 dark:text-gray-300 block mb-1">Industry / what the business does</label>
+            <input
+              type="text"
+              value={draft.industry}
+              onChange={(e) => patch({ industry: e.target.value })}
+              placeholder="e.g. regional health insurer; B2B SaaS; manufacturing"
+              className="w-full p-2 text-sm border dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-white"
+            />
+          </div>
+        </div>
+      )
+    },
+    {
+      icon: Building2,
+      title: 'How big is the organization?',
+      body: (
+        <div className="space-y-2">
+          {SIZE_BANDS.map((band) => (
+            <label key={band} className="flex items-center gap-3 p-2 border dark:border-gray-600 rounded-lg cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700">
+              <input
+                type="radio"
+                name="sizeBand"
+                checked={draft.sizeBand === band}
+                onChange={() => patch({ sizeBand: band })}
+              />
+              <span className="text-sm dark:text-white">{band} people</span>
+            </label>
+          ))}
+        </div>
+      )
+    },
+    {
+      icon: Server,
+      title: 'Key IT infrastructure?',
+      body: (
+        <ChipPicker
+          presets={INFRA_PRESETS}
+          value={draft.infrastructure}
+          onChange={(infrastructure) => patch({ infrastructure })}
+          placeholder="Add your own and press Enter…"
+        />
+      )
+    },
+    {
+      icon: Shield,
+      title: 'Security tools in use?',
+      body: (
+        <ChipPicker
+          presets={TOOL_PRESETS}
+          value={draft.securityTools}
+          onChange={(securityTools) => patch({ securityTools })}
+          placeholder="e.g. CrowdStrike, Splunk, Okta — press Enter to add…"
+        />
+      )
+    },
+    {
+      icon: Gem,
+      title: 'Crown jewels — your highest-value assets?',
+      body: (
+        <div className="space-y-2">
+          <ChipPicker
+            presets={[]}
+            value={draft.crownJewels}
+            onChange={(crownJewels) => patch({ crownJewels })}
+            placeholder="e.g. customer PII database, payment platform — press Enter to add…"
+          />
+          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-lg p-3 text-xs text-amber-800 dark:text-amber-300">
+            This profile — especially crown jewels and tooling — is sensitive. It stays in this
+            browser's local storage, is <strong>never included in share exports</strong> (tailored
+            procedure text is swapped back to the community version), and rides complete backups
+            only. Password-protect backups that carry it.
+          </div>
+        </div>
+      )
+    }
+  ];
+
+  const current = steps[step - 1];
+  const Icon = current.icon;
+  const isLast = step === steps.length;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-lg">
+        <div className="flex items-center justify-between p-4 border-b dark:border-gray-700">
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white flex items-center gap-2">
+            <Icon size={18} className="text-amber-600" />
+            Organization profile
+          </h3>
+          <button onClick={onClose} aria-label="Close">
+            <X size={18} className="text-gray-500" />
+          </button>
+        </div>
+
+        <div className="p-4">
+          <div className="flex items-center gap-1 mb-4">
+            {steps.map((_, i) => (
+              <div key={i} className={`h-1.5 flex-1 rounded-full ${i < step ? 'bg-amber-500' : 'bg-gray-200 dark:bg-gray-600'}`} />
+            ))}
+          </div>
+          <h4 className="font-medium text-gray-900 dark:text-white mb-3">
+            {step}. {current.title} <span className="text-xs font-normal text-gray-400">(optional)</span>
+          </h4>
+          {current.body}
+        </div>
+
+        <div className="flex items-center justify-between p-4 border-t dark:border-gray-700">
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-gray-500 dark:text-gray-400 hover:underline"
+            title="Close without saving — you can set this up any time in Settings"
+          >
+            Skip all
+          </button>
+          <div className="flex items-center gap-2">
+            {step > 1 && (
+              <button
+                type="button"
+                onClick={() => setStep(step - 1)}
+                className="px-3 py-2 text-sm border dark:border-gray-600 rounded-lg flex items-center gap-1 dark:text-gray-300"
+              >
+                <ChevronLeft size={14} /> Back
+              </button>
+            )}
+            {!isLast && (
+              <button
+                type="button"
+                onClick={() => setStep(step + 1)}
+                className="px-3 py-2 text-sm border dark:border-gray-600 rounded-lg dark:text-gray-300"
+                title="Skip this question"
+              >
+                Skip
+              </button>
+            )}
+            {isLast ? (
+              <button
+                type="button"
+                onClick={finish}
+                className="px-4 py-2 text-sm bg-amber-600 hover:bg-amber-700 text-white rounded-lg font-medium"
+              >
+                Save profile
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setStep(step + 1)}
+                className="px-4 py-2 text-sm bg-amber-600 hover:bg-amber-700 text-white rounded-lg font-medium flex items-center gap-1"
+              >
+                Next <ChevronRight size={14} />
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OrgProfileWizard;

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -27,6 +27,9 @@ import useAIStore from '../stores/aiStore';
 import useUIStore from '../stores/uiStore';
 import { formatInlineMarkdown, stripMarkdown } from '../utils/markdownText';
 import { bankCoverage, getBankProcedure, buildProcedureSource, bankSourceUrl } from '../utils/procedureBank';
+import { tailorMarkdown, canUseProfileWithProvider, buildTailorPrompt, tailoredProvenance } from '../utils/procedureTailor';
+import useOrgProfileStore from '../stores/orgProfileStore';
+import OrgProfileWizard from '../components/OrgProfileWizard';
 
 // File upload security configuration
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
@@ -128,6 +131,14 @@ const Assessments = () => {
   const [scopeFilterText, setScopeFilterText] = useState('');
   const [useBankProcedures, setUseBankProcedures] = useState(true);
   const [showBankPreview, setShowBankPreview] = useState(false);
+  const [tailorWithProfile, setTailorWithProfile] = useState(false);
+  const [showProfileWizard, setShowProfileWizard] = useState(false);
+  const [isTailoringItem, setIsTailoringItem] = useState(false);
+
+  // Org profile (optional) — powers deterministic + AI tailoring
+  const orgProfile = useOrgProfileStore((s) => s.profile);
+  const hasOrgProfile = useOrgProfileStore((s) => s.hasProfile)();
+  const cloudConsent = useOrgProfileStore((s) => s.cloudConsent);
   const [generateTestProcedures, setGenerateTestProcedures] = useState(false);
   const [isGeneratingProcedures, setIsGeneratingProcedures] = useState(false);
   const [generatedProcedures, setGeneratedProcedures] = useState({});
@@ -548,6 +559,7 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
     setScopeFilterText('');
     setUseBankProcedures(true);
     setShowBankPreview(false);
+    setTailorWithProfile(false);
     setGenerateTestProcedures(false);
     setIsGeneratingProcedures(false);
     setGeneratedProcedures({});
@@ -581,9 +593,15 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
       // provenance) for every covered item; AI/manual fills the gaps.
       const bankEntry = useBankProcedures ? getBankProcedure(itemId) : null;
       if (bankEntry) {
+        // Optional deterministic tailoring: substitute the org's name for
+        // the case study's "Alma Security". Tailored text carries the
+        // tailored flag so share export can swap back to pristine.
+        const { text, tailored } = tailorWithProfile && orgProfile
+          ? tailorMarkdown(bankEntry.markdown, orgProfile)
+          : { text: bankEntry.markdown, tailored: false };
         updateObservation(created.id, itemId, {
-          testProcedures: bankEntry.markdown,
-          procedureSource: buildProcedureSource(bankEntry.bankId)
+          testProcedures: text,
+          procedureSource: { ...buildProcedureSource(bankEntry.bankId), tailored }
         });
       } else if (generatedProcedures[itemId]) {
         updateObservation(created.id, itemId, { testProcedures: generatedProcedures[itemId] });
@@ -608,7 +626,7 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
     setCurrentAssessmentId(created.id);
     setView('scope');
     toast.success(`Assessment "${created.name}" created with ${selectedScopeItems.size} items`);
-  }, [newAssessment, createAssessment, selectedScopeItems, useBankProcedures, generatedProcedures, evidenceAnalysis, addToScope, updateObservation, getObservation, setCurrentAssessmentId, resetWizard]);
+  }, [newAssessment, createAssessment, selectedScopeItems, useBankProcedures, tailorWithProfile, orgProfile, generatedProcedures, evidenceAnalysis, addToScope, updateObservation, getObservation, setCurrentAssessmentId, resetWizard]);
 
   const handleSelectAssessment = useCallback((assessment) => {
     setCurrentAssessmentId(assessment.id);
@@ -686,6 +704,49 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
     });
     toast.success(`Community procedure for ${entry.bankId} attached`);
   }, [currentAssessmentId, selectedItemId, updateObservation]);
+
+  // AI-tailor the selected item's procedure with the org profile.
+  // Consent gate: the profile never goes to a CLOUD provider without the
+  // explicit stored opt-in; local Ollama needs none.
+  const handleTailorWithAI = useCallback(async (currentText) => {
+    if (!currentAssessmentId || !selectedItemId) return;
+    if (!hasOrgProfile) {
+      toast.error('Set up your organization profile first (Settings → Organization profile).');
+      return;
+    }
+    if (!canUseProfileWithProvider(llmProvider, cloudConsent)) {
+      toast.error(
+        'Sending your org profile to a cloud AI provider requires consent — enable it in ' +
+        'Settings → Organization profile, or switch the AI provider to local Ollama.',
+        { duration: 8000 }
+      );
+      return;
+    }
+    if (!isAIReady) {
+      toast.error('AI provider is not ready.');
+      return;
+    }
+
+    setIsTailoringItem(true);
+    try {
+      const prompt = buildTailorPrompt(currentText, orgProfile);
+      const response = llmProvider === 'ollama'
+        ? await generateWithOllama(prompt, 2500)
+        : await generateWithClaude(prompt, 2500);
+      const existing = getObservation(currentAssessmentId, selectedItemId);
+      // ALWAYS stamp tailored provenance — an untagged tailored procedure
+      // would bypass the share-export pristine swap and leak profile facts.
+      updateObservation(currentAssessmentId, selectedItemId, {
+        testProcedures: response,
+        procedureSource: tailoredProvenance(existing?.procedureSource, selectedItemId)
+      });
+      toast.success('Procedure tailored to your organization');
+    } catch (error) {
+      console.error('Tailor error:', error);
+      toast.error('Tailoring failed — the original text is unchanged.');
+    }
+    setIsTailoringItem(false);
+  }, [currentAssessmentId, selectedItemId, hasOrgProfile, llmProvider, cloudConsent, isAIReady, orgProfile, generateWithOllama, generateWithClaude, getObservation, updateObservation]);
 
   const handleQuarterlyChange = useCallback((field, value) => {
     if (!currentAssessmentId || !selectedItemId) return;
@@ -1394,8 +1455,26 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                             {currentObservation.procedureSource.modified ? 'Community · customized' : 'Community'}
                           </span>
                         )}
+                        {currentObservation.procedureSource?.tailored && currentObservation.procedureSource?.bank !== 'community' && (
+                          <span className="px-1.5 py-0.5 rounded text-xs bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+                            Tailored to your org
+                          </span>
+                        )}
                       </label>
                       <div className="flex items-center gap-3">
+                        {editMode && hasOrgProfile && currentObservation.testProcedures && (
+                          <button
+                            type="button"
+                            onClick={() => handleTailorWithAI(currentObservation.testProcedures)}
+                            disabled={isTailoringItem}
+                            className="text-xs text-amber-700 dark:text-amber-400 flex items-center gap-1 hover:underline disabled:opacity-50"
+                            title="Rewrite this procedure for your organization using AI (profile-aware; cloud providers require consent)"
+                          >
+                            {isTailoringItem
+                              ? (<><Loader2 size={12} className="animate-spin" /> Tailoring…</>)
+                              : (<><Sparkles size={12} /> Tailor with AI</>)}
+                          </button>
+                        )}
                         {editMode && getBankProcedure(selectedItemId) && (
                           <button
                             type="button"
@@ -2140,7 +2219,54 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                     )}
                   </div>
 
-                  {/* Card 2: AI generation — optional, targets the gaps */}
+                  {/* Card 2: tailor to the organization (optional, needs profile) */}
+                  <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-lg p-4">
+                    <div className="flex items-start gap-3">
+                      <Settings size={20} className="text-amber-600 mt-0.5" />
+                      <div className="flex-1">
+                        <h4 className="font-medium text-amber-900 dark:text-amber-200">Tailor to your organization (optional)</h4>
+                        {hasOrgProfile ? (
+                          <>
+                            <label className="flex items-center gap-2 mt-2 cursor-pointer">
+                              <input
+                                type="checkbox"
+                                checked={tailorWithProfile}
+                                onChange={(e) => setTailorWithProfile(e.target.checked)}
+                                className="w-4 h-4 rounded"
+                                disabled={!useBankProcedures}
+                              />
+                              <span className="text-sm text-amber-900 dark:text-amber-200">
+                                Substitute my organization's name into attached procedures
+                              </span>
+                            </label>
+                            <p className="text-xs text-amber-700 dark:text-amber-400 mt-1">
+                              Uses your saved profile{orgProfile?.orgName ? ` (${orgProfile.orgName})` : ''} —{' '}
+                              <button type="button" className="underline" onClick={() => setShowProfileWizard(true)}>edit</button>.
+                              Per-item AI tailoring is available on each requirement after creation.
+                              {!useBankProcedures && ' (Enable community procedures above to tailor them.)'}
+                            </p>
+                          </>
+                        ) : (
+                          <>
+                            <p className="text-sm text-amber-800 dark:text-amber-300 mt-1">
+                              Answer a few optional questions (business type, size, systems, security
+                              tools, crown jewels) and procedures adapt to your environment. Skippable —
+                              you can set this up any time.
+                            </p>
+                            <button
+                              type="button"
+                              onClick={() => setShowProfileWizard(true)}
+                              className="mt-2 px-3 py-1.5 text-sm border border-amber-400 text-amber-800 dark:text-amber-300 rounded-lg hover:bg-amber-100 dark:hover:bg-amber-900/40"
+                            >
+                              Set up org profile (~2 min)
+                            </button>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Card 3: AI generation — optional, targets the gaps */}
                   <div className="bg-purple-50 dark:bg-purple-900/20 border border-purple-200 dark:border-purple-700 rounded-lg p-4">
                     <div className="flex items-start gap-3">
                       <Bot size={24} className="text-purple-600 mt-0.5" />
@@ -2448,6 +2574,10 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
             </div>
           </div>
         </div>
+      )}
+
+      {showProfileWizard && (
+        <OrgProfileWizard onClose={() => setShowProfileWizard(false)} />
       )}
     </div>
   );

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -32,6 +32,8 @@ import useUserStore from '../stores/userStore';
 import useArtifactStore from '../stores/artifactStore';
 import useFindingsStore from '../stores/findingsStore';
 import useMetricsStore from '../stores/metricsStore';
+import useOrgProfileStore from '../stores/orgProfileStore';
+import OrgProfileWizard from '../components/OrgProfileWizard';
 
 // Utils
 import { exportCompleteDatabase, exportAssessmentsJSON, exportShareableDatabase } from '../utils/dataExport';
@@ -81,6 +83,13 @@ const Settings = () => {
   // Local state
   const [editingFramework, setEditingFramework] = useState(null);
   const [backupFrequency, setBackupFrequency] = useState(getBackupReminderFrequency());
+  const [showOrgProfileWizard, setShowOrgProfileWizard] = useState(false);
+
+  // Organization profile (optional tailoring input; never in share exports)
+  const orgProfileSet = useOrgProfileStore((s) => s.hasProfile)();
+  const orgCloudConsent = useOrgProfileStore((s) => s.cloudConsent);
+  const setOrgCloudConsent = useOrgProfileStore((s) => s.setCloudConsent);
+  const clearOrgProfile = useOrgProfileStore((s) => s.clearProfile);
 
   // Atlassian configuration state
   const [atlassianSiteUrl, setAtlassianSiteUrl] = useState('');
@@ -273,7 +282,8 @@ const Settings = () => {
         artifactStore: useArtifactStore,
         userStore: useUserStore,
         findingsStore: useFindingsStore,
-        metricsStore: useMetricsStore
+        metricsStore: useMetricsStore,
+        orgProfileStore: useOrgProfileStore
       });
       toast.success('Complete database exported as JSON');
     } catch (err) {
@@ -287,7 +297,9 @@ const Settings = () => {
       if (includePackData) {
         const confirmed = window.confirm(
           'Include private pack data in this export?\n\n' +
-          'The file will contain your organization\'s private assessment values and risk entries. ' +
+          'The file will contain your organization\'s private assessment values and risk entries, ' +
+          'AND any procedure text tailored from your org profile (org name, crown-jewel references). ' +
+          'Your org profile itself stays excluded either way. ' +
           'Only do this for a copy you keep to yourself — never for a file you plan to share.'
         );
         if (!confirmed) return;
@@ -300,7 +312,8 @@ const Settings = () => {
         artifactStore: useArtifactStore,
         userStore: useUserStore,
         findingsStore: useFindingsStore,
-        metricsStore: useMetricsStore
+        metricsStore: useMetricsStore,
+        orgProfileStore: useOrgProfileStore
       }, { includePrivate: includePackData });
       toast.success(includePackData
         ? 'Export created WITH private pack data — handle with care'
@@ -372,6 +385,7 @@ const Settings = () => {
       const catalogSlug = catalogSlugFromFilename(file.name);
       const preview = previewMetricsImport(validation, {
         metricsStore: useMetricsStore,
+        orgProfileStore: useOrgProfileStore,
         frameworksStore: useFrameworksStore,
         requirementsStore: useRequirementsStore
       }, { catalogSlug });
@@ -386,7 +400,8 @@ const Settings = () => {
     if (!metricsPreview) return;
     try {
       const result = importMetricsCatalog(metricsPreview.validation, {
-        metricsStore: useMetricsStore
+        metricsStore: useMetricsStore,
+        orgProfileStore: useOrgProfileStore
       }, { catalogSlug: metricsPreview.preview.catalogSlug });
       toast.success(
         `${result.replaced ? 'Replaced' : 'Imported'} catalogue "${metricsPreview.preview.catalogSlug}" — ` +
@@ -443,7 +458,8 @@ const Settings = () => {
         artifactStore: useArtifactStore,
         userStore: useUserStore,
         findingsStore: useFindingsStore,
-        metricsStore: useMetricsStore
+        metricsStore: useMetricsStore,
+        orgProfileStore: useOrgProfileStore
       };
 
       const validation = validateDatabaseExport(parsed);
@@ -1094,6 +1110,60 @@ nist-csf-2.0,RECOVER (RC),Incident Recovery Plan Execution (RC.RP),RC.RP-01,The 
             </button>
             <p className="text-xs text-red-600 mt-3">
               Accepts csf_assessment_*.json files created by Export Complete Database. This is a full replace, not a merge.
+            </p>
+          </div>
+
+          {/* Organization profile — optional tailoring input; the most sensitive
+              record in the app (crown jewels + tooling). Never in share exports. */}
+          <div className="mt-6 bg-amber-50 border border-amber-200 rounded-lg p-4">
+            <div className="flex items-center justify-between mb-3">
+              <div>
+                <h3 className="font-medium text-amber-800">Organization Profile (optional)</h3>
+                <p className="text-sm text-amber-700 mt-1">
+                  Business type, size, key systems, security tools, and crown jewels — used to tailor
+                  community test procedures to your environment. Every question is skippable.
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                className="flex items-center gap-2 text-sm bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded"
+                onClick={() => setShowOrgProfileWizard(true)}
+              >
+                {orgProfileSet ? 'Edit Profile' : 'Set Up Profile'}
+              </button>
+              {orgProfileSet && (
+                <button
+                  className="text-sm text-amber-700 hover:underline"
+                  onClick={() => {
+                    if (window.confirm('Clear the organization profile from this browser? Tailored text already in assessments is not changed.')) {
+                      clearOrgProfile();
+                      toast.success('Organization profile cleared');
+                    }
+                  }}
+                >
+                  Clear profile
+                </button>
+              )}
+            </div>
+            {orgProfileSet && (
+              <label className="flex items-start gap-2 mt-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={orgCloudConsent}
+                  onChange={(e) => setOrgCloudConsent(e.target.checked)}
+                  className="w-4 h-4 rounded mt-0.5"
+                />
+                <span className="text-xs text-amber-700">
+                  Allow sending my profile to a <strong>cloud</strong> AI provider (Claude API) for procedure
+                  tailoring. Local Ollama never needs this — nothing leaves your machine there.
+                </span>
+              </label>
+            )}
+            <p className="text-xs text-amber-600 mt-3">
+              Stored only in this browser. <strong>Never included in shareable exports</strong> — tailored
+              procedure text is swapped back to the community version there. It rides complete backups
+              only; password-protect backups that carry it.
             </p>
           </div>
 
@@ -1863,6 +1933,10 @@ nist-csf-2.0,RECOVER (RC),Incident Recovery Plan Execution (RC.RP),RC.RP-01,The 
             </div>
           </div>
         </div>
+      )}
+
+      {showOrgProfileWizard && (
+        <OrgProfileWizard onClose={() => setShowOrgProfileWizard(false)} />
       )}
     </div>
   );

--- a/src/stores/orgProfileStore.js
+++ b/src/stores/orgProfileStore.js
@@ -1,0 +1,66 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+/**
+ * Organization profile — powers optional tailoring of community test
+ * procedures (org-name substitution, AI tailoring context).
+ *
+ * PRIVACY MODEL (see PRIVATE_DATA.md): this is the most sensitive record in
+ * the app — crown jewels plus the security tooling list read like an
+ * attacker's shopping list. It lives only in this browser's localStorage,
+ * is UNCONDITIONALLY excluded from share exports (including derived text:
+ * tailored procedures are swapped back to the pristine community version),
+ * and rides complete backups only. Sending profile text to a CLOUD AI
+ * provider requires the explicit cloudConsent opt-in; local Ollama needs
+ * none.
+ */
+
+export const ORG_PROFILE_SCHEMA_VERSION = 1;
+
+export const EMPTY_PROFILE = {
+  orgName: '',
+  industry: '',
+  sizeBand: '',
+  infrastructure: [],
+  securityTools: [],
+  crownJewels: [],
+  notes: ''
+};
+
+const profileHasContent = (profile) => {
+  if (!profile) return false;
+  return Object.values(profile).some((v) =>
+    Array.isArray(v) ? v.length > 0 : String(v || '').trim() !== ''
+  );
+};
+
+const useOrgProfileStore = create(
+  persist(
+    (set, get) => ({
+      profile: null, // null = never set up
+      cloudConsent: false,
+
+      saveProfile: (partial) =>
+        set({ profile: { ...EMPTY_PROFILE, ...(get().profile || {}), ...partial } }),
+
+      setCloudConsent: (value) => set({ cloudConsent: !!value }),
+
+      clearProfile: () => set({ profile: null, cloudConsent: false }),
+
+      hasProfile: () => profileHasContent(get().profile),
+
+      // Bulk setter for the backup-restore path (dataImport.js).
+      setProfileState: (state) =>
+        set({
+          profile: state && profileHasContent(state.profile) ? { ...EMPTY_PROFILE, ...state.profile } : null,
+          cloudConsent: !!(state && state.cloudConsent)
+        })
+    }),
+    {
+      name: 'csf-org-profile-storage',
+      version: ORG_PROFILE_SCHEMA_VERSION
+    }
+  )
+);
+
+export default useOrgProfileStore;

--- a/src/utils/dataExport.js
+++ b/src/utils/dataExport.js
@@ -5,6 +5,7 @@
  */
 
 import { licenseIsRestricted } from './metricsImport';
+import { getBankProcedure } from './procedureBank';
 
 /**
  * Export format version. Bump when the envelope shape changes and teach
@@ -12,8 +13,11 @@ import { licenseIsRestricted } from './metricsImport';
  * Format 1: legacy `version: '1.0'` exports (no storeVersions, no findings).
  * Format 2: adds formatVersion, storeVersions, and the findings section.
  * Format 3: adds the metrics section (imported metrics catalogues).
+ * Format 4: adds the orgProfile section (object, not array) to COMPLETE
+ *   backups. Share exports NEVER carry it, and tailored procedures are
+ *   swapped back to the pristine community text (see PRIVATE_DATA.md).
  */
-export const EXPORT_FORMAT_VERSION = 3;
+export const EXPORT_FORMAT_VERSION = 4;
 
 // zustand persist keys whose schema versions travel with the export so a
 // restore can detect version drift between the exporting and importing app.
@@ -22,7 +26,8 @@ export const PERSIST_KEYS = {
   frameworks: 'csf-frameworks-storage',
   findings: 'csf-findings-storage',
   requirements: 'csf-requirements-storage',
-  metrics: 'csf-metrics-storage'
+  metrics: 'csf-metrics-storage',
+  orgProfile: 'csf-org-profile-storage'
 };
 
 /**
@@ -62,8 +67,11 @@ export const exportAllDataJSON = (stores) => {
     artifactStore,
     userStore,
     findingsStore,
-    metricsStore
+    metricsStore,
+    orgProfileStore
   } = stores;
+
+  const orgProfileState = orgProfileStore?.getState?.();
 
   const jsonData = {
     exportDate: new Date().toISOString(),
@@ -87,7 +95,12 @@ export const exportAllDataJSON = (stores) => {
       frameworks: frameworksStore?.getState?.()?.frameworks || [],
       artifacts: artifactStore?.getState?.()?.artifacts || [],
       findings: findingsStore?.getState?.()?.findings || [],
-      metrics: metricsStore?.getState?.()?.metrics || []
+      metrics: metricsStore?.getState?.()?.metrics || [],
+      // Object section (not an array): the org profile rides COMPLETE
+      // backups only; buildShareableExport strips it unconditionally.
+      orgProfile: orgProfileState
+        ? { profile: orgProfileState.profile, cloudConsent: orgProfileState.cloudConsent }
+        : { profile: null, cloudConsent: false }
     }
   };
 
@@ -139,11 +152,49 @@ const stripMetricLinks = (assessments, excludedIds) => {
 };
 
 /**
+ * Swap tailored procedures back to the pristine community version. The org
+ * profile is excluded from share exports, but tailoring BAKES profile facts
+ * (org name, systems, crown-jewel references) into observation text — a
+ * derived leak path. Provenance (procedureSource.bankId) makes the fix
+ * deterministic: shared copies get the untailored community markdown. If the
+ * bank entry cannot be resolved, the text is dropped entirely — never leaked.
+ * Copies on write; never mutates store objects.
+ */
+const swapTailoredProcedures = (assessments) =>
+  assessments.map((assessment) => {
+    const observations = assessment.observations;
+    if (!observations || typeof observations !== 'object') return assessment;
+
+    let changed = false;
+    const nextObservations = {};
+    Object.entries(observations).forEach(([itemId, obs]) => {
+      if (obs?.procedureSource?.tailored) {
+        const bankEntry = getBankProcedure(obs.procedureSource.bankId);
+        nextObservations[itemId] = {
+          ...obs,
+          testProcedures: bankEntry ? bankEntry.markdown : '',
+          procedureSource: { ...obs.procedureSource, tailored: false, modified: false }
+        };
+        changed = true;
+      } else {
+        nextObservations[itemId] = obs;
+      }
+    });
+
+    return changed ? { ...assessment, observations: nextObservations } : assessment;
+  });
+
+/**
  * Build a shareable export: the complete-database envelope minus private
  * pack data. The filter is LINEAGE-aware, not tag-only — it drops every
  * assessment that originated from a pack import (including all observations
  * nested inside it, which carry no tags of their own) and every finding that
  * either carries pack provenance or points at a pack-owned assessment.
+ *
+ * The org profile is stripped UNCONDITIONALLY — the include-private opt-in
+ * does not restore it (crown jewels + tooling are never share material).
+ * Tailored procedure text (profile-derived) is swapped back to the pristine
+ * community version by default; include-private keeps the tailored text.
  *
  * @param {Object} stores - Same store map exportAllDataJSON receives
  * @param {Object} [options]
@@ -152,6 +203,9 @@ const stripMetricLinks = (assessments, excludedIds) => {
 export const buildShareableExport = (stores, { includePrivate = false } = {}) => {
   const jsonData = exportAllDataJSON(stores);
   const allMetrics = jsonData.data.metrics || [];
+
+  // Org profile: never in a share export, opt-in or not.
+  delete jsonData.data.orgProfile;
 
   // Restricted-license metric definitions (NC/ND/proprietary — e.g. a CIS
   // catalogue an org uses internally) are HARD-BLOCKED from share exports:
@@ -173,7 +227,9 @@ export const buildShareableExport = (stores, { includePrivate = false } = {}) =>
   const packAssessmentIds = new Set(
     jsonData.data.assessments.filter((a) => a.source === 'pack').map((a) => a.id)
   );
-  jsonData.data.assessments = jsonData.data.assessments.filter((a) => a.source !== 'pack');
+  jsonData.data.assessments = swapTailoredProcedures(
+    jsonData.data.assessments.filter((a) => a.source !== 'pack')
+  );
   jsonData.data.findings = jsonData.data.findings.filter(
     (f) => f.source !== 'pack' && !packAssessmentIds.has(f.assessmentId)
   );

--- a/src/utils/dataImport.js
+++ b/src/utils/dataImport.js
@@ -85,6 +85,18 @@ export const validateDatabaseExport = (parsed) => {
     counts[key] = value.length;
     presentSections += 1;
   });
+
+  // orgProfile (format 4+) is an OBJECT section, not an array. Format-3 and
+  // older files simply don't carry it — the profile is skipped, not erased.
+  const orgProfileSection = parsed.data.orgProfile;
+  if (orgProfileSection !== undefined) {
+    if (typeof orgProfileSection !== 'object' || Array.isArray(orgProfileSection) || orgProfileSection === null) {
+      errors.push('Section "orgProfile" is not an object.');
+    } else {
+      counts.orgProfile = orgProfileSection.profile ? 1 : 0;
+      presentSections += 1;
+    }
+  }
   if (presentSections === 0) {
     errors.push('Export contains none of the known data sections.');
   }
@@ -172,6 +184,24 @@ export const importCompleteDatabase = (parsed, stores, { backupFirst = true } = 
     // Snapshot the current value so a mid-apply failure can roll back.
     writes.push({ key, setFn, value, previous: storeState[key] });
   });
+
+  // orgProfile (format 4+, object section) rides the same resolve-then-apply
+  // pipeline. Absent in older files → skipped, current profile untouched.
+  if (data.orgProfile !== undefined) {
+    const orgState = stores.orgProfileStore?.getState?.();
+    const setProfileState = orgState?.setProfileState;
+    if (typeof setProfileState !== 'function') {
+      throw new Error('Store "orgProfileStore" is missing setProfileState(); restore aborted before any data was changed.');
+    }
+    writes.push({
+      key: 'orgProfile',
+      setFn: setProfileState,
+      value: data.orgProfile,
+      previous: { profile: orgState.profile, cloudConsent: orgState.cloudConsent }
+    });
+  } else {
+    skipped.push('orgProfile');
+  }
 
   try {
     writes.forEach(({ key, setFn, value }) => {

--- a/src/utils/dataImport.test.js
+++ b/src/utils/dataImport.test.js
@@ -27,7 +27,8 @@ const makeStores = (data = SAMPLE) => {
     setFrameworks: jest.fn(),
     setArtifacts: jest.fn(),
     setFindings: jest.fn(),
-    setMetrics: jest.fn()
+    setMetrics: jest.fn(),
+    setProfileState: jest.fn()
   };
   const stores = {
     userStore: { getState: () => ({ users: data.users, setUsers: setters.setUsers }) },
@@ -37,7 +38,8 @@ const makeStores = (data = SAMPLE) => {
     frameworksStore: { getState: () => ({ frameworks: data.frameworks, setFrameworks: setters.setFrameworks }) },
     artifactStore: { getState: () => ({ artifacts: data.artifacts, setArtifacts: setters.setArtifacts }) },
     findingsStore: { getState: () => ({ findings: data.findings, setFindings: setters.setFindings }) },
-    metricsStore: { getState: () => ({ metrics: data.metrics, setMetrics: setters.setMetrics }) }
+    metricsStore: { getState: () => ({ metrics: data.metrics, setMetrics: setters.setMetrics }) },
+    orgProfileStore: { getState: () => ({ profile: null, cloudConsent: false, setProfileState: setters.setProfileState }) }
   };
   return { stores, setters };
 };

--- a/src/utils/metricsImport.test.js
+++ b/src/utils/metricsImport.test.js
@@ -63,7 +63,8 @@ const makeStores = ({ metrics = [], assessments = [], findings = [] } = {}) => (
   requirementsStore: { getState: () => ({ requirements: REQUIREMENTS, setRequirements: jest.fn() }) },
   controlsStore: { getState: () => ({ controls: [], setControls: jest.fn() }) },
   artifactStore: { getState: () => ({ artifacts: [], setArtifacts: jest.fn() }) },
-  userStore: { getState: () => ({ users: [], setUsers: jest.fn() }) }
+  userStore: { getState: () => ({ users: [], setUsers: jest.fn() }) },
+  orgProfileStore: { getState: () => ({ profile: null, cloudConsent: false, setProfileState: jest.fn() }) }
 });
 
 const importCsv = (text, stores, slug = 'test-catalog') => {

--- a/src/utils/orgProfileExport.test.js
+++ b/src/utils/orgProfileExport.test.js
@@ -1,0 +1,251 @@
+/**
+ * Org-profile privacy guards (PRIVATE_DATA.md):
+ *  - the profile object NEVER rides share exports (opt-in or not);
+ *  - the DERIVED leak path is closed: tailored procedure text (org name,
+ *    crown-jewel references baked in) is swapped back to the pristine
+ *    community version in default share exports;
+ *  - complete backups DO carry the profile (that's their job);
+ *  - restore round-trips it, older files skip it, cloud consent gates it.
+ */
+import { exportAllDataJSON, buildShareableExport, EXPORT_FORMAT_VERSION } from './dataExport';
+import { validateDatabaseExport, importCompleteDatabase } from './dataImport';
+import { tailorMarkdown, canUseProfileWithProvider, tailoredProvenance } from './procedureTailor';
+import { getBankProcedure, buildProcedureSource } from './procedureBank';
+import useOrgProfileStore from '../stores/orgProfileStore';
+import useAssessmentsStore from '../stores/assessmentsStore';
+
+const CANARY_JEWEL = 'CustomerVault9000';
+const CANARY_ORG = 'Northwind Insurance';
+
+const seedProfile = () => {
+  useOrgProfileStore.getState().saveProfile({
+    orgName: CANARY_ORG,
+    industry: 'Insurance',
+    sizeBand: '250–999',
+    infrastructure: ['AWS'],
+    securityTools: ['EDR'],
+    crownJewels: [CANARY_JEWEL]
+  });
+};
+
+const stores = () => ({
+  assessmentsStore: useAssessmentsStore,
+  orgProfileStore: useOrgProfileStore
+});
+
+describe('org profile in exports', () => {
+  let assessmentId;
+  const pristine = getBankProcedure('GV.OC-01').markdown;
+
+  beforeEach(() => {
+    seedProfile();
+    const created = useAssessmentsStore.getState().createAssessment({
+      name: 'Tailored export test',
+      description: '',
+      scopeType: 'requirements'
+    });
+    assessmentId = created.id;
+    useAssessmentsStore.getState().addToScope(assessmentId, 'GV.OC-01 Ex1');
+
+    // A tailored attach: profile facts baked into the observation text
+    const { text, tailored } = tailorMarkdown(
+      `${pristine}\n\nCrown-jewel focus: verify ${CANARY_JEWEL} recovery steps.`,
+      useOrgProfileStore.getState().profile
+    );
+    useAssessmentsStore.getState().updateObservation(assessmentId, 'GV.OC-01 Ex1', {
+      testProcedures: text,
+      procedureSource: { ...buildProcedureSource('GV.OC-01'), tailored: tailored || true }
+    });
+  });
+
+  afterEach(() => {
+    useAssessmentsStore.getState().deleteAssessment(assessmentId);
+    useOrgProfileStore.getState().clearProfile();
+  });
+
+  test('complete backup carries the profile — that is its job', () => {
+    const backup = exportAllDataJSON(stores());
+    expect(backup.formatVersion).toBe(EXPORT_FORMAT_VERSION);
+    expect(backup.data.orgProfile.profile.crownJewels).toContain(CANARY_JEWEL);
+    // Tailored text stays in the user's own backup
+    expect(JSON.stringify(backup.data.assessments)).toContain(CANARY_JEWEL);
+  });
+
+  test('default share export: no profile object AND no derived leak — tailored text swapped to pristine', () => {
+    const share = buildShareableExport(stores());
+    const serialized = JSON.stringify(share);
+
+    expect(share.data.orgProfile).toBeUndefined();
+    expect(serialized).not.toContain(CANARY_JEWEL);
+    expect(serialized).not.toContain(CANARY_ORG);
+
+    const exported = share.data.assessments.find((a) => a.id === assessmentId);
+    const obs = exported.observations['GV.OC-01 Ex1'];
+    expect(obs.testProcedures).toBe(pristine);
+    expect(obs.procedureSource.tailored).toBe(false);
+
+    // Store objects were never mutated (copy-on-write)
+    const inStore = useAssessmentsStore.getState()
+      .getObservation(assessmentId, 'GV.OC-01 Ex1');
+    expect(inStore.testProcedures).toContain(CANARY_JEWEL);
+    expect(inStore.procedureSource.tailored).toBe(true);
+  });
+
+  test('include-private opt-in keeps tailored text but STILL never the profile object', () => {
+    const share = buildShareableExport(stores(), { includePrivate: true });
+    expect(share.data.orgProfile).toBeUndefined();
+    expect(JSON.stringify(share.data.assessments)).toContain(CANARY_JEWEL);
+  });
+
+  test('AI-tailoring an observation with NO prior provenance still swaps in default share (bank-covered item)', () => {
+    // The reviewer-caught hole: tailored output must ALWAYS carry tailored
+    // provenance, or the swap never fires. Simulates handleTailorWithAI on a
+    // hand-written procedure for a bank-covered item.
+    useAssessmentsStore.getState().updateObservation(assessmentId, 'GV.OC-01 Ex1', {
+      testProcedures: 'My own procedure — no provenance yet.',
+      procedureSource: undefined
+    });
+    useAssessmentsStore.getState().updateObservation(assessmentId, 'GV.OC-01 Ex1', {
+      testProcedures: `Tailored for ${CANARY_ORG}: protect ${CANARY_JEWEL}.`,
+      procedureSource: tailoredProvenance(undefined, 'GV.OC-01 Ex1')
+    });
+
+    const share = buildShareableExport(stores());
+    const obs = share.data.assessments.find((a) => a.id === assessmentId).observations['GV.OC-01 Ex1'];
+    expect(obs.testProcedures).toBe(pristine);
+    expect(JSON.stringify(share)).not.toContain(CANARY_JEWEL);
+  });
+
+  test('AI-tailoring an item with no bank coverage (control scope) drops the text in default share', () => {
+    useAssessmentsStore.getState().addToScope(assessmentId, 'CTRL-042');
+    useAssessmentsStore.getState().updateObservation(assessmentId, 'CTRL-042', {
+      testProcedures: `Tailored control steps referencing ${CANARY_JEWEL}.`,
+      procedureSource: tailoredProvenance(undefined, 'CTRL-042')
+    });
+
+    const share = buildShareableExport(stores());
+    const obs = share.data.assessments.find((a) => a.id === assessmentId).observations['CTRL-042'];
+    expect(obs.testProcedures).toBe('');
+    expect(JSON.stringify(share)).not.toContain(CANARY_JEWEL);
+  });
+
+  test('a tailored observation whose bank entry cannot resolve exports empty text, never the tailored text', () => {
+    useAssessmentsStore.getState().updateObservation(assessmentId, 'GV.OC-01 Ex1', {
+      testProcedures: `Secret steps for ${CANARY_JEWEL}`,
+      procedureSource: { bank: 'community', bankId: 'ZZ.GONE-99', bankVersion: 'x', tailored: true }
+    });
+    const share = buildShareableExport(stores());
+    const obs = share.data.assessments.find((a) => a.id === assessmentId).observations['GV.OC-01 Ex1'];
+    expect(obs.testProcedures).toBe('');
+    expect(JSON.stringify(share)).not.toContain(CANARY_JEWEL);
+  });
+});
+
+describe('org profile restore path', () => {
+  const stubArrayStores = () => {
+    const mk = (stateKey, setterName) => {
+      const state = { [stateKey]: [], [setterName]: jest.fn() };
+      return { getState: () => state };
+    };
+    return {
+      userStore: mk('users', 'setUsers'),
+      controlsStore: mk('controls', 'setControls'),
+      assessmentsStore: mk('assessments', 'setAssessments'),
+      requirementsStore: mk('requirements', 'setRequirements'),
+      frameworksStore: mk('frameworks', 'setFrameworks'),
+      artifactStore: mk('artifacts', 'setArtifacts'),
+      findingsStore: mk('findings', 'setFindings'),
+      metricsStore: mk('metrics', 'setMetrics'),
+      orgProfileStore: useOrgProfileStore
+    };
+  };
+
+  const envelope = (extra = {}) => ({
+    formatVersion: EXPORT_FORMAT_VERSION,
+    data: {
+      frameworks: [{ id: 'csf2', name: 'CSF 2.0' }],
+      assessments: [],
+      ...extra
+    }
+  });
+
+  afterEach(() => {
+    useOrgProfileStore.getState().clearProfile();
+  });
+
+  test('format-4 restore round-trips the profile', () => {
+    const file = envelope({
+      orgProfile: { profile: { orgName: 'Restored Org', crownJewels: ['DB1'] }, cloudConsent: true }
+    });
+    expect(validateDatabaseExport(file).ok).toBe(true);
+    const result = importCompleteDatabase(file, stubArrayStores(), { backupFirst: false });
+    expect(result.applied).toContain('orgProfile');
+    expect(useOrgProfileStore.getState().profile.orgName).toBe('Restored Org');
+    expect(useOrgProfileStore.getState().cloudConsent).toBe(true);
+  });
+
+  test('format-3 files (no orgProfile section) skip the profile — existing profile untouched', () => {
+    useOrgProfileStore.getState().saveProfile({ orgName: 'Keep Me' });
+    const file = { ...envelope(), formatVersion: 3 };
+    const result = importCompleteDatabase(file, stubArrayStores(), { backupFirst: false });
+    expect(result.skipped).toContain('orgProfile');
+    expect(useOrgProfileStore.getState().profile.orgName).toBe('Keep Me');
+  });
+
+  test('malformed orgProfile section is rejected', () => {
+    const file = envelope({ orgProfile: ['not', 'an', 'object'] });
+    const validation = validateDatabaseExport(file);
+    expect(validation.ok).toBe(false);
+    expect(validation.errors.join(' ')).toContain('orgProfile');
+  });
+});
+
+describe('tailoredProvenance — always tailored, never undefined', () => {
+  test('existing source: flags stamped, identity preserved', () => {
+    const src = tailoredProvenance(
+      { bank: 'community', bankId: 'GV.OC-01', bankVersion: 'abc', modified: false },
+      'GV.OC-01 Ex1'
+    );
+    expect(src).toMatchObject({ bank: 'community', bankId: 'GV.OC-01', tailored: true, modified: true });
+  });
+
+  test('no source + bank-covered item: synthesizes resolvable community provenance', () => {
+    const src = tailoredProvenance(undefined, 'PR.AA-01 Ex2');
+    expect(src.bank).toBe('community');
+    expect(src.bankId).toBe('PR.AA-01');
+    expect(src.tailored).toBe(true);
+  });
+
+  test('no source + no bank coverage: bank:"none" marker, still tailored', () => {
+    const src = tailoredProvenance(undefined, 'CTRL-042');
+    expect(src.bank).toBe('none');
+    expect(src.bankId).toBeNull();
+    expect(src.tailored).toBe(true);
+  });
+});
+
+describe('cloud consent gate', () => {
+  test('local Ollama needs no consent; cloud Claude requires the explicit opt-in', () => {
+    expect(canUseProfileWithProvider('ollama', false)).toBe(true);
+    expect(canUseProfileWithProvider('claude', false)).toBe(false);
+    expect(canUseProfileWithProvider('claude', true)).toBe(true);
+  });
+});
+
+describe('deterministic tailoring', () => {
+  test('substitutes the org name for Alma Security and flags the result tailored', () => {
+    const { text, tailored } = tailorMarkdown(
+      "Review Alma Security's mission. Confirm Alma leadership sign-off.",
+      { orgName: CANARY_ORG }
+    );
+    expect(tailored).toBe(true);
+    expect(text).toContain(CANARY_ORG);
+    expect(text).not.toMatch(/\bAlma\b/);
+  });
+
+  test('no org name → text unchanged, not tailored', () => {
+    const { text, tailored } = tailorMarkdown('Review Alma Security policy.', { orgName: '  ' });
+    expect(tailored).toBe(false);
+    expect(text).toBe('Review Alma Security policy.');
+  });
+});

--- a/src/utils/procedureTailor.js
+++ b/src/utils/procedureTailor.js
@@ -1,0 +1,94 @@
+/**
+ * Tailoring of community test procedures to an organization profile.
+ *
+ * Two tiers:
+ *  - Deterministic (no AI): substitute the org's name for the fictional
+ *    "Alma Security" the catalog is written against.
+ *  - AI (optional): rewrite an attached procedure with profile context via
+ *    the configured provider. Cloud providers require explicit consent
+ *    (orgProfileStore.cloudConsent) — the profile never leaves the machine
+ *    without it. Local Ollama needs no consent.
+ *
+ * Any tailored output carries procedureSource.tailored = true so share
+ * export can swap it back to the pristine community version (the profile
+ * must not leak through derived procedure text — see PRIVATE_DATA.md).
+ */
+
+import { getBankProcedure, buildProcedureSource } from './procedureBank';
+
+/**
+ * Provenance for AI-tailored output. ALWAYS returns a tailored-marked source:
+ * a tailored procedure without provenance would bypass the share-export
+ * pristine swap and leak profile-derived text — the exact hole this closes.
+ * With no prior source, synthesize community provenance when the item has
+ * bank coverage (share export then swaps to the pristine text); otherwise a
+ * bank:"none" marker whose unresolvable bankId makes the swap drop the text
+ * entirely rather than leak it.
+ */
+export const tailoredProvenance = (existingSource, itemId) => {
+  if (existingSource) return { ...existingSource, tailored: true, modified: true };
+  const bankEntry = getBankProcedure(itemId);
+  if (bankEntry) {
+    return { ...buildProcedureSource(bankEntry.bankId), tailored: true, modified: true };
+  }
+  return {
+    bank: 'none',
+    bankId: null,
+    bankVersion: null,
+    attachedAt: new Date().toISOString(),
+    tailored: true,
+    modified: true
+  };
+};
+
+/** Deterministic substitution. Returns { text, tailored }. */
+export const tailorMarkdown = (markdown, profile) => {
+  const orgName = profile?.orgName?.trim();
+  if (!orgName || !markdown) return { text: markdown, tailored: false };
+  const text = markdown
+    .replace(/Alma Security/g, orgName)
+    .replace(/\bAlma's\b/g, `${orgName}'s`)
+    .replace(/\bAlma\b/g, orgName);
+  return { text, tailored: text !== markdown };
+};
+
+/**
+ * Consent gate: may profile text be sent to this provider?
+ * Ollama runs locally — always allowed. Claude is a cloud egress — requires
+ * the explicit stored opt-in.
+ */
+export const canUseProfileWithProvider = (provider, cloudConsent) =>
+  provider === 'ollama' || !!cloudConsent;
+
+/** Profile summary block shared by AI prompts (only called post-consent-gate). */
+const profileContext = (profile) => {
+  const lines = [];
+  if (profile.orgName?.trim()) lines.push(`Organization: ${profile.orgName.trim()}`);
+  if (profile.industry?.trim()) lines.push(`Industry: ${profile.industry.trim()}`);
+  if (profile.sizeBand?.trim()) lines.push(`Size: ${profile.sizeBand.trim()} people`);
+  if (profile.infrastructure?.length) lines.push(`Key IT infrastructure: ${profile.infrastructure.join(', ')}`);
+  if (profile.securityTools?.length) lines.push(`Security tools in use: ${profile.securityTools.join(', ')}`);
+  if (profile.crownJewels?.length) lines.push(`Highest-value assets (crown jewels): ${profile.crownJewels.join(', ')}`);
+  if (profile.notes?.trim()) lines.push(`Notes: ${profile.notes.trim()}`);
+  return lines.join('\n');
+};
+
+/**
+ * AI-tailoring prompt: constrained editing of an existing good procedure,
+ * not from-scratch generation. Structure preserved (SP 800-53A methods:
+ * examine / interview / test), specifics re-aimed at the org's stack.
+ */
+export const buildTailorPrompt = (procedureMarkdown, profile) => `You are tailoring an existing NIST CSF 2.0 test procedure to a specific organization. Rewrite it so an auditor at THIS organization can follow it directly.
+
+ORGANIZATION PROFILE:
+${profileContext(profile)}
+
+RULES:
+- Keep the same structure and markdown formatting (headings, numbered steps, pass/fail criteria, evidence requests).
+- Keep every test's intent; change examples, system names, and evidence sources to match the organization's stated infrastructure and tools.
+- Reference the organization's crown jewels where data-protection steps apply.
+- Do not invent findings or scores. Do not drop pass/fail criteria or interview questions.
+- Output only the rewritten procedure markdown.
+
+PROCEDURE TO TAILOR:
+${procedureMarkdown}`;


### PR DESCRIPTION
Optional 5-question org profile (every question skippable) powering deterministic org-name substitution + per-item AI tailoring (SP 800-53A structure preserved). Privacy: profile UNCONDITIONALLY excluded from share exports; derived leak closed — tailored procedures swap back to pristine community text via provenance; cloud (Claude) tailoring hard-gated on explicit consent, local Ollama free; export format 3→4 with compat + rollback. Leak tests assert the DERIVED case (crown-jewel canaries). 225/225 tests.