### PR TITLE
Fix Assessments New-Assessment modal: define max-h-* so the card caps at 90vh

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -270,7 +270,21 @@ code {
 .max-w-3xl { max-width: 48rem; }
 .max-w-4xl { max-width: 56rem; }
 .max-w-none { max-width: none; }
+/* max-height scale (Tailwind spacing: N x 0.25rem). No Tailwind build here, so
+   every utility the JSX uses must be defined by hand — an undefined one computes
+   to `max-height: none`, letting a modal/panel grow past its intended cap. */
+.max-h-40 { max-height: 10rem; }
+.max-h-48 { max-height: 12rem; }
+.max-h-56 { max-height: 14rem; }
 .max-h-60 { max-height: 15rem; }
+.max-h-64 { max-height: 16rem; }
+.max-h-72 { max-height: 18rem; }
+.max-h-80 { max-height: 20rem; }
+/* Arbitrary-value utility on modal dialog cards. Without this the card grows to
+   its full content height; the overlay's `items-center` then centers it and
+   pushes the header/footer off-screen (unreachable, page won't scroll). Capping
+   at 90vh activates the card's existing `flex-1 overflow-auto` body region. */
+.max-h-\[90vh\] { max-height: 90vh; }
 
 /* ==========================================================================
    6. Typography

--- a/src/index.overlays.test.js
+++ b/src/index.overlays.test.js
@@ -63,3 +63,64 @@ describe('index.css overlay/position utilities (issue #279)', () => {
     }
   });
 });
+
+/**
+ * Regression guard for the New Assessment modal scroll bug.
+ *
+ * The modal card is `max-h-[90vh] flex flex-col` with a fixed header, a
+ * `flex-1 overflow-auto` body, and a fixed footer. `.max-h-[90vh]` was never
+ * defined in the hand-written CSS, so the card's max-height computed to `none`,
+ * it grew to full content height, the overlay's `items-center` centered it, and
+ * the header + footer scrolled off-screen with no way to reach them. These
+ * assertions fail if the height-cap utilities the modals/panels depend on are
+ * removed. Values follow the Tailwind spacing scale (N x 0.25rem).
+ */
+describe('index.css max-height utilities (Assessments modal scroll)', () => {
+  test('.max-h-[90vh] caps the modal dialog card at 90% of the viewport', () => {
+    expect(hasRule('.max-h-\\[90vh\\]', 'max-height: 90vh')).toBe(true);
+  });
+
+  const scale = {
+    '.max-h-40': '10rem',
+    '.max-h-48': '12rem',
+    '.max-h-56': '14rem',
+    '.max-h-60': '15rem',
+    '.max-h-64': '16rem',
+    '.max-h-72': '18rem',
+    '.max-h-80': '20rem',
+  };
+
+  test.each(Object.entries(scale))('%s is defined as %s', (sel, value) => {
+    expect(hasRule(sel, `max-height: ${value}`)).toBe(true);
+  });
+
+  test('no max-h-* class used in JSX is left undefined in index.css', () => {
+    const srcDir = __dirname;
+    const files = [];
+    const walk = (dir) => {
+      for (const name of fs.readdirSync(dir)) {
+        const p = path.join(dir, name);
+        const stat = fs.statSync(p);
+        if (stat.isDirectory()) walk(p);
+        else if (/\.(js|jsx)$/.test(name) && !/\.test\.js$/.test(name)) {
+          files.push(fs.readFileSync(p, 'utf8'));
+        }
+      }
+    };
+    walk(srcDir);
+    const used = new Set();
+    for (const content of files) {
+      for (const m of content.matchAll(/\bmax-h-(?:\[[^\]]+\]|[a-z0-9]+)/g)) {
+        used.add(m[0]);
+      }
+    }
+    // CSS escapes brackets in selectors (`.max-h-\[90vh\]`); the JSX class is
+    // raw (`max-h-[90vh]`). Strip the CSS escaping so a raw-class regex matches.
+    const flatNoEsc = flat.replace(/\\/g, '');
+    const missing = [...used].filter((cls) => {
+      const sel = '.' + cls.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      return !new RegExp(sel + '\\s*\\{').test(flatNoEsc);
+    });
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
The New Assessment modal card is `max-h-[90vh] flex flex-col` with a fixed
header (name field), a `flex-1 overflow-auto` body (the requirement/scope
picker), and a fixed footer (Cancel/Skip/Next). The overlay centers the card
with `items-center`, so when the card is taller than the viewport its header and
footer render off-screen and neither the body nor the page scrolls to reach
them — you can't name the assessment or press Next.

Same inert-utility root cause as #279: the app has no Tailwind build, and
src/index.css (hand-written utility subset) never defined `.max-h-[90vh]` (nor
`.max-h-40/48/56/64/72/80`). The card's max-height computed to `none`, so it grew
to its full ~11000px content height. `.max-h-60` was the only max-h defined.

CSS-only fix in src/index.css — add the max-h-* scale (Tailwind N x 0.25rem) and
the arbitrary `.max-h-\[90vh\]`. Capping the card activates its already-correct
`flex-1 overflow-auto` body (overflow != visible zeroes the flex item's auto
min-size, so no min-h-0 needed). Repairs every consumer of these classes app-wide
(modal cards, dropdowns, scroll panels), not just this modal. No component JS
changed.

Verified live: card max-height resolves to 90vh (was none), header/footer both
in-viewport, body scrolls (scrollHeight > clientHeight). Extended
src/index.overlays.test.js (the #279 guard) with value assertions for each
max-h-* utility plus a check that no max-h-* class used in JSX is left undefined.
