### PR TITLE
Scoring granularity: quarter-point second dropdown + 5-point CMMI scale option (#277)

### DIFF
--- a/src/components/AIScoreSuggestion.js
+++ b/src/components/AIScoreSuggestion.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import useAIStore from '../stores/aiStore';
+import { snapScore, CMMI_LEVELS } from '../utils/scoringScale';
 
 /**
  * AIScoreSuggestion Component
@@ -17,7 +18,13 @@ import useAIStore from '../stores/aiStore';
  * />
  */
 
-const SCORING_REFERENCE = `
+const scoringReference = (maxScore) => maxScore === 5
+  ? `
+NIST CSF Assessment Scoring (0-5 CMMI-style maturity scale):
+${CMMI_LEVELS.map(l => `${l.level}: ${l.name} - ${l.description}`).join('\n')}
+Quarter-point scores (e.g. 3.25) indicate partial progress toward the next level.
+`
+  : `
 NIST CSF Assessment Scoring (0-10 scale):
 0-1: Not implemented - No evidence of implementation
 2-3: Initial - Ad-hoc, undocumented, reactive
@@ -25,6 +32,7 @@ NIST CSF Assessment Scoring (0-10 scale):
 6-7: Defined - Documented, implemented, minor gaps
 8-9: Managed - Consistently implemented, measured, improved
 10: Optimized - Best-in-class, continuous improvement, integrated
+Quarter-point scores (e.g. 7.25) are allowed.
 `;
 
 const AIScoreSuggestion = ({
@@ -34,6 +42,7 @@ const AIScoreSuggestion = ({
   currentScore,
   targetScore,
   testProcedures,
+  maxScore = 10,
   onAccept,
   onClose
 }) => {
@@ -49,7 +58,7 @@ const AIScoreSuggestion = ({
 
     const prompt = `You are a NIST CSF assessment expert. Analyze the following audit observation and suggest an appropriate score.
 
-${SCORING_REFERENCE}
+${scoringReference(maxScore)}
 
 CONTROL: ${controlId}
 ${controlDescription ? `DESCRIPTION: ${controlDescription}` : ''}
@@ -63,11 +72,11 @@ TARGET SCORE: ${targetScore || 'Not set'}
 
 Based on the observation text and NIST CSF scoring criteria, provide:
 
-1. **Suggested Score**: [0-10]
+1. **Suggested Score**: [0-${maxScore}, quarter points allowed]
 2. **Confidence**: [High/Medium/Low]
 3. **Rationale**: 2-3 sentences explaining why this score is appropriate
 4. **Gaps Identified**: Bullet points of what's preventing a higher score
-5. **To Improve**: Specific actions to reach target score of ${targetScore || 8}
+5. **To Improve**: Specific actions to reach target score of ${targetScore || Math.round(maxScore * 0.8)}
 
 Be specific and reference the observation text in your rationale.`;
 
@@ -79,9 +88,10 @@ Be specific and reference the observation text in your rationale.`;
         response = await generateWithClaude(prompt, 1500);
       }
 
-      // Parse the response to extract score
-      const scoreMatch = response.match(/Suggested Score[:\s]*(\d+)/i);
-      const suggestedScore = scoreMatch ? parseInt(scoreMatch[1]) : null;
+      // Parse the response to extract score (decimals allowed), then snap
+      // to the nearest quarter point and clamp to the scale (issue #277)
+      const scoreMatch = response.match(/Suggested Score[:\s*]*\[?(\d+(?:\.\d+)?)/i);
+      const suggestedScore = scoreMatch ? snapScore(parseFloat(scoreMatch[1]), maxScore) : null;
 
       setSuggestion({
         text: response,

--- a/src/components/ScoreSelect.js
+++ b/src/components/ScoreSelect.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import {
+  QUARTER_FRACTIONS,
+  wholeScoreOptions,
+  composeScore,
+  decomposeScore,
+  snapScore
+} from '../utils/scoringScale';
+
+/**
+ * ScoreSelect — two-dropdown score entry with quarter-point precision
+ * (issue #277).
+ *
+ * The first dropdown selects the whole number (0..maxScore), the second
+ * selects the quarter fraction (.00 / .25 / .50 / .75). At the scale
+ * maximum the fraction locks to .00 so values above the maximum are
+ * impossible to enter.
+ *
+ * Props:
+ * - value:    current score (number; off-step legacy values display at
+ *             the nearest quarter and are only changed if the user edits)
+ * - onChange: called with the composed numeric score
+ * - maxScore: 10 (default) or 5, from the assessment's scoringScale
+ * - label:    accessible label prefix, e.g. "Actual Score"
+ * - className: optional class for each <select>
+ */
+const ScoreSelect = ({ value, onChange, maxScore = 10, label = 'Score', className = '' }) => {
+  // Clamp against the scale so an out-of-range import (e.g. an 8 in a
+  // 5-point assessment) displays at the scale max instead of rendering a
+  // blank controlled select. Storage is only changed if the user edits.
+  const { whole, fraction } = decomposeScore(snapScore(value, maxScore));
+  const atMax = whole >= maxScore;
+
+  const handleWholeChange = (e) => {
+    const nextWhole = Number(e.target.value);
+    // Fraction is forced to .00 when the whole hits the maximum.
+    const nextFraction = nextWhole >= maxScore ? 0 : fraction;
+    onChange(composeScore(nextWhole, nextFraction, maxScore));
+  };
+
+  const handleFractionChange = (e) => {
+    onChange(composeScore(whole, Number(e.target.value), maxScore));
+  };
+
+  const selectClass = className || 'p-1 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white';
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <select
+        value={whole}
+        onChange={handleWholeChange}
+        className={selectClass}
+        aria-label={`${label} whole number`}
+      >
+        {wholeScoreOptions(maxScore).map((s) => (
+          <option key={s} value={s}>{s}</option>
+        ))}
+      </select>
+      <select
+        value={atMax ? 0 : fraction}
+        onChange={handleFractionChange}
+        disabled={atMax}
+        className={`${selectClass} ${atMax ? 'opacity-50 cursor-not-allowed' : ''}`}
+        aria-label={`${label} quarter fraction`}
+        title={atMax ? `Fractions are not available at the maximum score of ${maxScore}` : 'Quarter-point fraction'}
+      >
+        {QUARTER_FRACTIONS.map((f) => (
+          <option key={f} value={f}>{f.toFixed(2).slice(1)}</option>
+        ))}
+      </select>
+    </span>
+  );
+};
+
+export default ScoreSelect;

--- a/src/components/ScoreSelect.test.js
+++ b/src/components/ScoreSelect.test.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ScoreSelect from './ScoreSelect';
+
+describe('ScoreSelect', () => {
+  it('renders two dropdowns: whole number and quarter fraction', () => {
+    render(<ScoreSelect value={7} onChange={() => {}} maxScore={10} label="Actual Score" />);
+    expect(screen.getByLabelText('Actual Score whole number')).toBeInTheDocument();
+    expect(screen.getByLabelText('Actual Score quarter fraction')).toBeInTheDocument();
+  });
+
+  it('offers 0..10 wholes and .00/.25/.50/.75 fractions on the 10-point scale', () => {
+    render(<ScoreSelect value={0} onChange={() => {}} maxScore={10} label="Score" />);
+    const whole = screen.getByLabelText('Score whole number');
+    const fraction = screen.getByLabelText('Score quarter fraction');
+    expect(Array.from(whole.options).map(o => o.value)).toEqual(
+      ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
+    );
+    expect(Array.from(fraction.options).map(o => o.text)).toEqual(['.00', '.25', '.50', '.75']);
+  });
+
+  it('offers 0..5 wholes on the 5-point scale', () => {
+    render(<ScoreSelect value={0} onChange={() => {}} maxScore={5} label="Score" />);
+    const whole = screen.getByLabelText('Score whole number');
+    expect(Array.from(whole.options).map(o => o.value)).toEqual(['0', '1', '2', '3', '4', '5']);
+  });
+
+  it('composes whole + fraction into the numeric score', () => {
+    const onChange = jest.fn();
+    render(<ScoreSelect value={7} onChange={onChange} maxScore={10} label="Score" />);
+    fireEvent.change(screen.getByLabelText('Score quarter fraction'), { target: { value: '0.25' } });
+    expect(onChange).toHaveBeenCalledWith(7.25);
+  });
+
+  it('preserves the fraction when the whole changes below max', () => {
+    const onChange = jest.fn();
+    render(<ScoreSelect value={7.25} onChange={onChange} maxScore={10} label="Score" />);
+    fireEvent.change(screen.getByLabelText('Score whole number'), { target: { value: '3' } });
+    expect(onChange).toHaveBeenCalledWith(3.25);
+  });
+
+  it('decomposes an existing half-point value into whole 7 + .50', () => {
+    render(<ScoreSelect value={7.5} onChange={() => {}} maxScore={10} label="Score" />);
+    expect(screen.getByLabelText('Score whole number').value).toBe('7');
+    expect(screen.getByLabelText('Score quarter fraction').value).toBe('0.5');
+  });
+
+  it('locks the fraction to .00 at the scale maximum', () => {
+    const onChange = jest.fn();
+    render(<ScoreSelect value={10} onChange={onChange} maxScore={10} label="Score" />);
+    const fraction = screen.getByLabelText('Score quarter fraction');
+    expect(fraction).toBeDisabled();
+    expect(fraction.value).toBe('0');
+  });
+
+  it('resets the fraction when the whole is raised to the maximum', () => {
+    const onChange = jest.fn();
+    render(<ScoreSelect value={9.75} onChange={onChange} maxScore={10} label="Score" />);
+    fireEvent.change(screen.getByLabelText('Score whole number'), { target: { value: '10' } });
+    expect(onChange).toHaveBeenCalledWith(10);
+  });
+
+  it('locks the fraction at the 5-point maximum too', () => {
+    render(<ScoreSelect value={5} onChange={() => {}} maxScore={5} label="Score" />);
+    expect(screen.getByLabelText('Score quarter fraction')).toBeDisabled();
+  });
+
+  it('can never produce a value above the maximum', () => {
+    const onChange = jest.fn();
+    // Legacy out-of-band value renders clamped for display purposes.
+    render(<ScoreSelect value={9.75} onChange={onChange} maxScore={10} label="Score" />);
+    fireEvent.change(screen.getByLabelText('Score quarter fraction'), { target: { value: '0.75' } });
+    expect(onChange).toHaveBeenCalledWith(9.75);
+    expect(onChange).not.toHaveBeenCalledWith(expect.any(Number) > 10);
+  });
+
+  it('clamps an out-of-range-for-scale value (8 in a 5-point assessment) to the scale max for display', () => {
+    const onChange = jest.fn();
+    render(<ScoreSelect value={8} onChange={onChange} maxScore={5} label="Score" />);
+    expect(screen.getByLabelText('Score whole number').value).toBe('5');
+    expect(screen.getByLabelText('Score quarter fraction')).toBeDisabled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('quarter points are selectable on the 5-point scale (4.75 works end-to-end)', () => {
+    const onChange = jest.fn();
+    render(<ScoreSelect value={4.5} onChange={onChange} maxScore={5} label="Score" />);
+    fireEvent.change(screen.getByLabelText('Score quarter fraction'), { target: { value: '0.75' } });
+    expect(onChange).toHaveBeenCalledWith(4.75);
+  });
+
+  it('displays off-step legacy values at the nearest quarter without writing', () => {
+    const onChange = jest.fn();
+    render(<ScoreSelect value={7.3} onChange={onChange} maxScore={10} label="Score" />);
+    expect(screen.getByLabelText('Score whole number').value).toBe('7');
+    expect(screen.getByLabelText('Score quarter fraction').value).toBe('0.25');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -17,6 +17,7 @@ import FindingSelector from '../components/FindingSelector';
 import SortableHeader from '../components/SortableHeader';
 import ExportPasswordDialog from '../components/ExportPasswordDialog';
 import EmptyState from '../components/EmptyState';
+import ScoreSelect from '../components/ScoreSelect';
 
 // Stores
 import useAssessmentsStore from '../stores/assessmentsStore';
@@ -28,6 +29,7 @@ import useUIStore from '../stores/uiStore';
 import { formatInlineMarkdown, stripMarkdown } from '../utils/markdownText';
 import { bankCoverage, getBankProcedure, buildProcedureSource, bankSourceUrl } from '../utils/procedureBank';
 import { tailorMarkdown, canUseProfileWithProvider, buildTailorPrompt, tailoredProvenance } from '../utils/procedureTailor';
+import { getScoringScale, scoreBand, CMMI_LEVELS } from '../utils/scoringScale';
 import useOrgProfileStore from '../stores/orgProfileStore';
 import OrgProfileWizard from '../components/OrgProfileWizard';
 
@@ -124,7 +126,8 @@ const Assessments = () => {
   const [newAssessment, setNewAssessment] = useState({
     name: '',
     description: '',
-    scopeType: 'requirements'
+    scopeType: 'requirements',
+    scoringScale: 10
   });
   const [selectedScopeItems, setSelectedScopeItems] = useState(new Set()); // Selected controls/requirements
   const [scopePreset, setScopePreset] = useState(null); // 'category' | 'subcategory' | 'all' | null (custom)
@@ -553,7 +556,7 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
   // Reset wizard state
   const resetWizard = useCallback(() => {
     setWizardStep(1);
-    setNewAssessment({ name: '', description: '', scopeType: 'requirements' });
+    setNewAssessment({ name: '', description: '', scopeType: 'requirements', scoringScale: 10 });
     setSelectedScopeItems(new Set());
     setScopePreset(null);
     setScopeFilterText('');
@@ -1317,11 +1320,12 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
     }
   };
 
-  // Get score badge style
+  // Get score badge style (thresholds proportional to the assessment's scale)
   const getScoreBadgeStyle = (score) => {
     if (!score || score === 0) return 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-300';
-    if (score >= 8) return 'bg-green-100 text-green-700 dark:bg-green-600 dark:text-white';
-    if (score >= 5) return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-600 dark:text-white';
+    const band = scoreBand(score, getScoringScale(currentAssessment));
+    if (band === 'green') return 'bg-green-100 text-green-700 dark:bg-green-600 dark:text-white';
+    if (band === 'yellow') return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-600 dark:text-white';
     return 'bg-red-100 text-red-700 dark:bg-red-600 dark:text-white';
   };
 
@@ -1630,15 +1634,12 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                   <div className="flex items-center justify-between">
                     <span className="text-sm text-gray-500 dark:text-gray-400">{selectedQuarter} Target Score</span>
                     {editMode ? (
-                      <select
+                      <ScoreSelect
                         value={currentObservation.quarters?.[selectedQuarter]?.targetScore || 0}
-                        onChange={(e) => handleQuarterlyChange('targetScore', Number(e.target.value))}
-                        className="w-16 p-1 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white"
-                      >
-                        {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(s => (
-                          <option key={s} value={s}>{s}</option>
-                        ))}
-                      </select>
+                        onChange={(score) => handleQuarterlyChange('targetScore', score)}
+                        maxScore={getScoringScale(currentAssessment)}
+                        label={`${selectedQuarter} Target Score`}
+                      />
                     ) : (
                       <span className="px-2 py-0.5 bg-gray-200 dark:bg-gray-700 rounded text-sm font-medium text-gray-700 dark:text-gray-300">
                         {currentObservation.quarters?.[selectedQuarter]?.targetScore || 0}
@@ -1650,15 +1651,12 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                   <div className="flex items-center justify-between">
                     <span className="text-sm text-gray-500 dark:text-gray-400">{selectedQuarter} Actual Score</span>
                     {editMode ? (
-                      <select
+                      <ScoreSelect
                         value={currentObservation.quarters?.[selectedQuarter]?.actualScore || 0}
-                        onChange={(e) => handleQuarterlyChange('actualScore', Number(e.target.value))}
-                        className="w-16 p-1 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white"
-                      >
-                        {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(s => (
-                          <option key={s} value={s}>{s}</option>
-                        ))}
-                      </select>
+                        onChange={(score) => handleQuarterlyChange('actualScore', score)}
+                        maxScore={getScoringScale(currentAssessment)}
+                        label={`${selectedQuarter} Actual Score`}
+                      />
                     ) : (
                       <span className={`px-2 py-0.5 rounded text-sm font-bold ${getScoreBadgeStyle(currentObservation.quarters?.[selectedQuarter]?.actualScore)}`}>
                         {currentObservation.quarters?.[selectedQuarter]?.actualScore || 0}
@@ -1968,6 +1966,46 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                       value={newAssessment.description}
                       onChange={(e) => setNewAssessment(prev => ({ ...prev, description: e.target.value }))}
                     />
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">Scoring Scale</label>
+                    <div className="space-y-2">
+                      <label className="flex items-center gap-2 p-3 border rounded cursor-pointer hover:bg-gray-50">
+                        <input
+                          type="radio"
+                          name="scoringScale"
+                          value="10"
+                          checked={newAssessment.scoringScale !== 5}
+                          onChange={() => setNewAssessment(prev => ({ ...prev, scoringScale: 10 }))}
+                        />
+                        <div>
+                          <span className="font-medium">10-point scale</span>
+                          <span className="text-green-600 ml-2">(Default)</span>
+                          <p className="text-xs text-gray-500">
+                            The Simply Cyber Academy scale (0&ndash;10). See the Scoring Legend page for band definitions.
+                          </p>
+                        </div>
+                      </label>
+                      <label className="flex items-center gap-2 p-3 border rounded cursor-pointer hover:bg-gray-50">
+                        <input
+                          type="radio"
+                          name="scoringScale"
+                          value="5"
+                          checked={newAssessment.scoringScale === 5}
+                          onChange={() => setNewAssessment(prev => ({ ...prev, scoringScale: 5 }))}
+                        />
+                        <div>
+                          <span className="font-medium">5-point maturity scale (CMMI-style)</span>
+                          <p className="text-xs text-gray-500">
+                            0&ndash;5 as in the NIST CSF Maturity Toolkit: {CMMI_LEVELS.map(l => `${l.level} ${l.name}`).join(' · ')}
+                          </p>
+                        </div>
+                      </label>
+                    </div>
+                    <p className="text-xs text-gray-500 mt-1">
+                      Both scales support quarter-point precision (e.g. 3.25). The scale is locked once the assessment is created.
+                    </p>
                   </div>
 
                   <div>

--- a/src/pages/Controls.js
+++ b/src/pages/Controls.js
@@ -12,6 +12,7 @@ import UserSelector from '../components/UserSelector';
 import ArtifactSelector from '../components/ArtifactSelector';
 import DropdownPortal from '../components/DropdownPortal';
 import SortableHeader from '../components/SortableHeader';
+import ScoreSelect from '../components/ScoreSelect';
 
 // Hooks and stores
 import { useCSFData } from '../hooks/useCSFData';
@@ -701,15 +702,15 @@ const Controls = () => {
                       <div className="flex-1">
                         <span className="text-sm font-medium text-gray-500">Actual Score:</span>
                         {editMode ? (
-                          <select
-                            value={getQuarterData(currentItem.ID, selectedQuarter)?.actualScore || 0}
-                            onChange={(e) => updateQuarterData(currentItem.ID, selectedQuarter, { actualScore: Number(e.target.value) })}
-                            className="mt-1 w-full p-2 border rounded text-sm"
-                          >
-                            {[0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9, 9.5, 10].map((score) => (
-                              <option key={score} value={score}>{score}</option>
-                            ))}
-                          </select>
+                          <div className="mt-1">
+                            <ScoreSelect
+                              value={getQuarterData(currentItem.ID, selectedQuarter)?.actualScore || 0}
+                              onChange={(score) => updateQuarterData(currentItem.ID, selectedQuarter, { actualScore: score })}
+                              maxScore={10}
+                              label="Actual Score"
+                              className="p-2 border rounded text-sm"
+                            />
+                          </div>
                         ) : (
                           <div className="mt-1 text-lg font-bold">
                             {getQuarterData(currentItem.ID, selectedQuarter)?.actualScore ?? 0}
@@ -720,15 +721,15 @@ const Controls = () => {
                       <div className="flex-1">
                         <span className="text-sm font-medium text-gray-500">Target Score:</span>
                         {editMode ? (
-                          <select
-                            value={getQuarterData(currentItem.ID, selectedQuarter)?.targetScore || 0}
-                            onChange={(e) => updateQuarterData(currentItem.ID, selectedQuarter, { targetScore: Number(e.target.value) })}
-                            className="mt-1 w-full p-2 border rounded text-sm"
-                          >
-                            {[0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9, 9.5, 10].map((score) => (
-                              <option key={score} value={score}>{score}</option>
-                            ))}
-                          </select>
+                          <div className="mt-1">
+                            <ScoreSelect
+                              value={getQuarterData(currentItem.ID, selectedQuarter)?.targetScore || 0}
+                              onChange={(score) => updateQuarterData(currentItem.ID, selectedQuarter, { targetScore: score })}
+                              maxScore={10}
+                              label="Target Score"
+                              className="p-2 border rounded text-sm"
+                            />
+                          </div>
                         ) : (
                           <div className="mt-1 text-lg font-bold">
                             {getQuarterData(currentItem.ID, selectedQuarter)?.targetScore ?? 0}

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -1,6 +1,7 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import { ClipboardList } from 'lucide-react';
 import EmptyState from '../components/EmptyState';
+import { getScoringScale } from '../utils/scoringScale';
 import {
   RadarChart,
   PolarGrid,
@@ -165,6 +166,9 @@ const Dashboard = () => {
     return assessments.find(a => a.id === selectedAssessmentId);
   }, [assessments, selectedAssessmentId]);
 
+  // Scoring scale of the selected assessment (10 default, 5 CMMI-style) — issue #277
+  const scoringScale = getScoringScale(selectedAssessment);
+
   // Chart colors based on theme
   const chartColors = {
     text: darkMode ? '#e5e7eb' : '#374151',
@@ -290,7 +294,7 @@ const Dashboard = () => {
 
   // Calculate bar chart data for functions (Actual + Gap to Target)
   const functionBarChartData = useMemo(() => {
-    if (!pivotTableData || pivotTableData.length === 0) return { data: [], maxTarget: 5 };
+    if (!pivotTableData || pivotTableData.length === 0) return { data: [], maxTarget: scoringScale / 2 };
 
     const quarterKey = `Q${selectedQuarter}`;
     const actualKey = `${quarterKey}Actual`;
@@ -312,8 +316,8 @@ const Dashboard = () => {
       };
     });
 
-    return { data: chartData, maxTarget: maxTarget || 5 };
-  }, [pivotTableData, selectedQuarter]);
+    return { data: chartData, maxTarget: maxTarget || scoringScale / 2 };
+  }, [pivotTableData, selectedQuarter, scoringScale]);
 
   // Calculate subcategory (Category ID) data for the selected quarter
   const subcategoryData = useMemo(() => {
@@ -724,7 +728,7 @@ const Dashboard = () => {
                       </td>
                       <td className="border border-gray-200 px-3 py-3 text-center">
                         {q1Variance !== null ? (
-                          <span className={`font-semibold ${q1Variance >= 0 ? 'text-green-600' : q1Variance >= -1 ? 'text-amber-600' : 'text-red-600'}`}>
+                          <span className={`font-semibold ${q1Variance >= 0 ? 'text-green-600' : q1Variance >= -1 * (scoringScale / 10) ? 'text-amber-600' : 'text-red-600'}`}>
                             {q1Variance >= 0 ? '+' : ''}{formatScore(q1Variance)}
                           </span>
                         ) : (
@@ -750,7 +754,7 @@ const Dashboard = () => {
                       </td>
                       <td className="border border-gray-200 px-3 py-3 text-center">
                         {q2Variance !== null ? (
-                          <span className={`font-semibold ${q2Variance >= 0 ? 'text-green-600' : q2Variance >= -1 ? 'text-amber-600' : 'text-red-600'}`}>
+                          <span className={`font-semibold ${q2Variance >= 0 ? 'text-green-600' : q2Variance >= -1 * (scoringScale / 10) ? 'text-amber-600' : 'text-red-600'}`}>
                             {q2Variance >= 0 ? '+' : ''}{formatScore(q2Variance)}
                           </span>
                         ) : (
@@ -776,7 +780,7 @@ const Dashboard = () => {
                       </td>
                       <td className="border border-gray-200 px-3 py-3 text-center">
                         {q3Variance !== null ? (
-                          <span className={`font-semibold ${q3Variance >= 0 ? 'text-green-600' : q3Variance >= -1 ? 'text-amber-600' : 'text-red-600'}`}>
+                          <span className={`font-semibold ${q3Variance >= 0 ? 'text-green-600' : q3Variance >= -1 * (scoringScale / 10) ? 'text-amber-600' : 'text-red-600'}`}>
                             {q3Variance >= 0 ? '+' : ''}{formatScore(q3Variance)}
                           </span>
                         ) : (
@@ -802,7 +806,7 @@ const Dashboard = () => {
                       </td>
                       <td className="border border-gray-200 px-3 py-3 text-center">
                         {q4Variance !== null ? (
-                          <span className={`font-semibold ${q4Variance >= 0 ? 'text-green-600' : q4Variance >= -1 ? 'text-amber-600' : 'text-red-600'}`}>
+                          <span className={`font-semibold ${q4Variance >= 0 ? 'text-green-600' : q4Variance >= -1 * (scoringScale / 10) ? 'text-amber-600' : 'text-red-600'}`}>
                             {q4Variance >= 0 ? '+' : ''}{formatScore(q4Variance)}
                           </span>
                         ) : (
@@ -847,7 +851,7 @@ const Dashboard = () => {
                       interval={0}
                     />
                     <YAxis
-                      domain={[0, 10]}
+                      domain={[0, scoringScale]}
                       tick={{ fontSize: 11, fill: chartColors.text }}
                       tickLine={false}
                       axisLine={false}
@@ -972,7 +976,7 @@ const Dashboard = () => {
                             const totalVariance = +(grandTotals.actualScore - grandTotals.desiredTarget).toFixed(1);
                             return (
                               <span className={`${
-                                totalVariance >= 0 ? 'text-green-600' : totalVariance >= -1 ? 'text-amber-600' : 'text-red-600'
+                                totalVariance >= 0 ? 'text-green-600' : totalVariance >= -1 * (scoringScale / 10) ? 'text-amber-600' : 'text-red-600'
                               }`}>
                                 {totalVariance >= 0 ? '+' : ''}{formatScore(totalVariance)}
                               </span>
@@ -1008,7 +1012,7 @@ const Dashboard = () => {
                       />
                       <PolarRadiusAxis
                         angle={90}
-                        domain={[0, 10]}
+                        domain={[0, scoringScale]}
                         tick={{ fontSize: 10, fill: chartColors.text }}
                         tickCount={6}
                       />
@@ -1160,7 +1164,7 @@ const Dashboard = () => {
                     tickLine={false}
                   />
                   <YAxis
-                    domain={[0, 7]}
+                    domain={[0, scoringScale]}
                     tick={{ fontSize: 11, fill: chartColors.text }}
                     tickLine={false}
                     axisLine={false}
@@ -1289,15 +1293,15 @@ const Dashboard = () => {
             <tbody>
               {priorityGaps.map((row, index) => {
                 let scoreClass;
-                if (row.priorityScore >= 3.0) {
+                if (row.priorityScore >= 3.0 * (scoringScale / 10)) {
                   scoreClass = darkMode
                     ? 'text-red-400 bg-red-900/30'
                     : 'text-red-600 bg-red-50';
-                } else if (row.priorityScore >= 2.0) {
+                } else if (row.priorityScore >= 2.0 * (scoringScale / 10)) {
                   scoreClass = darkMode
                     ? 'text-orange-400 bg-orange-900/30'
                     : 'text-orange-600 bg-orange-50';
-                } else if (row.priorityScore >= 1.0) {
+                } else if (row.priorityScore >= 1.0 * (scoringScale / 10)) {
                   scoreClass = darkMode
                     ? 'text-yellow-400 bg-yellow-900/30'
                     : 'text-yellow-600 bg-yellow-50';

--- a/src/pages/ScoringLegend.js
+++ b/src/pages/ScoringLegend.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Papa from 'papaparse';
+import { CMMI_LEVELS } from '../utils/scoringScale';
 
 const ScoringLegend = () => {
   const [legendData, setLegendData] = useState([]);
@@ -145,6 +146,34 @@ const ScoringLegend = () => {
       </div>
 
       <p className="text-sm text-gray-600 mt-6 mb-2 italic">Scoring Legend from Mastering Cyber Resilience by AKYLADE</p>
+
+      <h1 className="text-2xl font-bold mb-4 mt-4">5-Point Maturity Scale (CMMI-Style)</h1>
+      <div className="bg-white p-4 rounded-lg shadow-sm border overflow-x-auto">
+        <p className="text-sm text-gray-700 mb-4">
+          Assessments created with the 5-point scale use CMMI-style maturity levels (0&ndash;5), as popularized
+          for CSF assessments by the NIST CSF Maturity Toolkit. Both scales support quarter-point precision
+          (e.g. 3.25 indicates partial progress toward the next level). The scale is chosen when an assessment
+          is created and locked afterward.
+        </p>
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="p-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Level</th>
+              <th className="p-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+              <th className="p-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {CMMI_LEVELS.map((level) => (
+              <tr key={level.level}>
+                <td className="p-3 text-sm font-medium">{level.level}</td>
+                <td className="p-3 text-sm">{level.name}</td>
+                <td className="p-3 text-sm">{level.description}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
 
       <h1 className="text-2xl font-bold mb-4 mt-4">NIST SP 800-53A Assessment Methods</h1>
       <div className="bg-white p-4 rounded-lg shadow-sm border">

--- a/src/stores/aiStore.js
+++ b/src/stores/aiStore.js
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { getScoringScale } from '../utils/scoringScale';
 
 /**
  * AI Assistant Store
@@ -234,6 +235,9 @@ const useAIStore = create(
         set({ isAnalyzing: true, analysisError: null });
 
         try {
+          // Severity thresholds are proportional to the assessment's scoring
+          // scale (>=3 critical / >=2 high on the 10-point scale) — issue #277
+          const gapRatio = getScoringScale(assessmentData) / 10;
           // Extract gaps (controls where actual < target)
           const gaps = [];
           for (const [controlId, observation] of Object.entries(assessmentData.observations || {})) {
@@ -248,8 +252,8 @@ const useAIStore = create(
                 observations: q1.observations,
                 description: control?.description || '',
                 function: controlId.split('.')[0],
-                severity: (q1.targetScore - q1.actualScore) >= 3 ? 'critical' :
-                  (q1.targetScore - q1.actualScore) >= 2 ? 'high' : 'medium'
+                severity: (q1.targetScore - q1.actualScore) >= 3 * gapRatio ? 'critical' :
+                  (q1.targetScore - q1.actualScore) >= 2 * gapRatio ? 'high' : 'medium'
               });
             }
           }

--- a/src/stores/assessmentsStore.js
+++ b/src/stores/assessmentsStore.js
@@ -131,7 +131,7 @@ const migrateObservationToQuarterly = (oldObs) => {
  * Current schema version of csf-assessments-storage. Exported so the restore
  * path (dataImport.js) can migrate older exported payloads before applying them.
  */
-export const ASSESSMENTS_SCHEMA_VERSION = 9;
+export const ASSESSMENTS_SCHEMA_VERSION = 10;
 
 /**
  * Full persisted-state migration chain for csf-assessments-storage.
@@ -222,6 +222,16 @@ export const migrateAssessmentsState = (persistedState, version) => {
     if (!assessments.some(a => a.id === COMPREHENSIVE_ASSESSMENT_ID)) {
       assessments.push(COMPREHENSIVE_ASSESSMENT);
     }
+    state = { ...state, assessments };
+  }
+
+  // Version 10: Stamp scoringScale (issue #277). Existing assessments were
+  // all scored on the 10-point scale; stored scores are NEVER rescaled.
+  // Idempotent: an assessment already carrying a valid scale keeps it.
+  if (version < 10) {
+    const assessments = (state.assessments || []).map(a =>
+      a.scoringScale === 5 || a.scoringScale === 10 ? a : { ...a, scoringScale: 10 }
+    );
     state = { ...state, assessments };
   }
 
@@ -418,6 +428,7 @@ const useAssessmentsStore = create(
                     name: group.name,
                     description: group.description,
                     scopeType: group.scopeType,
+                    scoringScale: 10,
                     scopeIds: [...new Set(scopeIds)],
                     frameworkFilter: null,
                     jiraKey: group.jiraKey || null,
@@ -479,6 +490,8 @@ const useAssessmentsStore = create(
           name: assessmentData.name || `Assessment ${assessments.length + 1}`,
           description: assessmentData.description || '',
           scopeType: assessmentData.scopeType || 'requirements', // 'requirements' or 'controls'
+          // 10-point (default) or 5-point CMMI-style scale; locked at creation (issue #277)
+          scoringScale: assessmentData.scoringScale === 5 ? 5 : 10,
           scopeIds: assessmentData.scopeIds || [], // Array of requirement IDs or control IDs
           frameworkFilter: assessmentData.frameworkFilter || null, // Optional framework filter
           status: 'Not Started', // Not Started, In Progress, Complete
@@ -820,6 +833,7 @@ const useAssessmentsStore = create(
             'ID': escapeCSVValue(getItemName(itemId)),
             'Assessment': escapeCSVValue(assessment.name),
             'Scope Type': escapeCSVValue(assessment.scopeType),
+            'Scoring Scale': assessment.scoringScale === 5 ? 5 : 10,
             'Auditor': escapeCSVValue(getUserName(obs.auditorId)),
             'Test Procedure(s)': escapeCSVValue(obs.testProcedures || '')
           };
@@ -996,6 +1010,8 @@ const useAssessmentsStore = create(
                     description: epicInfo?.description || row['Description'] || row.description || '',
                     scopeType: scopeType,
                     frameworkFilter: row['Framework Filter'] || row.frameworkFilter || null,
+                    // Round-trip the scoring scale; CSVs without the column default to 10 (issue #277)
+                    scoringScale: Number(row['Scoring Scale']) === 5 ? 5 : 10,
                     jiraKey: assessmentJiraKey, // Store Jira Epic key for reference
                     rows: []
                   };
@@ -1208,6 +1224,7 @@ const useAssessmentsStore = create(
                   name: group.name,
                   description: group.description,
                   scopeType: group.scopeType,
+                  scoringScale: group.scoringScale === 5 ? 5 : 10,
                   scopeIds: [...new Set(scopeIds)],
                   frameworkFilter: group.frameworkFilter,
                   jiraKey: group.jiraKey || null, // Store Jira Epic key for sync reference
@@ -1533,6 +1550,7 @@ const useAssessmentsStore = create(
               'Description': escapeCSVValue(assessment.description || ''),
               'Scope Type': escapeCSVValue(assessment.scopeType),
               'Framework Filter': escapeCSVValue(assessment.frameworkFilter || ''),
+              'Scoring Scale': assessment.scoringScale === 5 ? 5 : 10,
               'Auditor': escapeCSVValue(getUserName(obs.auditorId)),
               'Test Procedure(s)': escapeCSVValue(obs.testProcedures || '')
             };

--- a/src/stores/assessmentsStore.migrate.test.js
+++ b/src/stores/assessmentsStore.migrate.test.js
@@ -60,9 +60,62 @@ describe('migrateAssessmentsState', () => {
   });
 
   test('current-version state passes through unchanged', () => {
-    const state = { assessments: [{ id: 'ASM-x', observations: {} }], currentAssessmentId: 'ASM-x' };
-    const result = migrateAssessmentsState(state, 9);
+    const state = {
+      assessments: [{ id: 'ASM-x', observations: {}, scoringScale: 10 }],
+      currentAssessmentId: 'ASM-x'
+    };
+    const result = migrateAssessmentsState(state, 10);
     expect(result).toEqual(state);
+  });
+
+  describe('v10: scoringScale stamp (issue #277)', () => {
+    test('a v9 client gets scoringScale 10 stamped on every assessment', () => {
+      const state = {
+        assessments: [
+          { id: 'ASM-a', observations: {} },
+          { id: 'ASM-b', observations: {} }
+        ],
+        currentAssessmentId: 'ASM-a'
+      };
+      const result = migrateAssessmentsState(state, 9);
+      expect(result.assessments.every(a => a.scoringScale === 10)).toBe(true);
+    });
+
+    test('stored scores are byte-equal across the v10 stamp — never rescaled', () => {
+      const state = {
+        assessments: [{
+          id: 'ASM-a',
+          observations: {
+            'GV.SC-04': { quarters: { Q1: { actualScore: 7.5, targetScore: 9 } } }
+          }
+        }],
+        currentAssessmentId: 'ASM-a'
+      };
+      const result = migrateAssessmentsState(state, 9);
+      const q1 = result.assessments[0].observations['GV.SC-04'].quarters.Q1;
+      expect(q1.actualScore).toBe(7.5);
+      expect(q1.targetScore).toBe(9);
+    });
+
+    test('idempotent: an assessment already carrying a valid scale keeps it', () => {
+      const state = {
+        assessments: [
+          { id: 'ASM-five', observations: {}, scoringScale: 5 },
+          { id: 'ASM-ten', observations: {}, scoringScale: 10 },
+          { id: 'ASM-junk', observations: {}, scoringScale: 7 }
+        ],
+        currentAssessmentId: 'ASM-five'
+      };
+      const result = migrateAssessmentsState(state, 9);
+      expect(result.assessments.find(a => a.id === 'ASM-five').scoringScale).toBe(5);
+      expect(result.assessments.find(a => a.id === 'ASM-ten').scoringScale).toBe(10);
+      expect(result.assessments.find(a => a.id === 'ASM-junk').scoringScale).toBe(10);
+    });
+
+    test('a v0 client also receives the scale stamp (fall-through)', () => {
+      const result = migrateAssessmentsState(legacyV0State(), 0);
+      expect(result.assessments.every(a => a.scoringScale === 5 || a.scoringScale === 10)).toBe(true);
+    });
   });
 
   test('empty/new state gets defaults and still runs the rest of the chain', () => {

--- a/src/utils/auditReportMarkdown.js
+++ b/src/utils/auditReportMarkdown.js
@@ -1,4 +1,5 @@
 import DOMPurify from 'dompurify';
+import { getScoringScale, CMMI_LEVELS } from './scoringScale';
 
 // CSF function order and display names
 const FUNCTION_ORDER = ['GOVERN (GV)', 'IDENTIFY (ID)', 'PROTECT (PR)', 'DETECT (DE)', 'RESPOND (RS)', 'RECOVER (RC)'];
@@ -117,17 +118,25 @@ const ratingBadge = (rating) => {
 };
 
 /**
- * Format a numeric score to one decimal place
+ * Format a numeric score to one decimal place; quarter-point scores
+ * (x.25 / x.75) keep two decimals so 7.25 doesn't render as 7.3.
  */
 const formatScore = (value) => {
   if (value === null || value === undefined || isNaN(value)) return '0.0';
-  return Number(value).toFixed(1);
+  const num = Number(value);
+  return (num * 4) % 2 !== 0 ? num.toFixed(2) : num.toFixed(1);
 };
 
 /**
- * Map a maturity score (1-10 scale) to a label
+ * Map a maturity score to a label on the assessment's scale (issue #277).
+ * 10-point keeps the classic bands unchanged; 5-point uses CMMI-style
+ * level names (a score is at level N until it reaches N+1).
  */
-const scoreToMaturityLabel = (score) => {
+const scoreToMaturityLabel = (score, scale = 10) => {
+  if (scale === 5) {
+    const level = Math.min(5, Math.max(0, Math.floor(Number(score) || 0)));
+    return CMMI_LEVELS[level].name;
+  }
   if (score < 2) return 'Insecurity';
   if (score < 5) return 'Some Security';
   if (score < 6) return 'Minimally Acceptable';
@@ -191,6 +200,9 @@ export const generateAuditReportMarkdown = ({
   }
 }) => {
   const quarterKey = `Q${selectedQuarter}`;
+  // Scoring scale for this assessment: 10 (default) or 5-point CMMI-style (issue #277)
+  const scoringScale = getScoringScale(assessment);
+  const scaleRatio = scoringScale / 10;
 
   // ── Step 1: Build requirement lookup ──────────────────────────────────
   const requirementLookup = new Map();
@@ -284,7 +296,7 @@ export const generateAuditReportMarkdown = ({
   const controlsMeetingTarget = controlData.filter(cd => cd.actualScore >= cd.targetScore).length;
   const controlsBelowTarget = totalControls - controlsMeetingTarget;
 
-  const overallMaturity = scoreToMaturityLabel(overallActual);
+  const overallMaturity = scoreToMaturityLabel(overallActual, scoringScale);
 
   // ── Step 6: Compute overall assessment rating ────────────────────────
   const functionsWithData = FUNCTION_ORDER.filter(fn => functionAggregates[fn].count > 0);
@@ -423,7 +435,7 @@ Based on our assessment of ${totalControls} control implementations across all s
 
 | Metric | Value |
 |---|---|
-| **Overall Maturity Score** | ${formatScore(overallActual)} / 10.0 (${overallMaturity}) |
+| **Overall Maturity Score** | ${formatScore(overallActual)} / ${scoringScale}.0 (${overallMaturity}) |
 | **Controls Meeting Target** | ${controlsMeetingTarget} of ${totalControls} (${totalControls > 0 ? ((controlsMeetingTarget / totalControls) * 100).toFixed(0) : 0}%) |
 | **Controls Below Target** | ${controlsBelowTarget} of ${totalControls} |
 | **Critical Findings** | ${findingsByCriticality.Critical} |
@@ -483,7 +495,7 @@ This assessment evaluated ${sanitize(organizationName)}'s implementation of the 
   scopeSection += `
 ### Scoring Framework
 
-Controls were evaluated on a 1-10 scale. See [Appendix B](#appendix-b-assessment-criteria-and-rating-definitions) for full scoring definitions.
+Controls were evaluated on a ${scoringScale === 5 ? '0-5 CMMI-style' : '1-10'} scale. See [Appendix B](#appendix-b-assessment-criteria-and-rating-definitions) for full scoring definitions.
 
 ### Methodology
 
@@ -501,12 +513,12 @@ Assessment procedures included:
 
 ### Current Maturity Profile
 
-The organization's overall cybersecurity maturity is assessed at **${overallMaturity}** (${formatScore(overallActual)} / 10.0).
+The organization's overall cybersecurity maturity is assessed at **${overallMaturity}** (${formatScore(overallActual)} / ${scoringScale}.0).
 
 | Dimension | Average Score | Maturity Level |
 |---|---|---|
-| Governance (GV) | ${formatScore(govAgg.avgActual)} | ${scoreToMaturityLabel(govAgg.avgActual)} |
-| Operations (ID, PR, DE, RS, RC) | ${formatScore(opsAvg)} | ${scoreToMaturityLabel(opsAvg)} |
+| Governance (GV) | ${formatScore(govAgg.avgActual)} | ${scoreToMaturityLabel(govAgg.avgActual, scoringScale)} |
+| Operations (ID, PR, DE, RS, RC) | ${formatScore(opsAvg)} | ${scoreToMaturityLabel(opsAvg, scoringScale)} |
 | **Overall** | **${formatScore(overallActual)}** | **${overallMaturity}** |
 
 ### Governance vs Operations Gap Analysis
@@ -655,8 +667,8 @@ The organization's overall cybersecurity maturity is assessed at **${overallMatu
       const scoreBg = gapCellColor(cd.actualScore, cd.targetScore);
       const scoreTc = gapTextColor(cd.actualScore, cd.targetScore);
       const gapVal = cd.gap;
-      const gapBg = gapVal <= 0 ? '#dcfce7' : gapVal < 2 ? '#fef3c7' : '#fee2e2';
-      const gapTc = gapVal <= 0 ? '#16a34a' : gapVal < 2 ? '#d97706' : '#dc2626';
+      const gapBg = gapVal <= 0 ? '#dcfce7' : gapVal < 2 * scaleRatio ? '#fef3c7' : '#fee2e2';
+      const gapTc = gapVal <= 0 ? '#16a34a' : gapVal < 2 * scaleRatio ? '#d97706' : '#dc2626';
       appendixA += `<tr style="background:${rowBg}"><td style="padding:4px 10px;border-bottom:1px solid #e5e7eb;font-family:monospace;font-size:13px">${sanitize(cd.controlId)}</td><td style="padding:4px 10px;text-align:center;border-bottom:1px solid #e5e7eb;color:${scoreTc};font-weight:600">${formatScore(cd.actualScore)}</td><td style="padding:4px 10px;text-align:center;border-bottom:1px solid #e5e7eb">${formatScore(cd.targetScore)}</td><td style="padding:4px 10px;text-align:center;border-bottom:1px solid #e5e7eb;background:${gapBg};color:${gapTc};font-weight:600">${formatScore(cd.gap)}</td></tr>\n`;
     });
 
@@ -686,7 +698,13 @@ The organization's overall cybersecurity maturity is assessed at **${overallMatu
 | **Needs Improvement** | Function average score is at least 70% of the target but below full target. Controls are partially effective with identified gaps. |
 | **Unsatisfactory** | Function average score is below 70% of the target. Controls have significant deficiencies requiring immediate attention. |
 
-### Scoring Scale (1-10)
+${scoringScale === 5 ? `### Scoring Scale (0-5, CMMI-style)
+
+| Score | Level | Description |
+|---|---|---|
+${CMMI_LEVELS.map(l => `| ${l.level} | ${l.name} | ${l.description} |`).join('\n')}
+
+Quarter-point scores (e.g. 3.25) indicate partial progress toward the next level.` : `### Scoring Scale (1-10)
 
 | Score | Level | How Secure? |
 |---|---|---|
@@ -695,7 +713,7 @@ The organization's overall cybersecurity maturity is assessed at **${overallMatu
 | 5.0 - 5.9 | Minimally Acceptable | Organization does this consistently, with some minor flaws. Just right. |
 | 6.1 - 6.9 | Optimized | Organization does this consistently, with great effectiveness and high quality. Just right. |
 | 7.0 - 7.9 | Fully Optimized | Organization does this consistently, with fully optimized effectiveness and quality. Just right. |
-| 8.1 - 10.0 | Too Much Security (Waste) | Organization does this at excessive financial cost. People can't easily get their work done. |
+| 8.1 - 10.0 | Too Much Security (Waste) | Organization does this at excessive financial cost. People can't easily get their work done. |`}
 
 ---`);
 

--- a/src/utils/dataImport.test.js
+++ b/src/utils/dataImport.test.js
@@ -150,6 +150,58 @@ describe('importCompleteDatabase safety semantics', () => {
     expect(written.some(a => a.id === 'ASM-audit-2025-alma')).toBe(true);
   });
 
+  test('a v9 export (no scoringScale) restores with scale 10 stamped; scores untouched (issue #277)', () => {
+    const { stores, setters } = makeStores();
+    const parsed = {
+      formatVersion: EXPORT_FORMAT_VERSION,
+      storeVersions: { assessments: 9 },
+      data: {
+        assessments: [{
+          id: 'ASM-v9',
+          name: 'Pre-scale export',
+          scopeType: 'requirements',
+          scopeIds: ['GV.SC-04 Ex1'],
+          observations: {
+            'GV.SC-04 Ex1': { quarters: { Q1: { actualScore: 7.5, targetScore: 9 } } }
+          }
+        }]
+      }
+    };
+    importCompleteDatabase(parsed, stores, { backupFirst: false });
+
+    const written = setters.setAssessments.mock.calls[0][0];
+    const restored = written.find(a => a.id === 'ASM-v9');
+    expect(restored.scoringScale).toBe(10);
+    expect(restored.observations['GV.SC-04 Ex1'].quarters.Q1.actualScore).toBe(7.5);
+    expect(restored.observations['GV.SC-04 Ex1'].quarters.Q1.targetScore).toBe(9);
+  });
+
+  test('a 5-point assessment keeps its scale through restore (issue #277)', () => {
+    const { stores, setters } = makeStores();
+    const parsed = {
+      formatVersion: EXPORT_FORMAT_VERSION,
+      storeVersions: { assessments: 9 },
+      data: {
+        assessments: [{
+          id: 'ASM-cmmi',
+          name: 'CMMI-scale assessment',
+          scopeType: 'requirements',
+          scoringScale: 5,
+          scopeIds: ['GV.SC-04 Ex1'],
+          observations: {
+            'GV.SC-04 Ex1': { quarters: { Q1: { actualScore: 3.25, targetScore: 4 } } }
+          }
+        }]
+      }
+    };
+    importCompleteDatabase(parsed, stores, { backupFirst: false });
+
+    const written = setters.setAssessments.mock.calls[0][0];
+    const restored = written.find(a => a.id === 'ASM-cmmi');
+    expect(restored.scoringScale).toBe(5);
+    expect(restored.observations['GV.SC-04 Ex1'].quarters.Q1.actualScore).toBe(3.25);
+  });
+
   test('a mid-apply setter failure rolls back every already-applied section', () => {
     const { stores, setters } = makeStores();
     // users applies first, then findings throws

--- a/src/utils/executiveSummaryPDF.js
+++ b/src/utils/executiveSummaryPDF.js
@@ -1,5 +1,6 @@
 import jsPDF from 'jspdf';
 import 'jspdf-autotable';
+import { getScoringScale, CMMI_LEVELS } from './scoringScale';
 
 // CSF function order for consistent display
 const FUNCTION_ORDER = [
@@ -37,9 +38,15 @@ const normalizeFunctionName = (func) => {
 };
 
 /**
- * Map a maturity score (0-7 scale) to a label.
+ * Map a maturity score to a label. Thresholds were authored on the
+ * 10-point scale era and stay unchanged for it; the 5-point CMMI-style
+ * scale uses its level names directly (issue #277).
  */
-const scoreToLabel = (score) => {
+const scoreToLabel = (score, scale = 10) => {
+  if (scale === 5) {
+    const level = Math.min(5, Math.max(0, Math.floor(Number(score) || 0)));
+    return CMMI_LEVELS[level].name;
+  }
   if (score < 1) return 'Initial';
   if (score < 3) return 'Developing';
   if (score < 5) return 'Managed';
@@ -47,13 +54,14 @@ const scoreToLabel = (score) => {
 };
 
 /**
- * Return an RGB color array based on gap size.
- * Green: gap <= 0, Yellow: gap < 2, Red: gap >= 2
+ * Return an RGB color array based on gap size, proportional to the scale
+ * (on the 10-point scale: green <= 0, yellow < 2, red >= 2).
  */
-const gapColor = (gap) => {
-  if (gap <= 0) return [34, 197, 94];    // green-500
-  if (gap < 2)  return [234, 179, 8];   // yellow-500
-  return [239, 68, 68];                 // red-500
+const gapColor = (gap, scale = 10) => {
+  const ratio = scale / 10;
+  if (gap <= 0) return [34, 197, 94];              // green-500
+  if (gap < 2 * ratio) return [234, 179, 8];       // yellow-500
+  return [239, 68, 68];                            // red-500
 };
 
 /**
@@ -106,6 +114,8 @@ export const generateExecutiveSummary = ({
   // ─── Build Data ──────────────────────────────────────────────────────────────
 
   const { scopeIds, observations } = assessment;
+  // Scoring scale for this assessment: 10 (default) or 5-point CMMI-style (issue #277)
+  const scale = getScoringScale(assessment);
 
   // Build a lookup: requirementId → function name
   const reqLookup = new Map();
@@ -248,7 +258,7 @@ export const generateExecutiveSummary = ({
   doc.setFontSize(13);
   doc.setFont('helvetica', 'bold');
   doc.text(
-    `Overall Maturity Score: ${overallActual} / 7.0  —  ${scoreToLabel(overallActual)}`,
+`Overall Maturity Score: ${overallActual} / ${scale}.0  —  ${scoreToLabel(overallActual, scale)}`,
     pageWidth / 2,
     curY + 9,
     { align: 'center' }
@@ -258,7 +268,7 @@ export const generateExecutiveSummary = ({
   doc.setFont('helvetica', 'normal');
   doc.setTextColor(37, 99, 235); // blue-600
   doc.text(
-    `Target: ${overallTarget} / 7.0  |  Gap to target: ${Math.max(0, overallTarget - overallActual).toFixed(1)}  |  ${items.length} items in scope`,
+    `Target: ${overallTarget} / ${scale}.0  |  Gap to target: ${Math.max(0, overallTarget - overallActual).toFixed(1)}  |  ${items.length} items in scope`,
     pageWidth / 2,
     curY + 17,
     { align: 'center' }
@@ -304,7 +314,7 @@ export const generateExecutiveSummary = ({
       if (data.section === 'body' && data.column.index === 3) {
         const gapVal = parseFloat(data.cell.raw);
         if (!isNaN(gapVal)) {
-          const [r, g, b] = gapColor(gapVal);
+          const [r, g, b] = gapColor(gapVal, scale);
           doc.setFillColor(r, g, b);
           doc.setTextColor(255, 255, 255);
           const { x, y, width, height } = data.cell;
@@ -507,12 +517,16 @@ export const generateExecutiveSummary = ({
   doc.setFont('helvetica', 'italic');
   doc.setTextColor(100, 116, 139); // slate-500
   doc.text(
-    'Maturity Scale: 0-1 Initial  |  1-3 Developing  |  3-5 Managed  |  5-7 Optimized',
+    scale === 5
+      ? 'Maturity Scale (CMMI-style): 0 Not Performed | 1 Initial | 2 Repeatable | 3 Defined | 4 Managed | 5 Optimizing'
+      : 'Maturity Scale: 0-1 Initial  |  1-3 Developing  |  3-5 Managed  |  5-7 Optimized',
     marginL,
     curY
   );
   doc.text(
-    'Gap Color: Green (<=0, on/above target)  |  Yellow (<2, minor gap)  |  Red (>=2, significant gap)',
+    scale === 5
+      ? 'Gap Color: Green (<=0, on/above target)  |  Yellow (<1, minor gap)  |  Red (>=1, significant gap)'
+      : 'Gap Color: Green (<=0, on/above target)  |  Yellow (<2, minor gap)  |  Red (>=2, significant gap)',
     marginL,
     curY + 5
   );

--- a/src/utils/packImport.js
+++ b/src/utils/packImport.js
@@ -325,6 +325,8 @@ export const importPack = (parsed, stores) => {
     name: `${parsed.org.name} (private pack)`,
     description: `Imported from data pack "${slug}" ${packVersion}. Re-importing the pack replaces this assessment.`,
     scopeType: 'requirements',
+    // packFormat 1 scores are defined on the 10-point scale (issue #277)
+    scoringScale: 10,
     scopeIds: resolved.map(({ requirementId }) => requirementId),
     frameworkFilter: defaultFramework?.id || null,
     status: 'In Progress',

--- a/src/utils/scoringScale.js
+++ b/src/utils/scoringScale.js
@@ -1,0 +1,113 @@
+/**
+ * Scoring scale utilities (issue #277).
+ *
+ * An assessment carries a `scoringScale` of 10 (default — the classic
+ * 10-point scale) or 5 (CMMI-style maturity scale, as in the NIST CSF
+ * Maturity Toolkit). Scores are stored RAW on the assessment's own scale
+ * and are never rescaled; every scale-dependent threshold in the app is
+ * expressed as a fraction of the scale via `scaleRatio` so 10-point
+ * behavior is unchanged and 5-point behavior is proportional.
+ *
+ * Both scales support quarter-point precision (0.25 steps). Quarter
+ * fractions (.0, .25, .5, .75) are exactly representable in binary
+ * floating point, so compose/decompose round-trips are lossless.
+ *
+ * Assessments never mix scales in aggregate views today (dashboards,
+ * reports and exports are single-assessment scoped). If a cross-assessment
+ * comparison surface is ever added, normalize at that boundary — not in
+ * storage.
+ */
+
+export const DEFAULT_SCALE = 10;
+
+/** Valid scale values, in display order (10 first — it is the default). */
+export const SCALE_OPTIONS = [10, 5];
+
+/** The quarter-point fraction choices offered by the second dropdown. */
+export const QUARTER_FRACTIONS = [0, 0.25, 0.5, 0.75];
+
+/**
+ * CMMI-style maturity level reference for the 5-point scale
+ * (classic CMM level names; 0 = not performed at all).
+ */
+export const CMMI_LEVELS = [
+  { level: 0, name: 'Not Performed', description: 'The activity is not performed at all.' },
+  { level: 1, name: 'Initial', description: 'Ad hoc and reactive; success depends on individual effort.' },
+  { level: 2, name: 'Repeatable', description: 'Basic processes established; discipline exists to repeat earlier successes.' },
+  { level: 3, name: 'Defined', description: 'Processes documented, standardized, and integrated across the organization.' },
+  { level: 4, name: 'Managed', description: 'Processes quantitatively measured and controlled.' },
+  { level: 5, name: 'Optimizing', description: 'Continuous process improvement from quantitative feedback and piloting.' }
+];
+
+/**
+ * Resolve an assessment's scoring scale. Anything other than an explicit
+ * 5 resolves to the default 10 — including legacy assessments created
+ * before the field existed.
+ */
+export function getScoringScale(assessment) {
+  return assessment && assessment.scoringScale === 5 ? 5 : DEFAULT_SCALE;
+}
+
+/** Whole-number options for the first dropdown: 0..scale inclusive. */
+export function wholeScoreOptions(scale) {
+  const max = scale === 5 ? 5 : DEFAULT_SCALE;
+  return Array.from({ length: max + 1 }, (_, i) => i);
+}
+
+/**
+ * Ratio for converting a threshold defined on the 10-point scale to the
+ * assessment's scale. Multiplying every absolute threshold by this keeps
+ * 10-point behavior identical and makes 5-point proportional.
+ */
+export function scaleRatio(scale) {
+  return (scale === 5 ? 5 : DEFAULT_SCALE) / DEFAULT_SCALE;
+}
+
+/** Snap a value to the nearest quarter point, clamped to [0, scale]. */
+export function snapScore(value, scale) {
+  const max = scale === 5 ? 5 : DEFAULT_SCALE;
+  const num = Number(value);
+  if (isNaN(num)) return 0;
+  const snapped = Math.round(num * 4) / 4;
+  return Math.min(Math.max(snapped, 0), max);
+}
+
+/**
+ * Combine the two dropdown values into one score, clamped to the scale
+ * maximum (so whole=10 + fraction=.75 yields 10, never 10.75).
+ */
+export function composeScore(whole, fraction, scale) {
+  return snapScore(Number(whole) + Number(fraction), scale);
+}
+
+/**
+ * Split a stored score into { whole, fraction } for the two dropdowns.
+ * Off-step legacy values (e.g. 7.3 from an old CSV import) are shown at
+ * the nearest quarter; storage is only changed if the user edits.
+ */
+export function decomposeScore(score) {
+  const num = Number(score);
+  const snapped = isNaN(num) ? 0 : Math.max(Math.round(num * 4) / 4, 0);
+  const whole = Math.floor(snapped);
+  return { whole, fraction: snapped - whole };
+}
+
+/**
+ * Traffic-light band for a score on its scale. Thresholds are the
+ * existing >=8 green / >=5 yellow on the 10-point scale, expressed
+ * proportionally (80% / 50% of the scale max).
+ */
+export function scoreBand(score, scale) {
+  const max = scale === 5 ? 5 : DEFAULT_SCALE;
+  const num = Number(score) || 0;
+  if (num >= 0.8 * max) return 'green';
+  if (num >= 0.5 * max) return 'yellow';
+  return 'red';
+}
+
+/** Format a score without trailing zeros: 7 -> "7", 7.5 -> "7.5", 7.25 -> "7.25". */
+export function formatScore(score) {
+  const num = Number(score);
+  if (isNaN(num)) return '0';
+  return String(parseFloat(num.toFixed(2)));
+}

--- a/src/utils/scoringScale.test.js
+++ b/src/utils/scoringScale.test.js
@@ -1,0 +1,158 @@
+import {
+  DEFAULT_SCALE,
+  SCALE_OPTIONS,
+  QUARTER_FRACTIONS,
+  CMMI_LEVELS,
+  getScoringScale,
+  wholeScoreOptions,
+  scaleRatio,
+  snapScore,
+  composeScore,
+  decomposeScore,
+  scoreBand,
+  formatScore
+} from './scoringScale';
+
+describe('scoringScale utilities', () => {
+  describe('getScoringScale', () => {
+    it('defaults to 10 for missing assessment', () => {
+      expect(getScoringScale(null)).toBe(10);
+      expect(getScoringScale(undefined)).toBe(10);
+    });
+
+    it('defaults to 10 for legacy assessments without the field', () => {
+      expect(getScoringScale({ id: 'ASM-1', name: 'Legacy' })).toBe(10);
+    });
+
+    it('returns 5 only for an explicit 5', () => {
+      expect(getScoringScale({ scoringScale: 5 })).toBe(5);
+      expect(getScoringScale({ scoringScale: 10 })).toBe(10);
+      expect(getScoringScale({ scoringScale: '5' })).toBe(10);
+      expect(getScoringScale({ scoringScale: 7 })).toBe(10);
+    });
+  });
+
+  describe('wholeScoreOptions', () => {
+    it('generates 0..10 for the 10-point scale', () => {
+      expect(wholeScoreOptions(10)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    });
+
+    it('generates 0..5 for the 5-point scale', () => {
+      expect(wholeScoreOptions(5)).toEqual([0, 1, 2, 3, 4, 5]);
+    });
+
+    it('treats invalid scales as 10', () => {
+      expect(wholeScoreOptions(undefined)).toHaveLength(11);
+      expect(wholeScoreOptions(7)).toHaveLength(11);
+    });
+  });
+
+  describe('quarter fractions', () => {
+    it('offers exactly .00 .25 .50 .75', () => {
+      expect(QUARTER_FRACTIONS).toEqual([0, 0.25, 0.5, 0.75]);
+    });
+  });
+
+  describe('composeScore', () => {
+    it('combines whole and fraction', () => {
+      expect(composeScore(7, 0.25, 10)).toBe(7.25);
+      expect(composeScore(3, 0.75, 5)).toBe(3.75);
+      expect(composeScore(0, 0, 10)).toBe(0);
+    });
+
+    it('clamps at the scale maximum', () => {
+      expect(composeScore(10, 0.75, 10)).toBe(10);
+      expect(composeScore(10, 0.25, 10)).toBe(10);
+      expect(composeScore(5, 0.25, 5)).toBe(5);
+      expect(composeScore(5, 0.75, 5)).toBe(5);
+    });
+
+    it('never returns negative', () => {
+      expect(composeScore(-1, 0, 10)).toBe(0);
+    });
+  });
+
+  describe('decomposeScore', () => {
+    it('is exact for every quarter step 0..10', () => {
+      for (let q = 0; q <= 40; q++) {
+        const score = q / 4;
+        const { whole, fraction } = decomposeScore(score);
+        expect(whole + fraction).toBe(score);
+        expect(QUARTER_FRACTIONS).toContain(fraction);
+      }
+    });
+
+    it('handles legacy half points exactly', () => {
+      expect(decomposeScore(7.5)).toEqual({ whole: 7, fraction: 0.5 });
+    });
+
+    it('snaps off-step legacy values to the nearest quarter for display', () => {
+      expect(decomposeScore(7.3)).toEqual({ whole: 7, fraction: 0.25 });
+      expect(decomposeScore(9.9)).toEqual({ whole: 10, fraction: 0 });
+    });
+
+    it('handles invalid input', () => {
+      expect(decomposeScore(undefined)).toEqual({ whole: 0, fraction: 0 });
+      expect(decomposeScore('abc')).toEqual({ whole: 0, fraction: 0 });
+    });
+  });
+
+  describe('snapScore', () => {
+    it('snaps to nearest quarter and clamps to scale', () => {
+      expect(snapScore(7.3, 10)).toBe(7.25);
+      expect(snapScore(7.9, 10)).toBe(8);
+      expect(snapScore(12, 10)).toBe(10);
+      expect(snapScore(6, 5)).toBe(5);
+      expect(snapScore(-2, 10)).toBe(0);
+      expect(snapScore('junk', 10)).toBe(0);
+    });
+  });
+
+  describe('scoreBand', () => {
+    it('keeps the existing 10-point thresholds (>=8 green, >=5 yellow)', () => {
+      expect(scoreBand(8, 10)).toBe('green');
+      expect(scoreBand(7.75, 10)).toBe('yellow');
+      expect(scoreBand(5, 10)).toBe('yellow');
+      expect(scoreBand(4.75, 10)).toBe('red');
+      expect(scoreBand(0, 10)).toBe('red');
+    });
+
+    it('is proportional on the 5-point scale (>=4 green, >=2.5 yellow)', () => {
+      expect(scoreBand(4, 5)).toBe('green');
+      expect(scoreBand(3.75, 5)).toBe('yellow');
+      expect(scoreBand(2.5, 5)).toBe('yellow');
+      expect(scoreBand(2.25, 5)).toBe('red');
+    });
+  });
+
+  describe('scaleRatio', () => {
+    it('is 1 for 10-point and 0.5 for 5-point', () => {
+      expect(scaleRatio(10)).toBe(1);
+      expect(scaleRatio(5)).toBe(0.5);
+      expect(scaleRatio(undefined)).toBe(1);
+    });
+  });
+
+  describe('formatScore', () => {
+    it('trims trailing zeros', () => {
+      expect(formatScore(7)).toBe('7');
+      expect(formatScore(7.5)).toBe('7.5');
+      expect(formatScore(7.25)).toBe('7.25');
+      expect(formatScore(0)).toBe('0');
+      expect(formatScore('bad')).toBe('0');
+    });
+  });
+
+  describe('reference data', () => {
+    it('exposes both scales with 10 first (the default)', () => {
+      expect(SCALE_OPTIONS).toEqual([10, 5]);
+      expect(DEFAULT_SCALE).toBe(10);
+    });
+
+    it('defines all six CMMI-style levels 0..5', () => {
+      expect(CMMI_LEVELS.map(l => l.level)).toEqual([0, 1, 2, 3, 4, 5]);
+      expect(CMMI_LEVELS[0].name).toBe('Not Performed');
+      expect(CMMI_LEVELS[5].name).toBe('Optimizing');
+    });
+  });
+});


### PR DESCRIPTION
Closes #277.

## What this adds

**1. Quarter-point score granularity via a second dropdown**
Score entry is now a `ScoreSelect` component with two dropdowns: the whole number (0..scale max) and a quarter fraction (`.00 / .25 / .50 / .75`). At the scale maximum the fraction locks to `.00`, so values like 10.75 are impossible to enter. This replaces both previous entry surfaces — the Assessments detail panel (which was integer-only) and the Controls page (which allowed half points) — eliminating a pre-existing granularity mismatch between the two.

**2. Wizard choice: 5-point CMMI-style scale or 10-point scale**
Step 1 of the new-assessment wizard now asks which scoring scale to use:
- **10-point** (default) — the Simply Cyber Academy scale, unchanged behavior.
- **5-point CMMI-style** (0 Not Performed · 1 Initial · 2 Repeatable · 3 Defined · 4 Managed · 5 Optimizing), as in the NIST CSF Maturity Toolkit featured on NIST's CSF 2.0 resources page.

Both scales support quarter points (e.g. `3.25`). The scale is stored per assessment (`scoringScale`), chosen at creation, and locked afterward.

## Design decisions

- **Stored scores are never rescaled.** The new v10 store migration only stamps `scoringScale: 10` onto existing assessments (their scores are literally on the 10-point scale). Legacy data is untouched — a migration test asserts scores are byte-equal across the stamp.
- **Every absolute threshold became proportional** (`× scale/10`), so 10-point behavior is identical to before and 5-point behavior is proportional: score badge (≥8/≥5 → ≥4/≥2.5), audit-report maturity bands and gap colors, executive-PDF gap colors, AI gap-severity bands, Dashboard priority-score bands, quarter-variance cell colors, and chart domains.
- **CMMI labels on the 5-point scale**: the audit report and executive PDF label scores with CMMI level names (floor semantics — a score is at level N until it reaches N+1; quarter points indicate partial progress toward the next level). The Scoring Legend page gained a 5-point CMMI reference table alongside the existing 10-point legend.
- **CSV round-trip**: assessment CSV exports gain a `Scoring Scale` column; import reads it (header-keyed, so old CSVs without the column import as 10-point, and new CSVs remain importable by older app versions, which simply ignore the column). JSON restore runs the migration chain, so pre-v10 exports restore with the scale stamped. Data-pack imports stamp `scoringScale: 10` (packFormat 1 scores are defined on the 10-point scale).
- **Defensive display clamp**: if an out-of-range value for the scale arrives via import (e.g. an 8 in a 5-point assessment), `ScoreSelect` displays it clamped at the scale max instead of rendering a blank select; storage is only changed if the user edits.

## Two pre-existing bugs fixed here (both are hardcoded scale assumptions this feature had to touch)

- `executiveSummaryPDF.js` printed `Overall Maturity Score: X / 7.0` and `Target: Y / 7.0` while scores are on the 10-point scale — now prints the assessment's actual scale max.
- `Dashboard.js` quarterly trend chart used a `[0, 7]` y-axis domain (the bar and radar charts used `[0, 10]`) — all three now use `[0, scale]`.

Also fixed while touching the formatter: the audit report rounded quarter scores away (`7.25` → `7.3`); quarter-point values now keep two decimals.

## Test coverage

- 40 new tests (`scoringScale.test.js`, `ScoreSelect.test.js`, migration v10 cases, restore round-trip cases); full suite 271/271.
- New-code files lint clean at `--max-warnings=0`; `CI=false npm run build` compiles.

## Notes for reviewers

- `AIScoreSuggestion` (currently not mounted anywhere) got a light scale-awareness fix: the prompt states the active scale and the response parser accepts decimals, snapping to the nearest quarter and clamping to the scale. `AIScoreExplainer` (also unmounted) was left untouched.
- `isValidScore` keeps its global 0–10 storage bound; CSV imports keep accepting arbitrary decimals as before (historical CSVs contain them). The UI enforces the quarter grid by construction.
