### PR TITLE
Fix #279: define .fixed/.inset-0 so modal overlays position correctly

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -265,6 +265,7 @@ code {
 
 .max-w-xs { max-width: 20rem; }
 .max-w-md { max-width: 28rem; }
+.max-w-lg { max-width: 32rem; }
 .max-w-2xl { max-width: 42rem; }
 .max-w-3xl { max-width: 48rem; }
 .max-w-4xl { max-width: 56rem; }
@@ -386,6 +387,15 @@ code {
 .bg-gray-200 { background-color: #e5e7eb; }
 .bg-gray-800 { background-color: #1f2937; }
 .bg-gray-900 { background-color: #111827; }
+/* bg-black reads an alpha var so bg-opacity-* can dim it (Tailwind semantics). */
+.bg-black { --tw-bg-opacity: 1; background-color: rgb(0 0 0 / var(--tw-bg-opacity)); }
+.bg-black\/50 { background-color: rgba(0, 0, 0, 0.5); }
+.bg-black\/10 { background-color: rgba(0, 0, 0, 0.1); }
+/* Color-agnostic alpha modifier: only affects backgrounds that read
+   --tw-bg-opacity (i.e. .bg-black). It never forces black onto other bg colors,
+   so a future `bg-white bg-opacity-50` stays white. Modal backdrops use
+   `bg-black bg-opacity-50`. */
+.bg-opacity-50 { --tw-bg-opacity: 0.5; }
 
 /* Background colors — semantic (reds/oranges/yellows/ambers/greens pass through) */
 .bg-red-50 { background-color: #fef2f2; }
@@ -504,6 +514,7 @@ code {
    10. Positioning
    ========================================================================== */
 
+.fixed { position: fixed; }
 .relative { position: relative; }
 .absolute { position: absolute; }
 .sticky { position: sticky; }
@@ -511,7 +522,9 @@ code {
 .-top-1 { top: -0.25rem; }
 .-right-1 { right: -0.25rem; }
 .left-0 { left: 0; }
+.bottom-0 { bottom: 0; }
 .inset-y-0 { top: 0; bottom: 0; }
+.inset-0 { top: 0; right: 0; bottom: 0; left: 0; }
 .z-20 { z-index: 20; }
 .z-30 { z-index: 30; }
 .z-40 { z-index: 40; }

--- a/src/index.overlays.test.js
+++ b/src/index.overlays.test.js
@@ -1,0 +1,65 @@
+/**
+ * Regression guard for issue #279.
+ *
+ * The app has no Tailwind build — src/index.css is a hand-written utility
+ * subset. Modal/overlay components use `className="fixed inset-0 ... z-50"`,
+ * but `.fixed` and `.inset-0` were never defined, so every overlay rendered
+ * `position: static` (in document flow) and the "Set up org profile" wizard
+ * opened off-screen. These assertions fail if the position/overlay utilities
+ * the modals depend on are removed or altered.
+ *
+ * jsdom does not apply CSS, so this guards the stylesheet source directly.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const css = fs.readFileSync(path.join(__dirname, 'index.css'), 'utf8');
+
+// collapse whitespace so `.x {\n position: fixed;\n}` matches a simple regex
+const flat = css.replace(/\s+/g, ' ');
+
+const hasRule = (selector, ...decls) => {
+  // selector may contain an escaped slash (e.g. .bg-black\/50)
+  const sel = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = flat.match(new RegExp(sel + '\\s*\\{([^}]*)\\}'));
+  if (!m) return false;
+  return decls.every((d) => m[1].includes(d));
+};
+
+describe('index.css overlay/position utilities (issue #279)', () => {
+  test('.fixed sets position: fixed', () => {
+    expect(hasRule('.fixed', 'position: fixed')).toBe(true);
+  });
+
+  test('.inset-0 pins all four edges to 0', () => {
+    expect(hasRule('.inset-0', 'top: 0', 'right: 0', 'bottom: 0', 'left: 0')).toBe(true);
+  });
+
+  test('.bottom-0 sets bottom: 0', () => {
+    expect(hasRule('.bottom-0', 'bottom: 0')).toBe(true);
+  });
+
+  test('.max-w-lg constrains the dialog card width', () => {
+    expect(hasRule('.max-w-lg', 'max-width: 32rem')).toBe(true);
+  });
+
+  test('modal backdrops dim: bg-black/50 is semi-transparent black', () => {
+    expect(hasRule('.bg-black\\/50', 'rgba(0, 0, 0, 0.5)')).toBe(true);
+  });
+
+  test('bg-opacity-50 is a color-agnostic alpha modifier, not hardcoded black', () => {
+    // it must dim bg-black (which reads the var) without forcing black on other colors
+    expect(hasRule('.bg-opacity-50', '--tw-bg-opacity: 0.5')).toBe(true);
+    expect(hasRule('.bg-black', 'var(--tw-bg-opacity)')).toBe(true);
+    // regression: it must NOT hardcode a black background-color
+    const flatOpacity = flat.match(/\.bg-opacity-50\s*\{([^}]*)\}/);
+    expect(flatOpacity && /background-color/.test(flatOpacity[1])).toBeFalsy();
+  });
+
+  test('every "fixed inset-0" overlay class the components use is now defined', () => {
+    // if a component asks for these classes, index.css must define them
+    for (const sel of ['.fixed', '.inset-0']) {
+      expect(flat).toMatch(new RegExp(sel.replace('.', '\\.') + '\\s*\\{'));
+    }
+  });
+});


### PR DESCRIPTION
The "Set up org profile" button appeared to do nothing. Root cause was not the button (its onClick, state, and render gate are all correct, and the wizard does mount) — the app has no Tailwind build and src/index.css never defined `.fixed` or `.inset-0`, so every `fixed inset-0` overlay computed `position: static` and rendered in document flow. The org-profile wizard opened ~1300px below the viewport, behind the (also in-flow) New Assessment modal, so nothing appeared.

CSS-only fix in src/index.css:
- .fixed { position: fixed; }  .inset-0 { top/right/bottom/left: 0 }  .bottom-0
- .max-w-lg { max-width: 32rem } so dialog cards are constrained, not full-width
- modal-backdrop dim: .bg-black reads --tw-bg-opacity; .bg-opacity-50 sets it to 0.5 (color-agnostic, never forces black on other bgs); .bg-black/50, .bg-black/10

This repairs every `fixed inset-0` overlay app-wide (New Assessment modal, Settings dialogs, ExportPasswordDialog, dropdowns, toolbars), not just the org wizard. Verified live: the wizard now opens as a centered dialog with a dark backdrop on top; New Assessment modal, DropdownPortal, and base views render correctly with no lingering overlay. Added src/index.overlays.test.js guarding the utilities. No component JS changed.