### PR TITLE
Fix #276: render GFM markdown tables (add remark-gfm)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-router-dom": "^6.30.4",
         "react-scripts": "5.0.1",
         "recharts": "^2.15.3",
+        "remark-gfm": "^4.0.1",
         "uuid": "^13.0.0",
         "web-vitals": "^2.1.4",
         "zod": "^4.3.6",
@@ -12220,6 +12221,16 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -12227,6 +12238,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -12247,6 +12286,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -12509,6 +12649,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -15998,6 +16259,24 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -16025,6 +16304,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-router-dom": "^6.30.4",
     "react-scripts": "5.0.1",
     "recharts": "^2.15.3",
+    "remark-gfm": "^4.0.1",
     "uuid": "^13.0.0",
     "web-vitals": "^2.1.4",
     "zod": "^4.3.6",

--- a/scripts/verify-markdown-tables.mjs
+++ b/scripts/verify-markdown-tables.mjs
@@ -1,0 +1,64 @@
+// End-to-end proof for issue #276: the shared Markdown wrapper's plugin config
+// (react-markdown + remark-gfm) turns a GFM pipe table into a real <table>,
+// AND enabling gfm on every render site does not regress non-table content.
+//
+// Jest cannot import this ESM chain in CRA (see src/components/Markdown.test.js),
+// so this standalone Node script renders the REAL library output and asserts:
+//   1. a GFM table becomes a real <table> with <th>/<td>
+//   2. bare react-markdown produces NO table (the plugin is what fixes it)
+//   3. non-table content is unaffected or correctly upgraded (blast-radius check)
+//
+// Run: node scripts/verify-markdown-tables.mjs   (exit 0 = pass, 1 = fail)
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+const render = (md, gfm) =>
+  renderToStaticMarkup(
+    React.createElement(ReactMarkdown, gfm ? { remarkPlugins: [remarkGfm] } : null, md)
+  );
+
+const TABLE_MD = [
+  '| Indicator | Source | Frequency |',
+  '|-----------|--------|-----------|',
+  '| Time to Detect (TTD) | SOC metrics dashboard | Monthly |',
+  '| GuardDuty finding volume | AWS Security Hub | Daily |',
+].join('\n');
+
+const withGfmTable = render(TABLE_MD, true);
+const withoutGfmTable = render(TABLE_MD, false);
+
+// Blast-radius: what changes for non-table content when gfm is enabled everywhere.
+const PROSE = '# Title\n\nSome **bold** and a bullet:\n\n- one\n- two';
+const STRAY_PIPE = 'Throughput is 10 | 20 depending on region.';
+const TASK_LIST = '## Evidence\n\n- [ ] CloudTrail export\n- [x] GuardDuty screenshot';
+const BARE_URL = 'See https://example.com/policy for details.';
+
+const checks = [
+  // The fix
+  ['gfm renders a <table> element', /<table>/.test(withGfmTable)],
+  ['gfm renders <th> header cells', /<th>Indicator<\/th>/.test(withGfmTable)],
+  ['gfm renders cell text inside <td>', /<td>Time to Detect \(TTD\)<\/td>/.test(withGfmTable)],
+  ['bare react-markdown produces NO table (proves the plugin is the fix)', !/<table>/.test(withoutGfmTable)],
+  // No regression to the common case
+  ['plain prose is byte-identical with/without gfm', render(PROSE, true) === render(PROSE, false)],
+  ['a stray pipe (no delimiter row) does NOT become a table', render(STRAY_PIPE, true) === render(STRAY_PIPE, false) && !/<table>/.test(render(STRAY_PIPE, true))],
+  // Intended gfm upgrades (correct behavior, not breakage)
+  ['task-list "- [ ]" becomes a clean disabled checkbox', /<input type="checkbox" disabled=""\/>/.test(render(TASK_LIST, true))],
+  ['task-list stays inside a <ul> (no layout break)', /<ul class="contains-task-list">/.test(render(TASK_LIST, true))],
+  ['bare URL becomes a clickable link', /<a href="https:\/\/example\.com\/policy">/.test(render(BARE_URL, true))],
+];
+
+let ok = true;
+for (const [label, pass] of checks) {
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${label}`);
+  if (!pass) ok = false;
+}
+
+if (!ok) {
+  console.error('\nissue #276 verification FAILED');
+  process.exit(1);
+}
+console.log('\nissue #276 verification PASSED — tables render; non-table content is unaffected or correctly upgraded.');

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,7 +2,12 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { act } from 'react';
 import App from './App';
 
-// Mock react-markdown to avoid ES module issues in Jest
+// Mock react-markdown to avoid ES module issues in Jest.
+// Note: remark-gfm (used by src/components/Markdown.js) is NOT mocked here only
+// because the pages that import Markdown are React.lazy-loaded and this test
+// never navigates to their routes. A future eager import, or a test that visits
+// /findings, /controls, etc., would load real remark-gfm ESM and must mock it
+// too (same reason this mocks react-markdown).
 jest.mock('react-markdown', () => {
   return function ReactMarkdown({ children }) {
     return <div>{children}</div>;

--- a/src/components/Markdown.js
+++ b/src/components/Markdown.js
@@ -1,0 +1,25 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+// Single source of truth for rendering markdown across the app.
+//
+// react-markdown is CommonMark-only, which does NOT include GitHub Flavored
+// Markdown tables. Without the remark-gfm plugin, a multi-line pipe table
+// collapses into one soft-wrapped paragraph (issue #276). Routing every
+// <ReactMarkdown> through this wrapper enables GFM (tables, strikethrough,
+// task lists, autolinks) everywhere and prevents the plugin from being
+// forgotten at a future render site.
+//
+// The rendered <table>/<th>/<td> inherit the app's global terminal table
+// styles from index.css — no per-site table CSS is needed.
+
+// gfm is prepended (not spread-overridable) so a caller passing its own
+// remarkPlugins augments rather than silently drops it — otherwise a future
+// `<Markdown remarkPlugins={[remarkBreaks]}>` would reintroduce issue #276.
+const Markdown = ({ children, remarkPlugins = [], ...props }) => (
+  <ReactMarkdown remarkPlugins={[remarkGfm, ...remarkPlugins]} {...props}>
+    {children}
+  </ReactMarkdown>
+);
+
+export default Markdown;

--- a/src/components/Markdown.test.js
+++ b/src/components/Markdown.test.js
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import remarkGfm from 'remark-gfm';
+import Markdown from './Markdown';
+
+// Regression guard for issue #276: GFM tables render as real tables only when
+// the remark-gfm plugin is wired into react-markdown. Bare react-markdown is
+// CommonMark-only and collapses a multi-line pipe table into one paragraph.
+//
+// react-markdown and remark-gfm are ESM and are not transformed by CRA's Jest
+// (the repo already mocks react-markdown in App.test.js for this reason). So
+// this suite mocks both and asserts the WIRING — the shared wrapper must pass
+// the remark-gfm plugin into react-markdown's remarkPlugins and forward
+// children/props unchanged. If the plugin is ever dropped, this goes red.
+//
+// The real end-to-end proof (an actual <table> in rendered HTML) lives in
+// scripts/verify-markdown-tables.mjs and the live app; webpack transforms the
+// ESM chain that Jest cannot.
+
+jest.mock('remark-gfm', () => ({
+  __esModule: true,
+  default: { _mock: 'remark-gfm-plugin' },
+}));
+
+// Capture the props react-markdown receives from the wrapper.
+let received = null;
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: (props) => {
+    received = props;
+    return <div data-testid="rm">{props.children}</div>;
+  },
+}));
+
+beforeEach(() => {
+  received = null;
+});
+
+describe('Markdown wrapper (issue #276 — GFM tables)', () => {
+  test('passes the remark-gfm plugin into react-markdown remarkPlugins', () => {
+    render(<Markdown>{'| a | b |\n|---|---|\n| 1 | 2 |'}</Markdown>);
+    expect(Array.isArray(received.remarkPlugins)).toBe(true);
+    // The exact plugin the wrapper imports is the (mocked) remark-gfm default.
+    expect(received.remarkPlugins).toContain(remarkGfm);
+  });
+
+  test('forwards children to react-markdown unchanged', () => {
+    render(<Markdown>{'hello **world**'}</Markdown>);
+    // The child string reaches react-markdown untransformed (rendered as-is).
+    expect(screen.getByTestId('rm')).toHaveTextContent('hello **world**');
+  });
+
+  test('forwards arbitrary props (e.g. className, components) unchanged', () => {
+    const components = { a: () => null };
+    render(
+      <Markdown className="prose" components={components}>
+        {'x'}
+      </Markdown>
+    );
+    expect(received.className).toBe('prose');
+    expect(received.components).toBe(components);
+    // caller props must not clobber the gfm plugin
+    expect(received.remarkPlugins).toContain(remarkGfm);
+  });
+
+  test('a caller-supplied remarkPlugins augments gfm, never replaces it', () => {
+    const extra = () => {};
+    render(<Markdown remarkPlugins={[extra]}>{'x'}</Markdown>);
+    // gfm stays wired AND the caller's plugin is added (issue #276 can't regress).
+    expect(received.remarkPlugins).toContain(remarkGfm);
+    expect(received.remarkPlugins).toContain(extra);
+  });
+});

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -7,7 +7,7 @@ import {
 } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
 import toast from 'react-hot-toast';
-import ReactMarkdown from 'react-markdown';
+import Markdown from '../components/Markdown';
 
 // Components
 import FrameworkBadge from '../components/FrameworkBadge';
@@ -1511,11 +1511,11 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                       <div className="prose prose-sm max-w-none text-gray-700 dark:text-gray-300">
                         {/* Bank-attached procedures are real markdown — render as-is;
                             the reformat helper is only for legacy free-text blobs. */}
-                        <ReactMarkdown>
+                        <Markdown>
                           {(currentObservation.procedureSource
                             ? currentObservation.testProcedures
                             : formatTestProcedures(currentObservation.testProcedures)) || 'No test procedures defined'}
-                        </ReactMarkdown>
+                        </Markdown>
                       </div>
                     )}
                   </div>
@@ -1678,7 +1678,7 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                       />
                     ) : (
                       <div className="prose prose-sm max-w-none text-sm text-gray-700 dark:text-gray-300 max-h-48 overflow-auto">
-                        <ReactMarkdown>{formatInlineMarkdown(currentObservation.quarters?.[selectedQuarter]?.observations) || 'None'}</ReactMarkdown>
+                        <Markdown>{formatInlineMarkdown(currentObservation.quarters?.[selectedQuarter]?.observations) || 'None'}</Markdown>
                       </div>
                     )}
                   </div>

--- a/src/pages/Controls.js
+++ b/src/pages/Controls.js
@@ -5,7 +5,7 @@ import {
   Calendar
 } from 'lucide-react';
 import toast from 'react-hot-toast';
-import ReactMarkdown from 'react-markdown';
+import Markdown from '../components/Markdown';
 
 // Components
 import UserSelector from '../components/UserSelector';
@@ -528,9 +528,9 @@ const Controls = () => {
                         />
                       ) : (
                         <div className="mt-1 prose prose-sm max-w-none">
-                          <ReactMarkdown>
+                          <Markdown>
                             {currentItem['Implementation Description'] || 'No implementation description'}
-                          </ReactMarkdown>
+                          </Markdown>
                         </div>
                       )}
                     </div>
@@ -683,9 +683,9 @@ const Controls = () => {
                         />
                       ) : (
                         <div className="mt-1 prose prose-sm max-w-none">
-                          <ReactMarkdown>
+                          <Markdown>
                             {getQuarterData(currentItem.ID, selectedQuarter)?.observations || 'No observations documented'}
-                          </ReactMarkdown>
+                          </Markdown>
                         </div>
                       )}
                     </div>
@@ -761,9 +761,9 @@ const Controls = () => {
                         />
                       ) : (
                         <div className="mt-1 prose prose-sm max-w-none">
-                          <ReactMarkdown>
+                          <Markdown>
                             {currentItem['Action Plan'] || 'No action plan documented'}
-                          </ReactMarkdown>
+                          </Markdown>
                         </div>
                       )}
                     </div>

--- a/src/pages/Findings.js
+++ b/src/pages/Findings.js
@@ -8,7 +8,7 @@ import useControlsStore from '../stores/controlsStore';
 import useRequirementsStore from '../stores/requirementsStore';
 import useSort from '../hooks/useSort';
 import EmptyState from '../components/EmptyState';
-import ReactMarkdown from 'react-markdown';
+import Markdown from '../components/Markdown';
 import { formatInlineMarkdown } from '../utils/markdownText';
 
 const Findings = () => {
@@ -612,7 +612,7 @@ const Findings = () => {
                   />
                 ) : (
                   <div className="prose prose-sm max-w-none text-sm text-gray-700 dark:text-gray-300">
-                    <ReactMarkdown>{formatInlineMarkdown(selectedFinding?.description) || 'No description provided.'}</ReactMarkdown>
+                    <Markdown>{formatInlineMarkdown(selectedFinding?.description) || 'No description provided.'}</Markdown>
                   </div>
                 )}
               </div>
@@ -634,7 +634,7 @@ const Findings = () => {
                   />
                 ) : (
                   <div className="prose prose-sm max-w-none text-sm text-gray-700 dark:text-gray-300">
-                    <ReactMarkdown>{formatInlineMarkdown(selectedFinding?.rootCause) || 'No root cause documented.'}</ReactMarkdown>
+                    <Markdown>{formatInlineMarkdown(selectedFinding?.rootCause) || 'No root cause documented.'}</Markdown>
                   </div>
                 )}
               </div>
@@ -656,7 +656,7 @@ const Findings = () => {
                   />
                 ) : (
                   <div className="prose prose-sm max-w-none text-sm text-gray-700 dark:text-gray-300">
-                    <ReactMarkdown>{formatInlineMarkdown(selectedFinding?.remediationActionPlan) || 'No remediation plan documented.'}</ReactMarkdown>
+                    <Markdown>{formatInlineMarkdown(selectedFinding?.remediationActionPlan) || 'No remediation plan documented.'}</Markdown>
                   </div>
                 )}
               </div>

--- a/src/pages/UserControls.js
+++ b/src/pages/UserControls.js
@@ -5,7 +5,7 @@ import {
   Upload, Download, Users, User, ChevronRight
 } from 'lucide-react';
 import toast from 'react-hot-toast';
-import ReactMarkdown from 'react-markdown';
+import Markdown from '../components/Markdown';
 
 // Components
 import FrameworkBadge from '../components/FrameworkBadge';
@@ -829,9 +829,9 @@ const UserControls = () => {
                         />
                       ) : (
                         <div className="mt-1 prose prose-sm max-w-none">
-                          <ReactMarkdown>
+                          <Markdown>
                             {currentControl.implementationDescription || 'No description'}
-                          </ReactMarkdown>
+                          </Markdown>
                         </div>
                       )}
                     </div>


### PR DESCRIPTION
Markdown tables in test procedures, observations, findings, and control descriptions rendered as one mashed paragraph. Root cause was not the data (every table is correctly newline-formatted) but the renderer: react-markdown is CommonMark-only, so GFM pipe tables collapsed into a soft-wrapped paragraph.

- Add remark-gfm@^4 (compatible with react-markdown@10).
- New shared src/components/Markdown.js wrapper enables GFM once for the whole app; gfm is prepended so a caller's remarkPlugins augments, never replaces it.
- Route all 9 <ReactMarkdown> usages (Assessments, Findings, UserControls, Controls) through the wrapper; only the wrapper imports react-markdown.
- Rendered <table>/<th>/<td> inherit the existing global terminal table styles.
- Tests: jest wiring guard (CRA jest can't transform the ESM chain, so it mocks and asserts the plugin is wired + augment-not-replace) plus a standalone scripts/verify-markdown-tables.mjs that renders the real library and proves tables appear while non-table content is unaffected or correctly upgraded (plain prose byte-identical, stray pipes stay prose, task-lists -> checkboxes, URLs -> links).

No source data or ASSESSMENT_CATALOG files changed.