### PR TITLE
Deterministic stack-aware tailoring: canned tool/platform substitution from the org profile (no AI)

### DIFF
--- a/src/components/OrgProfileWizard.js
+++ b/src/components/OrgProfileWizard.js
@@ -12,13 +12,19 @@ import useOrgProfileStore, { EMPTY_PROFILE } from '../stores/orgProfileStore';
 
 const SIZE_BANDS = ['1–49', '50–249', '250–999', '1,000–4,999', '5,000+'];
 
+// Cloud, email, and chat selections drive DETERMINISTIC procedure tailoring
+// (canned substitutions, no AI) — see utils/stackTailorMaps.js.
 const INFRA_PRESETS = [
   'AWS', 'Azure', 'Google Cloud', 'On-premises data center', 'SaaS-heavy',
-  'Kubernetes / containers', 'OT / ICS', 'Remote-first endpoints'
+  'Kubernetes / containers', 'OT / ICS', 'Remote-first endpoints',
+  'Microsoft 365', 'Google Workspace', 'Slack', 'Microsoft Teams'
 ];
 
+// Naming a specific EDR product here enables an exact SentinelOne→product
+// swap in tailored procedures; the generic 'EDR' chip neutralizes instead.
 const TOOL_PRESETS = [
-  'EDR', 'SIEM', 'IdP / SSO', 'MFA', 'Vulnerability scanner', 'DLP', 'Backup / DR', 'Firewall / SASE'
+  'EDR', 'SIEM', 'IdP / SSO', 'MFA', 'Vulnerability scanner', 'DLP', 'Backup / DR', 'Firewall / SASE',
+  'CrowdStrike Falcon', 'Microsoft Defender for Endpoint', 'SentinelOne'
 ];
 
 const ChipPicker = ({ presets, value, onChange, placeholder }) => {

--- a/src/index.css
+++ b/src/index.css
@@ -205,10 +205,12 @@ code {
 .pb-12 { padding-bottom: 3rem; }
 
 /* Margin */
+.mt-0\.5 { margin-top: 0.125rem; }
 .mt-1 { margin-top: 0.25rem; }
 .mt-2 { margin-top: 0.5rem; }
 .mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
 .ml-2 { margin-left: 0.5rem; }
+.ml-6 { margin-left: 1.5rem; }
 .mb-1 { margin-bottom: 0.25rem; }
 .mb-3 { margin-bottom: 0.75rem; }
 .mb-4 { margin-bottom: 1rem; }
@@ -222,7 +224,11 @@ code {
 .gap-4 { gap: 1rem; }
 .gap-6 { gap: 1.5rem; }
 
+/* List style */
+.list-disc { list-style-type: disc; padding-left: 1rem; }
+
 /* Space between */
+.space-y-0\.5 > * + * { margin-top: 0.125rem; }
 .space-y-2 > * + * { margin-top: 0.5rem; }
 .space-y-4 > * + * { margin-top: 1rem; }
 .space-y-6 > * + * { margin-top: 1.5rem; }

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -28,7 +28,7 @@ import useAIStore from '../stores/aiStore';
 import useUIStore from '../stores/uiStore';
 import { formatInlineMarkdown, stripMarkdown } from '../utils/markdownText';
 import { bankCoverage, getBankProcedure, buildProcedureSource, bankSourceUrl } from '../utils/procedureBank';
-import { tailorMarkdown, canUseProfileWithProvider, buildTailorPrompt, tailoredProvenance } from '../utils/procedureTailor';
+import { canUseProfileWithProvider, buildTailorPrompt, tailoredProvenance, deriveStackTargets, describeStackPlan, bankAttachObservation, deterministicTailorUpdate } from '../utils/procedureTailor';
 import { getScoringScale, scoreBand, CMMI_LEVELS } from '../utils/scoringScale';
 import useOrgProfileStore from '../stores/orgProfileStore';
 import OrgProfileWizard from '../components/OrgProfileWizard';
@@ -135,6 +135,7 @@ const Assessments = () => {
   const [useBankProcedures, setUseBankProcedures] = useState(true);
   const [showBankPreview, setShowBankPreview] = useState(false);
   const [tailorWithProfile, setTailorWithProfile] = useState(false);
+  const [adaptStackRefs, setAdaptStackRefs] = useState(false);
   const [showProfileWizard, setShowProfileWizard] = useState(false);
   const [isTailoringItem, setIsTailoringItem] = useState(false);
 
@@ -142,6 +143,13 @@ const Assessments = () => {
   const orgProfile = useOrgProfileStore((s) => s.profile);
   const hasOrgProfile = useOrgProfileStore((s) => s.hasProfile)();
   const cloudConsent = useOrgProfileStore((s) => s.cloudConsent);
+
+  // Deterministic swap plan derived from the profile (no AI): which canned
+  // tool/platform substitutions would fire, as human-readable lines.
+  const stackPlan = useMemo(
+    () => (orgProfile ? describeStackPlan(deriveStackTargets(orgProfile)) : []),
+    [orgProfile]
+  );
   const [generateTestProcedures, setGenerateTestProcedures] = useState(false);
   const [isGeneratingProcedures, setIsGeneratingProcedures] = useState(false);
   const [generatedProcedures, setGeneratedProcedures] = useState({});
@@ -563,6 +571,7 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
     setUseBankProcedures(true);
     setShowBankPreview(false);
     setTailorWithProfile(false);
+    setAdaptStackRefs(false);
     setGenerateTestProcedures(false);
     setIsGeneratingProcedures(false);
     setGeneratedProcedures({});
@@ -597,15 +606,13 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
       const bankEntry = useBankProcedures ? getBankProcedure(itemId) : null;
       if (bankEntry) {
         // Optional deterministic tailoring: substitute the org's name for
-        // the case study's "Alma Security". Tailored text carries the
-        // tailored flag so share export can swap back to pristine.
-        const { text, tailored } = tailorWithProfile && orgProfile
-          ? tailorMarkdown(bankEntry.markdown, orgProfile)
-          : { text: bankEntry.markdown, tailored: false };
-        updateObservation(created.id, itemId, {
-          testProcedures: text,
-          procedureSource: { ...buildProcedureSource(bankEntry.bankId), tailored }
-        });
+        // the case study's "Alma Security" and/or re-aim tool/platform
+        // references at the org's stack (canned maps, no AI). The producer
+        // stamps tailored provenance so share export can swap to pristine.
+        updateObservation(created.id, itemId, bankAttachObservation(bankEntry, orgProfile, {
+          substituteName: tailorWithProfile,
+          adaptStack: adaptStackRefs
+        }));
       } else if (generatedProcedures[itemId]) {
         updateObservation(created.id, itemId, { testProcedures: generatedProcedures[itemId] });
       }
@@ -629,7 +636,7 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
     setCurrentAssessmentId(created.id);
     setView('scope');
     toast.success(`Assessment "${created.name}" created with ${selectedScopeItems.size} items`);
-  }, [newAssessment, createAssessment, selectedScopeItems, useBankProcedures, tailorWithProfile, orgProfile, generatedProcedures, evidenceAnalysis, addToScope, updateObservation, getObservation, setCurrentAssessmentId, resetWizard]);
+  }, [newAssessment, createAssessment, selectedScopeItems, useBankProcedures, tailorWithProfile, adaptStackRefs, orgProfile, generatedProcedures, evidenceAnalysis, addToScope, updateObservation, getObservation, setCurrentAssessmentId, resetWizard]);
 
   const handleSelectAssessment = useCallback((assessment) => {
     setCurrentAssessmentId(assessment.id);
@@ -707,6 +714,31 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
     });
     toast.success(`Community procedure for ${entry.bankId} attached`);
   }, [currentAssessmentId, selectedItemId, updateObservation]);
+
+  // Deterministic tailoring of the selected item's procedure: canned
+  // name + tool/platform substitutions from the org profile. No AI, no
+  // key, nothing leaves the machine. Works on already-attached procedures
+  // so existing assessments benefit without re-creation.
+  const handleTailorDeterministic = useCallback((currentText) => {
+    if (!currentAssessmentId || !selectedItemId || !currentText) return;
+    if (!hasOrgProfile) {
+      toast.error('Set up your organization profile first (Settings → Organization profile).');
+      return;
+    }
+    const existing = getObservation(currentAssessmentId, selectedItemId);
+    // The producer stamps tailored provenance — an untagged tailored
+    // procedure would bypass the share-export pristine swap and leak
+    // profile facts.
+    const result = deterministicTailorUpdate(currentText, existing?.procedureSource, selectedItemId, orgProfile);
+    if (!result) {
+      toast('Nothing to adapt — this procedure already matches your profile. Name your cloud, EDR, or email platform in the org profile to enable swaps.', { duration: 6000 });
+      return;
+    }
+    updateObservation(currentAssessmentId, selectedItemId, result.update);
+    toast.success(result.swapCount > 0
+      ? `Procedure adapted to your environment — ${result.swapCount} reference${result.swapCount === 1 ? '' : 's'} swapped (no AI)`
+      : 'Organization name substituted (no AI)');
+  }, [currentAssessmentId, selectedItemId, hasOrgProfile, orgProfile, getObservation, updateObservation]);
 
   // AI-tailor the selected item's procedure with the org profile.
   // Consent gate: the profile never goes to a CLOUD provider without the
@@ -1466,6 +1498,16 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                         )}
                       </label>
                       <div className="flex items-center gap-3">
+                        {editMode && hasOrgProfile && currentObservation.testProcedures && (
+                          <button
+                            type="button"
+                            onClick={() => handleTailorDeterministic(currentObservation.testProcedures)}
+                            className="text-xs text-amber-700 dark:text-amber-400 flex items-center gap-1 hover:underline"
+                            title="Swap platform/tool references (AWS, SentinelOne, O365, Slack) for your profile's stack using canned mappings — no AI, nothing leaves this machine"
+                          >
+                            <Settings size={12} /> Adapt to my environment
+                          </button>
+                        )}
                         {editMode && hasOrgProfile && currentObservation.testProcedures && (
                           <button
                             type="button"
@@ -2277,10 +2319,34 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                                 Substitute my organization's name into attached procedures
                               </span>
                             </label>
+                            <label className="flex items-start gap-2 mt-2 cursor-pointer">
+                              <input
+                                type="checkbox"
+                                checked={adaptStackRefs}
+                                onChange={(e) => setAdaptStackRefs(e.target.checked)}
+                                className="w-4 h-4 rounded mt-0.5"
+                                disabled={!useBankProcedures || stackPlan.length === 0}
+                              />
+                              <span className="text-sm text-amber-900 dark:text-amber-200">
+                                Adapt tool &amp; platform references to my environment (no AI)
+                              </span>
+                            </label>
+                            {stackPlan.length > 0 ? (
+                              <ul className="text-xs text-amber-700 dark:text-amber-400 mt-1 ml-6 list-disc space-y-0.5">
+                                {stackPlan.map((line) => <li key={line}>{line}</li>)}
+                              </ul>
+                            ) : (
+                              <p className="text-xs text-amber-700 dark:text-amber-400 mt-1 ml-6">
+                                No swaps apply yet — the community procedures are written against an
+                                AWS + SentinelOne + O365 + Slack stack. Select a different cloud
+                                (Google Cloud, Azure, on-premises) or name your EDR / email / chat
+                                platform in the profile to enable canned substitutions.
+                              </p>
+                            )}
                             <p className="text-xs text-amber-700 dark:text-amber-400 mt-1">
                               Uses your saved profile{orgProfile?.orgName ? ` (${orgProfile.orgName})` : ''} —{' '}
                               <button type="button" className="underline" onClick={() => setShowProfileWizard(true)}>edit</button>.
-                              Per-item AI tailoring is available on each requirement after creation.
+                              Both options also work per-requirement after creation ("Adapt to my environment").
                               {!useBankProcedures && ' (Enable community procedures above to tailor them.)'}
                             </p>
                           </>

--- a/src/utils/orgProfileExport.test.js
+++ b/src/utils/orgProfileExport.test.js
@@ -9,7 +9,7 @@
  */
 import { exportAllDataJSON, buildShareableExport, EXPORT_FORMAT_VERSION } from './dataExport';
 import { validateDatabaseExport, importCompleteDatabase } from './dataImport';
-import { tailorMarkdown, canUseProfileWithProvider, tailoredProvenance } from './procedureTailor';
+import { tailorMarkdown, canUseProfileWithProvider, tailoredProvenance, bankAttachObservation } from './procedureTailor';
 import { getBankProcedure, buildProcedureSource } from './procedureBank';
 import useOrgProfileStore from '../stores/orgProfileStore';
 import useAssessmentsStore from '../stores/assessmentsStore';
@@ -127,6 +127,30 @@ describe('org profile in exports', () => {
     const obs = share.data.assessments.find((a) => a.id === assessmentId).observations['CTRL-042'];
     expect(obs.testProcedures).toBe('');
     expect(JSON.stringify(share)).not.toContain(CANARY_JEWEL);
+  });
+
+  test('stack-swap producer: deterministic tool substitutions never leak into default share', () => {
+    // The G8.1 producer path — canned stack swaps reveal profile facts
+    // (their cloud, their EDR vendor) just like AI tailoring does, so the
+    // pristine swap must cover it identically.
+    const stackProfile = {
+      orgName: CANARY_ORG,
+      infrastructure: ['Google Cloud'],
+      securityTools: ['CrowdStrike']
+    };
+    useOrgProfileStore.getState().saveProfile(stackProfile);
+    // Exercise the REAL wizard-attach producer, not a simulation of it —
+    // if it ever stops stamping tailored provenance, this test fails.
+    const produced = bankAttachObservation(getBankProcedure('GV.OC-01'), stackProfile, { substituteName: true, adaptStack: true });
+    expect(produced.procedureSource.tailored).toBe(true);
+    useAssessmentsStore.getState().updateObservation(assessmentId, 'GV.OC-01 Ex1', produced);
+
+    const share = buildShareableExport(stores());
+    const serialized = JSON.stringify(share);
+    const obs = share.data.assessments.find((a) => a.id === assessmentId).observations['GV.OC-01 Ex1'];
+    expect(obs.testProcedures).toBe(pristine);
+    expect(serialized).not.toContain('CrowdStrike');
+    expect(serialized).not.toContain(CANARY_ORG);
   });
 
   test('a tailored observation whose bank entry cannot resolve exports empty text, never the tailored text', () => {

--- a/src/utils/procedureTailor.js
+++ b/src/utils/procedureTailor.js
@@ -2,8 +2,13 @@
  * Tailoring of community test procedures to an organization profile.
  *
  * Two tiers:
- *  - Deterministic (no AI): substitute the org's name for the fictional
- *    "Alma Security" the catalog is written against.
+ *  - Deterministic (no AI, no key, offline): substitute the org's name for
+ *    the fictional "Alma Security" AND re-aim tool/platform references at
+ *    the org's actual stack via curated phrase maps (stackTailorMaps.js) —
+ *    AWS→GCP/Azure/on-prem service analogs, EDR/email/chat product swaps.
+ *    Swaps fire only on explicit profile signals: a cloud swap needs a
+ *    non-AWS cloud selected without AWS; product swaps need the product
+ *    named. No signal → no swap. Never guesses.
  *  - AI (optional): rewrite an attached procedure with profile context via
  *    the configured provider. Cloud providers require explicit consent
  *    (orgProfileStore.cloudConsent) — the profile never leaves the machine
@@ -15,6 +20,7 @@
  */
 
 import { getBankProcedure, buildProcedureSource } from './procedureBank';
+import { CLOUD_TERMS, EDR_PRODUCTS, GOOGLE_EMAIL_TERMS } from './stackTailorMaps';
 
 /**
  * Provenance for AI-tailored output. ALWAYS returns a tailored-marked source:
@@ -41,15 +47,194 @@ export const tailoredProvenance = (existingSource, itemId) => {
   };
 };
 
-/** Deterministic substitution. Returns { text, tailored }. */
-export const tailorMarkdown = (markdown, profile) => {
+/**
+ * Derive deterministic swap targets from the org profile. Detection is
+ * case-insensitive over the infrastructure and securityTools entries;
+ * insertion always uses canonical dictionary strings, never profile text.
+ *
+ * Returns { cloud: 'gcp'|'azure'|'onprem'|null,
+ *           edr: { name, neutral }|null,
+ *           email: 'google'|null,
+ *           chat: 'Microsoft Teams'|'Google Chat'|null }
+ */
+export const deriveStackTargets = (profile) => {
+  const infra = (profile?.infrastructure || []).map(String);
+  const tools = (profile?.securityTools || []).map(String);
+  const all = [...infra, ...tools].map((s) => s.toLowerCase());
+  const has = (...needles) => all.some((s) => needles.some((n) => s.includes(n)));
+
+  // Cloud: swap only when a non-AWS cloud is chosen and AWS is absent.
+  // The bank is AWS-written, so an org that runs AWS needs no cloud swap.
+  // "aws" is matched as a word ("flaws" must not suppress the swap), and
+  // identity products (Azure AD / Entra) are not a platform signal.
+  // Selection order is the profile's persisted chip order (stable), so a
+  // multi-cloud-without-AWS profile deterministically uses its first cloud.
+  let cloud = null;
+  if (!all.some((s) => /\baws\b/.test(s)) && !has('amazon web services')) {
+    for (const chip of infra) {
+      const c = chip.toLowerCase();
+      if (/azure a(d\b|ctive directory)/.test(c) || c.includes('entra')) continue;
+      if (c.includes('google cloud') || /\bgcp\b/.test(c)) { cloud = 'gcp'; break; }
+      if (c.includes('azure')) { cloud = 'azure'; break; }
+    }
+    if (!cloud && has('on-prem', 'on prem', 'data center', 'datacenter')) cloud = 'onprem';
+  }
+
+  // EDR: the first profile entry naming a known product wins (chip order,
+  // consistent with the cloud rule); a generic "EDR" chip neutralizes to a
+  // role noun (never guesses a vendor); SentinelOne named — or nothing
+  // named — keeps the bank's SentinelOne.
+  let edr = null;
+  if (!has('sentinelone', 'sentinel one')) {
+    let product = null;
+    for (const entry of all) {
+      product = EDR_PRODUCTS.find((p) =>
+        p.detect.some((d) => entry.includes(d)) &&
+        !(p.exclude || []).some((x) => entry.includes(x)));
+      if (product) break;
+    }
+    if (product) edr = { name: product.name, neutral: false };
+    else if (has('edr')) edr = { name: 'your EDR platform', neutral: true };
+  }
+
+  // Email: explicit Google Workspace / Gmail signal with no Microsoft-stack
+  // signal. Orgs running both keep the bank's O365 references.
+  let email = null;
+  const google = has('google workspace', 'gmail');
+  const microsoft = has('microsoft 365', 'm365', 'office 365', 'o365', 'exchange', 'outlook');
+  if (google && !microsoft) email = 'google';
+
+  // Chat: swap only when a different platform is explicitly named and
+  // Slack itself is not. Bare "teams" is ordinary prose ("on-call teams")
+  // and never counts as a signal.
+  let chat = null;
+  if (!has('slack')) {
+    if (has('microsoft teams')) chat = 'Microsoft Teams';
+    else if (has('google chat')) chat = 'Google Chat';
+  }
+
+  return { cloud, edr, email, chat };
+};
+
+const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Word-bounded, case-sensitive matcher. Boundaries only where the phrase
+// edge is alphanumeric, so "CloudTrail" never matches inside
+// "CloudTrailLogs" and lowercase paths like EVD-aws-* are never touched.
+const phraseRegExp = (phrase) => {
+  const lead = /^[A-Za-z0-9]/.test(phrase) ? '\\b' : '';
+  const tail = /[A-Za-z0-9]$/.test(phrase) ? '\\b' : '';
+  return new RegExp(lead + escapeRegExp(phrase) + tail, 'g');
+};
+
+/** Compile the ordered substitution rule list for the derived targets. */
+export const buildStackRules = (targets) => {
+  const rules = [];
+  if (targets?.cloud) {
+    for (const [phrase, byTarget] of CLOUD_TERMS) {
+      const to = byTarget[targets.cloud];
+      if (to) rules.push({ from: phrase, to });
+    }
+  }
+  if (targets?.edr) {
+    rules.push({ from: 'Deep Visibility', to: targets.edr.neutral ? 'the EDR telemetry search' : `${targets.edr.name} telemetry search` });
+    rules.push({ from: 'SentinelOne', to: targets.edr.name });
+  }
+  if (targets?.email === 'google') {
+    for (const [from, to] of GOOGLE_EMAIL_TERMS) rules.push({ from, to });
+  }
+  if (targets?.chat) {
+    rules.push({ from: 'Slack', to: targets.chat });
+  }
+  // Longest phrase first — the bare-vendor fallbacks ("AWS", "Amazon")
+  // must never fire inside a service phrase like "AWS Security Hub".
+  rules.sort((a, b) => b.from.length - a.from.length);
+  return rules.map((r) => ({ ...r, re: phraseRegExp(r.from) }));
+};
+
+/** Human-readable summary of what a swap plan will do (wizard disclosure). */
+export const describeStackPlan = (targets) => {
+  const lines = [];
+  if (targets?.cloud === 'gcp') lines.push('AWS services → Google Cloud equivalents (CloudTrail → Cloud Audit Logging, GuardDuty → Security Command Center, S3 → Cloud Storage, …)');
+  if (targets?.cloud === 'azure') lines.push('AWS services → Azure equivalents (CloudTrail → Azure Activity Log, GuardDuty → Microsoft Defender for Cloud, S3 → Blob Storage, …)');
+  if (targets?.cloud === 'onprem') lines.push('AWS services → neutral capability language (cloud consoles have no exact on-premises analog — adapt specifics to your environment)');
+  if (targets?.edr) {
+    lines.push(targets.edr.neutral
+      ? 'SentinelOne → "your EDR platform" (name your EDR product in the profile for an exact swap)'
+      : `SentinelOne → ${targets.edr.name}`);
+  }
+  if (targets?.email === 'google') lines.push('O365 / Microsoft 365 email security → Google Workspace equivalents');
+  if (targets?.chat) lines.push(`Slack → ${targets.chat}`);
+  return lines;
+};
+
+/**
+ * Deterministic substitution. Returns { text, tailored, applied }.
+ * Options: substituteName (default true) — org name for "Alma Security";
+ * adaptStack (default false) — canned tool/platform swaps per the profile.
+ * Existing two-argument callers keep the original name-only behavior.
+ */
+export const tailorMarkdown = (markdown, profile, options = {}) => {
+  const { substituteName = true, adaptStack = false } = options;
+  if (!markdown) return { text: markdown, tailored: false, applied: [] };
+
+  let text = markdown;
+  const applied = [];
+
   const orgName = profile?.orgName?.trim();
-  if (!orgName || !markdown) return { text: markdown, tailored: false };
-  const text = markdown
-    .replace(/Alma Security/g, orgName)
-    .replace(/\bAlma's\b/g, `${orgName}'s`)
-    .replace(/\bAlma\b/g, orgName);
-  return { text, tailored: text !== markdown };
+  if (substituteName && orgName) {
+    text = text
+      .replace(/Alma Security/g, orgName)
+      .replace(/\bAlma's\b/g, `${orgName}'s`)
+      .replace(/\bAlma\b/g, orgName);
+  }
+
+  if (adaptStack && profile) {
+    const rules = buildStackRules(deriveStackTargets(profile));
+    for (const rule of rules) {
+      let count = 0;
+      text = text.replace(rule.re, () => { count += 1; return rule.to; });
+      if (count > 0) applied.push({ from: rule.from, to: rule.to, count });
+    }
+  }
+
+  return { text, tailored: text !== markdown, applied };
+};
+
+/**
+ * Pure producer for the wizard's bank-attach path. Computes the
+ * observation update for one scoped item: bank markdown, optionally
+ * tailored, with provenance stamped HERE — the page is a dumb dispatcher,
+ * so the tailored flag can never be forgotten at a call site.
+ */
+export const bankAttachObservation = (bankEntry, profile, options = {}) => {
+  const { substituteName = false, adaptStack = false } = options;
+  const wantTailor = (substituteName || adaptStack) && profile;
+  const { text, tailored } = wantTailor
+    ? tailorMarkdown(bankEntry.markdown, profile, { substituteName, adaptStack })
+    : { text: bankEntry.markdown, tailored: false };
+  return {
+    testProcedures: text,
+    procedureSource: { ...buildProcedureSource(bankEntry.bankId), tailored }
+  };
+};
+
+/**
+ * Pure producer for the per-item "Adapt to my environment" action.
+ * Returns null when nothing would change; otherwise the observation
+ * update (tailored provenance always stamped) plus the stack-swap count
+ * for the toast.
+ */
+export const deterministicTailorUpdate = (currentText, existingSource, itemId, profile) => {
+  const { text, tailored, applied } = tailorMarkdown(currentText, profile, { substituteName: true, adaptStack: true });
+  if (!tailored) return null;
+  return {
+    update: {
+      testProcedures: text,
+      procedureSource: tailoredProvenance(existingSource, itemId)
+    },
+    swapCount: applied.reduce((n, a) => n + a.count, 0)
+  };
 };
 
 /**

--- a/src/utils/procedureTailor.stack.test.js
+++ b/src/utils/procedureTailor.stack.test.js
@@ -1,0 +1,404 @@
+/**
+ * Deterministic stack-aware tailoring — the canned, no-AI substitution
+ * engine. The community bank is written against AWS + SentinelOne + O365 +
+ * Slack; these tests prove the engine re-aims that stack from org-profile
+ * answers alone, and that it NEVER fires without an explicit signal.
+ */
+import {
+  tailorMarkdown,
+  deriveStackTargets,
+  buildStackRules,
+  describeStackPlan,
+  bankAttachObservation,
+  deterministicTailorUpdate
+} from './procedureTailor';
+import { getBankProcedure } from './procedureBank';
+import bankData from '../data/communityProcedures.json';
+
+const BANK = bankData.procedures;
+const BANK_IDS = Object.keys(BANK);
+
+const gcpProfile = {
+  orgName: 'a16z',
+  infrastructure: ['Google Cloud', 'SaaS-heavy', 'Remote-first endpoints'],
+  securityTools: []
+};
+const azureProfile = { orgName: 'Contoso', infrastructure: ['Azure'], securityTools: [] };
+const onpremProfile = { orgName: 'Steelworks', infrastructure: ['On-premises data center'], securityTools: [] };
+const awsProfile = { orgName: 'Rainforest', infrastructure: ['AWS', 'Kubernetes / containers'], securityTools: [] };
+
+// AWS-stack vocabulary that must be GONE after a cloud swap. Per-target
+// exclusions are deliberate: GCP keeps "KMS" (Cloud KMS) and "VPC Flow
+// Logs" (same product name); bare "IAM" and "WAF" are generic terms kept
+// on every target.
+const BANNED_COMMON = [
+  /\bAWS\b/, /\bAmazon\b/, /\bCloudTrail\b/, /\bGuardDuty\b/, /\bSecurity Hub\b/,
+  /\bS3\b/, /\bEC2\b/, /\bEKS\b/, /\bRDS\b/, /\bLambda\b/, /\bCloudWatch\b/,
+  /\bAthena\b/, /\bCloudFront\b/, /\bRoute 53\b/, /\bSNS\b/, /\bSystems Manager\b/,
+  /\bShield\b/,
+  // Fail-loud reserve: AWS services with ZERO bank hits today. If a future
+  // bank regeneration introduces one, the sweep goes red and forces a map
+  // entry — unknown unknowns become caught knowns.
+  /\bSecrets Manager\b/, /\bDynamoDB\b/, /\bRedshift\b/, /\bMacie\b/, /\bCognito\b/,
+  /\bCloudFormation\b/, /\bFargate\b/, /\bKinesis\b/, /\bSQS\b/, /\bElastiCache\b/
+];
+// Grammar gates: article/determiner damage a naive noun swap causes.
+// Capitals-only vowel checks so ordinary prose ("a one-time", "an hour")
+// can never false-positive; acronyms ("an NSG", "an SP 800-53") are
+// excluded by requiring a lowercase second letter.
+const GRAMMAR_GATES = [
+  /\b[Aa]n? the\b/, /\bthe the\b/, /\ban [BCDFGJKLMNPQRSTVWXZ][a-z]/, /\ba [AEIO][a-z]/
+];
+// AWS-networking vocabulary that Azure/on-prem must also scrub (GCP keeps
+// VPC — it is the real GCP product name; its firewall analog still bans
+// "security group").
+const BANNED = {
+  gcp: [...BANNED_COMMON, /\bsecurity groups?\b/, ...GRAMMAR_GATES],
+  azure: [...BANNED_COMMON, /\bKMS\b/, /\bVPCs?\b/, /\bsecurity groups?\b/, ...GRAMMAR_GATES],
+  onprem: [...BANNED_COMMON, /\bKMS\b/, /\bVPCs?\b/, /\bsecurity groups?\b/, ...GRAMMAR_GATES]
+};
+// The bank's SentinelOne/O365/Slack vocabulary, banned when the profile
+// names replacements for all of it.
+const BANNED_TOOLS = [
+  /\bSentinelOne\b/, /\bDeep Visibility\b/, /\bO365\b/, /\bMicrosoft 365\b/,
+  /\bM365\b/, /\bOffice 365\b/, /\bATP\b/, /\bSlack\b/
+];
+const fullStackProfile = {
+  orgName: 'a16z',
+  infrastructure: ['Google Cloud', 'Google Workspace', 'Microsoft Teams'],
+  securityTools: ['CrowdStrike']
+};
+
+const sweep = (profile, bannedList) => {
+  const failures = [];
+  for (const id of BANK_IDS) {
+    const { text } = tailorMarkdown(BANK[id].markdown, profile, { substituteName: false, adaptStack: true });
+    for (const re of bannedList) {
+      const m = text.match(re);
+      if (m) failures.push(`${id}: "${m[0]}" survived (${re})`);
+    }
+  }
+  return failures;
+};
+
+describe('deriveStackTargets — explicit signals only, never guesses', () => {
+  test('Google Cloud without AWS → gcp target (the reported field case)', () => {
+    expect(deriveStackTargets(gcpProfile).cloud).toBe('gcp');
+  });
+
+  test('GCP alias and case-insensitivity', () => {
+    expect(deriveStackTargets({ infrastructure: ['gcp'] }).cloud).toBe('gcp');
+    expect(deriveStackTargets({ infrastructure: ['GOOGLE CLOUD'] }).cloud).toBe('gcp');
+  });
+
+  test('Azure without AWS → azure target', () => {
+    expect(deriveStackTargets(azureProfile).cloud).toBe('azure');
+  });
+
+  test('AWS selected → NO cloud swap, even alongside another cloud', () => {
+    expect(deriveStackTargets(awsProfile).cloud).toBeNull();
+    expect(deriveStackTargets({ infrastructure: ['AWS', 'Google Cloud'] }).cloud).toBeNull();
+    expect(deriveStackTargets({ infrastructure: ['Google Cloud', 'AWS'] }).cloud).toBeNull();
+  });
+
+  test('multi-cloud without AWS → first selected chip wins, deterministically', () => {
+    expect(deriveStackTargets({ infrastructure: ['Azure', 'Google Cloud'] }).cloud).toBe('azure');
+    expect(deriveStackTargets({ infrastructure: ['Google Cloud', 'Azure'] }).cloud).toBe('gcp');
+  });
+
+  test('on-premises only → onprem neutralization target', () => {
+    expect(deriveStackTargets(onpremProfile).cloud).toBe('onprem');
+  });
+
+  test('no infrastructure answer → no cloud swap', () => {
+    expect(deriveStackTargets({ infrastructure: ['SaaS-heavy'] }).cloud).toBeNull();
+    expect(deriveStackTargets({}).cloud).toBeNull();
+  });
+
+  test('named EDR product → exact swap target with canonical name', () => {
+    const t = deriveStackTargets({ securityTools: ['CrowdStrike'] });
+    expect(t.edr).toEqual({ name: 'CrowdStrike Falcon', neutral: false });
+  });
+
+  test('generic EDR chip → neutral role noun, never a guessed vendor', () => {
+    const t = deriveStackTargets({ securityTools: ['EDR'] });
+    expect(t.edr).toEqual({ name: 'your EDR platform', neutral: true });
+  });
+
+  test('SentinelOne named → bank references kept (no swap)', () => {
+    expect(deriveStackTargets({ securityTools: ['SentinelOne', 'EDR'] }).edr).toBeNull();
+  });
+
+  test('Microsoft Sentinel (a SIEM) never triggers the EDR swap', () => {
+    expect(deriveStackTargets({ securityTools: ['Microsoft Sentinel'] }).edr).toBeNull();
+  });
+
+  test('Google Workspace signal → google email target; mixed-stack keeps O365', () => {
+    expect(deriveStackTargets({ infrastructure: ['Google Workspace'] }).email).toBe('google');
+    expect(deriveStackTargets({ infrastructure: ['Google Workspace', 'Microsoft 365'] }).email).toBeNull();
+    expect(deriveStackTargets({ infrastructure: [] }).email).toBeNull();
+  });
+
+  test('chat: Teams named → swap; Slack named → keep; nothing named → keep', () => {
+    expect(deriveStackTargets({ infrastructure: ['Microsoft Teams'] }).chat).toBe('Microsoft Teams');
+    expect(deriveStackTargets({ infrastructure: ['Microsoft Teams', 'Slack'] }).chat).toBeNull();
+    expect(deriveStackTargets({ infrastructure: ['Google Chat'] }).chat).toBe('Google Chat');
+    expect(deriveStackTargets({}).chat).toBeNull();
+  });
+});
+
+describe('full-bank sweeps — zero AWS-stack residue after a cloud swap', () => {
+  test(`GCP profile scrubs the AWS vocabulary from all ${BANK_IDS.length} bank procedures`, () => {
+    expect(sweep(gcpProfile, BANNED.gcp)).toEqual([]);
+  });
+
+  test('Azure profile — same sweep (incl. VPC/security-group vocabulary)', () => {
+    expect(sweep(azureProfile, BANNED.azure)).toEqual([]);
+  });
+
+  test('on-prem profile — same sweep (capability-language neutralization)', () => {
+    expect(sweep(onpremProfile, BANNED.onprem)).toEqual([]);
+  });
+
+  test('full-stack profile also scrubs SentinelOne / O365 / Slack across the whole bank', () => {
+    expect(sweep(fullStackProfile, [...BANNED.gcp, ...BANNED_TOOLS])).toEqual([]);
+  });
+
+  test('AWS profile — every bank procedure passes through byte-identical', () => {
+    for (const id of BANK_IDS) {
+      const { text, tailored } = tailorMarkdown(BANK[id].markdown, awsProfile, { substituteName: false, adaptStack: true });
+      expect(tailored).toBe(false);
+      expect(text).toBe(BANK[id].markdown);
+    }
+  });
+});
+
+describe('the reported field case — DE.AE-02 with a GCP profile', () => {
+  const result = tailorMarkdown(BANK['DE.AE-02'].markdown, gcpProfile, { substituteName: false, adaptStack: true });
+
+  test('reads as a Google Cloud procedure', () => {
+    expect(result.tailored).toBe(true);
+    expect(result.text).toContain('Cloud Audit Logging');
+    expect(result.text).toContain('Security Command Center');
+    expect(result.text).not.toMatch(/\bAWS\b|\bGuardDuty\b|\bCloudTrail\b/);
+  });
+
+  test('honest scope: SentinelOne and O365 stay when no EDR/email signal exists', () => {
+    // The profile names only a cloud — swapping the EDR or email platform
+    // would be a guess, and the engine never guesses.
+    expect(result.text).toContain('SentinelOne');
+    expect(result.text).toContain('O365');
+  });
+
+  test('applied[] reports what changed', () => {
+    const total = result.applied.reduce((n, a) => n + a.count, 0);
+    expect(total).toBeGreaterThan(5);
+    expect(result.applied.some((a) => a.from === 'GuardDuty' && a.to === 'Security Command Center')).toBe(true);
+  });
+});
+
+describe('substitution safety', () => {
+  test('longest phrase wins — no partial-overlap corruption', () => {
+    const { text } = tailorMarkdown(
+      'Check AWS Security Hub and AWS CloudTrail, then AWS console access.',
+      gcpProfile,
+      { substituteName: false, adaptStack: true }
+    );
+    expect(text).toBe('Check Security Command Center and Cloud Audit Logging, then Google Cloud console access.');
+  });
+
+  test('case-sensitive + word-bounded: evidence paths and identifiers untouched', () => {
+    const { text } = tailorMarkdown(
+      'See [evidence](../../5_Artifacts/Evidence/EVD-aws-config-compliance.md) and the CloudTrailLogs helper; laws and flaws unchanged.',
+      gcpProfile,
+      { substituteName: false, adaptStack: true }
+    );
+    expect(text).toContain('EVD-aws-config-compliance.md');
+    expect(text).toContain('CloudTrailLogs');
+    expect(text).toContain('laws and flaws');
+  });
+
+  test('idempotent — re-tailoring tailored output is a no-op (all procedures, all swap families)', () => {
+    // Doubles as the rule-feeding property test: no rule's replacement may
+    // re-trigger a later rule on a second pass.
+    for (const id of BANK_IDS) {
+      const once = tailorMarkdown(BANK[id].markdown, fullStackProfile, { adaptStack: true });
+      const twice = tailorMarkdown(once.text, fullStackProfile, { adaptStack: true });
+      expect(twice.text).toBe(once.text);
+    }
+  });
+
+  test('EDR swap: SentinelOne → named product incl. Deep Visibility', () => {
+    const profile = { securityTools: ['CrowdStrike Falcon'] };
+    const { text } = tailorMarkdown(
+      'SentinelOne EDR detections and Deep Visibility queries; SentinelOne MDR escalation.',
+      profile,
+      { substituteName: false, adaptStack: true }
+    );
+    expect(text).toBe('CrowdStrike Falcon EDR detections and CrowdStrike Falcon telemetry search queries; CrowdStrike Falcon MDR escalation.');
+  });
+
+  test('generic-EDR neutralization: role noun, not a vendor guess', () => {
+    const { text } = tailorMarkdown(
+      'Review SentinelOne exclusions and Deep Visibility coverage.',
+      { securityTools: ['EDR'] },
+      { substituteName: false, adaptStack: true }
+    );
+    expect(text).toBe('Review your EDR platform exclusions and the EDR telemetry search coverage.');
+  });
+
+  test('email swap on Google Workspace signal', () => {
+    const { text } = tailorMarkdown(
+      'O365 ATP policy configuration; O365 unified audit log retention; Microsoft 365 licensing.',
+      { infrastructure: ['Google Workspace'] },
+      { substituteName: false, adaptStack: true }
+    );
+    expect(text).toContain('Google Workspace email protection policy configuration');
+    expect(text).toContain('Google Workspace unified audit log retention');
+    expect(text).not.toMatch(/O365|Microsoft 365/);
+  });
+
+  test('chat swap: Slack → Microsoft Teams only when Teams is named', () => {
+    const teams = tailorMarkdown('Escalate via Slack workspace audit logs.', { infrastructure: ['Microsoft Teams'] }, { substituteName: false, adaptStack: true });
+    expect(teams.text).toBe('Escalate via Microsoft Teams workspace audit logs.');
+    const nothing = tailorMarkdown('Escalate via Slack.', {}, { substituteName: false, adaptStack: true });
+    expect(nothing.text).toBe('Escalate via Slack.');
+  });
+
+  test('backward compatibility: two-argument call stays name-only', () => {
+    const { text } = tailorMarkdown('AWS CloudTrail at Alma Security.', { orgName: 'Acme', infrastructure: ['Google Cloud'] });
+    expect(text).toBe('AWS CloudTrail at Acme.');
+  });
+
+  test('name + stack combine in one call', () => {
+    const { text, tailored } = tailorMarkdown(
+      "Alma Security's GuardDuty baseline.",
+      gcpProfile,
+      { substituteName: true, adaptStack: true }
+    );
+    expect(tailored).toBe(true);
+    expect(text).toBe("a16z's Security Command Center baseline.");
+  });
+});
+
+describe('swap-plan disclosure (wizard card)', () => {
+  test('GCP profile discloses the cloud swap', () => {
+    const lines = describeStackPlan(deriveStackTargets(gcpProfile));
+    expect(lines.some((l) => l.includes('Google Cloud equivalents'))).toBe(true);
+  });
+
+  test('azure / onprem / product-EDR / email / chat lines all render', () => {
+    expect(describeStackPlan(deriveStackTargets(azureProfile)).some((l) => l.includes('Azure equivalents'))).toBe(true);
+    expect(describeStackPlan(deriveStackTargets(onpremProfile)).some((l) => l.includes('neutral capability language'))).toBe(true);
+    const full = describeStackPlan(deriveStackTargets(fullStackProfile));
+    expect(full.some((l) => l.includes('SentinelOne → CrowdStrike Falcon'))).toBe(true);
+    expect(full.some((l) => l.includes('Google Workspace equivalents'))).toBe(true);
+    expect(full.some((l) => l.includes('Slack → Microsoft Teams'))).toBe(true);
+  });
+
+  test('no signals → empty plan (the card explains how to enable swaps)', () => {
+    expect(describeStackPlan(deriveStackTargets({ infrastructure: ['SaaS-heavy'] }))).toEqual([]);
+    expect(describeStackPlan(deriveStackTargets(awsProfile))).toEqual([]);
+  });
+
+  test('neutral EDR line teaches how to get an exact swap', () => {
+    const lines = describeStackPlan(deriveStackTargets({ securityTools: ['EDR'] }));
+    expect(lines.some((l) => l.includes('name your EDR product'))).toBe(true);
+  });
+});
+
+describe('buildStackRules', () => {
+  test('rules are compiled longest-first', () => {
+    const rules = buildStackRules({ cloud: 'gcp', edr: null, email: null, chat: null });
+    const lengths = rules.map((r) => r.from.length);
+    expect([...lengths].sort((a, b) => b - a)).toEqual(lengths);
+  });
+
+  test('no targets → no rules', () => {
+    expect(buildStackRules({ cloud: null, edr: null, email: null, chat: null })).toEqual([]);
+  });
+});
+
+describe('detection false-positive locks (reviewer-caught ambiguous signals)', () => {
+  test('"aws" as a substring never suppresses the cloud swap ("flaws" trap)', () => {
+    const t = deriveStackTargets({ infrastructure: ['Google Cloud'], securityTools: ['flaws.cloud training'] });
+    expect(t.cloud).toBe('gcp');
+  });
+
+  test('spelled-out "Amazon Web Services" does suppress it', () => {
+    expect(deriveStackTargets({ infrastructure: ['Google Cloud', 'Amazon Web Services'] }).cloud).toBeNull();
+  });
+
+  test('identity chips (Azure AD / Entra) are not a cloud-platform signal', () => {
+    expect(deriveStackTargets({ infrastructure: ['On-premises data center', 'Azure AD'] }).cloud).toBe('onprem');
+    expect(deriveStackTargets({ infrastructure: ['Entra ID'] }).cloud).toBeNull();
+    expect(deriveStackTargets({ infrastructure: ['Azure Active Directory', 'Google Cloud'] }).cloud).toBe('gcp');
+    expect(deriveStackTargets({ infrastructure: ['Azure'] }).cloud).toBe('azure');
+  });
+
+  test('an Elastic SIEM chip never re-brands the EDR; endpoint-flavored Elastic does', () => {
+    expect(deriveStackTargets({ securityTools: ['Elastic SIEM'] }).edr).toBeNull();
+    expect(deriveStackTargets({ securityTools: ['Elastic Defend'] }).edr).toEqual({ name: 'Elastic Defend', neutral: false });
+  });
+
+  test('Defender for Cloud (CSPM) and Cortex XSOAR (SOAR) never trigger the EDR swap', () => {
+    expect(deriveStackTargets({ securityTools: ['Microsoft Defender for Cloud'] }).edr).toBeNull();
+    expect(deriveStackTargets({ securityTools: ['Cortex XSOAR'] }).edr).toBeNull();
+    expect(deriveStackTargets({ securityTools: ['Microsoft Defender'] }).edr)
+      .toEqual({ name: 'Microsoft Defender for Endpoint', neutral: false });
+    expect(deriveStackTargets({ securityTools: ['Cortex XDR'] }).edr)
+      .toEqual({ name: 'Cortex XDR', neutral: false });
+  });
+
+  test('bare "teams" in prose is not a chat signal; only "Microsoft Teams" is', () => {
+    expect(deriveStackTargets({ securityTools: ['on-call response teams tooling'] }).chat).toBeNull();
+    expect(deriveStackTargets({ infrastructure: ['Microsoft Teams'] }).chat).toBe('Microsoft Teams');
+  });
+
+  test('EDR priority follows profile entry order, consistent with the cloud rule', () => {
+    expect(deriveStackTargets({ securityTools: ['Tanium', 'CrowdStrike'] }).edr.name).toBe('Tanium');
+    expect(deriveStackTargets({ securityTools: ['CrowdStrike', 'Tanium'] }).edr.name).toBe('CrowdStrike Falcon');
+  });
+});
+
+describe('producer paths — provenance enforced at the producer', () => {
+  const entry = getBankProcedure('DE.AE-02');
+
+  test('bank attach with adaptStack: tailored text + tailored:true provenance', () => {
+    const obs = bankAttachObservation(entry, gcpProfile, { substituteName: false, adaptStack: true });
+    expect(obs.testProcedures).toContain('Security Command Center');
+    expect(obs.procedureSource).toMatchObject({ bank: 'community', bankId: 'DE.AE-02', tailored: true });
+  });
+
+  test('bank attach pristine: byte-identical text, tailored:false', () => {
+    const obs = bankAttachObservation(entry, gcpProfile, { substituteName: false, adaptStack: false });
+    expect(obs.testProcedures).toBe(entry.markdown);
+    expect(obs.procedureSource.tailored).toBe(false);
+  });
+
+  test('flag mapping is not transposed: substituteName↛stack, adaptStack↛name', () => {
+    const nameOnly = bankAttachObservation(entry, gcpProfile, { substituteName: true, adaptStack: false });
+    expect(nameOnly.testProcedures).not.toContain('Alma Security');
+    expect(nameOnly.testProcedures).toContain('AWS');
+    const stackOnly = bankAttachObservation(entry, gcpProfile, { substituteName: false, adaptStack: true });
+    expect(stackOnly.testProcedures).toContain('Alma Security');
+    expect(stackOnly.testProcedures).not.toMatch(/\bAWS\b/);
+  });
+
+  test('per-item adapt: update carries tailored provenance + stack swap count', () => {
+    const result = deterministicTailorUpdate(entry.markdown, undefined, 'DE.AE-02 Ex1', gcpProfile);
+    expect(result.update.procedureSource).toMatchObject({ bank: 'community', bankId: 'DE.AE-02', tailored: true });
+    expect(result.swapCount).toBeGreaterThan(5);
+  });
+
+  test('per-item adapt: name-only change reports swapCount 0 (drives the toast wording)', () => {
+    const result = deterministicTailorUpdate('Alma Security policy review.', undefined, 'DE.AE-02 Ex1', { orgName: 'Acme', infrastructure: ['AWS'] });
+    expect(result.update.testProcedures).toBe('Acme policy review.');
+    expect(result.swapCount).toBe(0);
+    expect(result.update.procedureSource.tailored).toBe(true);
+  });
+
+  test('per-item adapt: true no-op returns null (nothing written)', () => {
+    expect(deterministicTailorUpdate('Generic text.', undefined, 'DE.AE-02 Ex1', { infrastructure: ['AWS'] })).toBeNull();
+  });
+});

--- a/src/utils/stackTailorMaps.js
+++ b/src/utils/stackTailorMaps.js
@@ -1,0 +1,161 @@
+/**
+ * Canned substitution maps for deterministic stack-aware tailoring.
+ *
+ * The community bank is written against the case study's fictional stack:
+ * AWS + SentinelOne EDR + O365 email + Slack. These tables let the app
+ * re-aim tool and platform references at the organization's ACTUAL stack
+ * purely by string substitution — no AI, no API key, fully offline.
+ *
+ * Authorship rules (see procedureTailor.js for the engine):
+ *  - Service names map to their real analog on the target platform, never
+ *    a bare vendor swap ("GCP GuardDuty" is not a thing).
+ *  - Longest phrase wins: the engine compiles these longest-first so the
+ *    bare "AWS" fallback never fires inside "AWS Security Hub".
+ *  - Matching is case-sensitive and word-bounded, so evidence file paths
+ *    (EVD-aws-*.md) and identifiers pass through untouched.
+ *  - Replacements are canonical dictionary strings only — profile free
+ *    text is used for DETECTION, never inserted into procedure bodies.
+ *  - On-prem gets capability-language neutralization, not fake console
+ *    steps: managed-cloud primitives have no 1:1 on-prem analog.
+ */
+
+/**
+ * Cloud term map. Each entry: [phrase, { gcp, azure, onprem }].
+ * A null target means "keep the phrase as-is for that platform"
+ * (e.g., GCP also calls them VPC Flow Logs).
+ * Order here is documentation; the engine sorts longest-first anyway.
+ */
+export const CLOUD_TERMS = [
+  // Audit logging
+  ['AWS CloudTrail', { gcp: 'Cloud Audit Logging', azure: 'Azure Activity Log', onprem: 'central audit logging' }],
+  ['CloudTrail', { gcp: 'Cloud Audit Logging', azure: 'Azure Activity Log', onprem: 'central audit logging' }],
+
+  // Threat detection / findings. The combined phrase keeps the common
+  // "GuardDuty findings report from AWS Security Hub" sentence from
+  // collapsing into a double "Security Command Center". The article
+  // variant keeps "a GuardDuty finding" grammatical on-prem.
+  ['GuardDuty findings report from AWS Security Hub', { gcp: 'Security Command Center findings report', azure: 'Microsoft Defender for Cloud findings report', onprem: 'threat-detection findings report' }],
+  ['a GuardDuty', { gcp: null, azure: null, onprem: 'a threat-detection' }],
+  ['Amazon GuardDuty', { gcp: 'Security Command Center', azure: 'Microsoft Defender for Cloud', onprem: 'threat-detection tooling' }],
+  ['AWS GuardDuty', { gcp: 'Security Command Center', azure: 'Microsoft Defender for Cloud', onprem: 'threat-detection tooling' }],
+  ['GuardDuty', { gcp: 'Security Command Center', azure: 'Microsoft Defender for Cloud', onprem: 'threat-detection tooling' }],
+  ['AWS Security Hub', { gcp: 'Security Command Center', azure: 'Microsoft Defender for Cloud', onprem: 'security-findings tooling' }],
+
+  // Configuration compliance
+  ['AWS Config rules', { gcp: 'Security Health Analytics detectors', azure: 'Azure Policy definitions', onprem: 'configuration-baseline rules' }],
+  ['AWS Config Compliance', { gcp: 'Security Health Analytics Compliance', azure: 'Azure Policy Compliance', onprem: 'Configuration-Baseline Compliance' }],
+  ['AWS Config compliance', { gcp: 'Security Health Analytics compliance', azure: 'Azure Policy compliance', onprem: 'configuration-baseline compliance' }],
+  ['AWS Config', { gcp: 'Security Health Analytics', azure: 'Azure Policy', onprem: 'configuration-baseline scanning' }],
+
+  // Network
+  ['AWS VPC Flow Logs', { gcp: 'VPC Flow Logs', azure: 'NSG flow logs', onprem: 'network flow logs' }],
+  ['VPC Flow Logs', { gcp: null, azure: 'NSG flow logs', onprem: 'network flow logs' }],
+  ['VPC Flow Log', { gcp: null, azure: 'NSG flow log', onprem: 'network flow log' }],
+  ['AWS VPC', { gcp: 'VPC networking', azure: 'Azure VNet networking', onprem: 'internal networking' }],
+  ['Security Group and Network ACL', { gcp: 'VPC firewall rule and firewall policy', azure: 'NSG and Azure Firewall rule', onprem: 'firewall rule and ACL' }],
+  ['VPC security group rules', { gcp: 'VPC firewall rules', azure: 'NSG rules', onprem: 'internal firewall rules' }],
+  ['VPC endpoints', { gcp: null, azure: 'private endpoints', onprem: 'internal service endpoints' }],
+  ['VPCs', { gcp: null, azure: 'VNets', onprem: 'network segments' }],
+  ['VPC', { gcp: null, azure: 'VNet', onprem: 'internal network' }],
+  ['security groups', { gcp: 'firewall rules', azure: 'NSGs', onprem: 'internal firewall rules' }],
+  ['security group', { gcp: 'firewall rule', azure: 'NSG', onprem: 'internal firewall rule' }],
+
+  // Storage & data
+  ['AWS S3 buckets', { gcp: 'Cloud Storage buckets', azure: 'Blob Storage containers', onprem: 'file storage locations' }],
+  ['AWS S3 bucket', { gcp: 'Cloud Storage bucket', azure: 'Blob Storage container', onprem: 'file storage location' }],
+  ['S3 buckets', { gcp: 'Cloud Storage buckets', azure: 'Blob Storage containers', onprem: 'file storage locations' }],
+  ['S3 bucket', { gcp: 'Cloud Storage bucket', azure: 'Blob Storage container', onprem: 'file storage location' }],
+  ['AWS S3', { gcp: 'Cloud Storage', azure: 'Azure Blob Storage', onprem: 'file storage' }],
+  ['S3', { gcp: 'Cloud Storage', azure: 'Blob Storage', onprem: 'file storage' }],
+  ['AWS RDS', { gcp: 'Cloud SQL', azure: 'Azure SQL Database', onprem: 'database servers' }],
+  ['RDS', { gcp: 'Cloud SQL', azure: 'Azure SQL Database', onprem: 'database servers' }],
+  ['AWS KMS', { gcp: 'Cloud KMS', azure: 'Azure Key Vault', onprem: 'enterprise key management' }],
+  ['KMS', { gcp: null, azure: 'Key Vault', onprem: 'key-management system' }],
+
+  // Compute
+  ['EC2', { gcp: 'Compute Engine', azure: 'Azure Virtual Machines', onprem: 'virtual machine' }],
+  ['EKS', { gcp: 'GKE', azure: 'AKS', onprem: 'Kubernetes' }],
+  ['Lambda', { gcp: 'Cloud Functions', azure: 'Azure Functions', onprem: 'scheduled automation jobs' }],
+  ['Amazon Linux 2', { gcp: 'Container-Optimized OS', azure: 'Azure-hardened base images', onprem: 'hardened base images' }],
+
+  // Monitoring & operations. The article variants keep "a CloudWatch Logs
+  // Insights query" / "an Athena query" grammatical after the swap.
+  ['a CloudWatch Logs Insights query', { gcp: 'a Cloud Logging query', azure: 'a Log Analytics query', onprem: 'a monitoring-stack log query' }],
+  ['CloudWatch', { gcp: 'Cloud Monitoring', azure: 'Azure Monitor', onprem: 'monitoring tooling' }],
+  ['AWS Systems Manager', { gcp: 'VM Manager', azure: 'Azure Automation', onprem: 'endpoint-management tooling' }],
+  ['Systems Manager', { gcp: 'VM Manager', azure: 'Azure Automation', onprem: 'endpoint-management tooling' }],
+  ['AWS Inspector', { gcp: 'Security Command Center vulnerability scanning', azure: 'Microsoft Defender vulnerability assessment', onprem: 'vulnerability scanning' }],
+  ['an Athena query', { gcp: 'a BigQuery query', azure: 'a Log Analytics query', onprem: 'a log-tooling query' }],
+  ['Athena', { gcp: 'BigQuery', azure: 'Log Analytics', onprem: 'log-query tooling' }],
+  ['AWS Shield', { gcp: 'Cloud Armor DDoS protection', azure: 'Azure DDoS Protection', onprem: 'upstream DDoS protection' }],
+  ['AWS WAF', { gcp: 'Cloud Armor', azure: 'Azure WAF', onprem: 'WAF appliance' }],
+  ['CloudFront', { gcp: 'Cloud CDN', azure: 'Azure Front Door', onprem: 'CDN' }],
+  ['Route 53', { gcp: 'Cloud DNS', azure: 'Azure DNS', onprem: 'DNS infrastructure' }],
+  ['SNS notification', { gcp: 'Cloud Monitoring notification', azure: 'Azure Monitor action-group', onprem: 'alert notification' }],
+  ['SNS', { gcp: 'Pub/Sub', azure: 'Azure Monitor alerting', onprem: 'alerting pipeline' }],
+
+  // Governance, identity, account structure
+  ['AWS Organizations', { gcp: 'Google Cloud organization hierarchy', azure: 'Azure management groups', onprem: 'environment inventory' }],
+  ['AWS accounts', { gcp: 'Google Cloud projects', azure: 'Azure subscriptions', onprem: 'internal environments' }],
+  ['AWS account', { gcp: 'Google Cloud project', azure: 'Azure subscription', onprem: 'internal environment' }],
+  ['AWS multi-AZ', { gcp: 'Google Cloud multi-zone', azure: 'Azure zone-redundant', onprem: 'multi-site' }],
+  ['an AWS-centric', { gcp: 'a Google Cloud-centric', azure: 'an Azure-centric', onprem: 'an infrastructure-dependent' }],
+  ["AWS's", { gcp: "Google Cloud's", azure: "Azure's", onprem: "the hosting provider's" }],
+  ['AWS IAM', { gcp: 'Cloud IAM', azure: 'Microsoft Entra ID', onprem: 'Active Directory' }],
+  ['AWS Marketplace', { gcp: 'Google Cloud Marketplace', azure: 'Azure Marketplace', onprem: 'software procurement records' }],
+  ['AWS SOC 2 Type II reports', { gcp: "Google Cloud's SOC 2 Type II reports", azure: "Azure's SOC 2 Type II reports", onprem: "the hosting provider's SOC 2 Type II reports" }],
+  ['AWS SOC 2 Type II report', { gcp: "Google Cloud's SOC 2 Type II report", azure: "Azure's SOC 2 Type II report", onprem: "the hosting provider's SOC 2 Type II report" }],
+  ['AWS Security Bulletins', { gcp: 'Google Cloud security bulletins', azure: 'MSRC security advisories', onprem: 'vendor security bulletins' }],
+  ['AWS service health dashboard', { gcp: 'Google Cloud Service Health dashboard', azure: 'Azure Service Health dashboard', onprem: 'vendor status pages' }],
+  ['AWS shared responsibility', { gcp: 'Google Cloud shared responsibility', azure: 'Azure shared responsibility', onprem: 'provider shared-responsibility' }],
+  ['AWS resource tags', { gcp: 'Google Cloud resource labels', azure: 'Azure resource tags', onprem: 'asset inventory tags' }],
+  ['AWS resource tag', { gcp: 'Google Cloud resource label', azure: 'Azure resource tag', onprem: 'asset inventory tag' }],
+  ['AWS Tagging Completeness', { gcp: 'Google Cloud Label Completeness', azure: 'Azure Tag Completeness', onprem: 'Asset Tag Completeness' }],
+  ['AWS Tag Compliance Report', { gcp: 'Google Cloud Label Compliance Report', azure: 'Azure Tag Compliance Report', onprem: 'Asset Tag Compliance Report' }],
+  ['AWS tags', { gcp: 'Google Cloud labels', azure: 'Azure tags', onprem: 'asset tags' }],
+
+  // Vendor-noun fallbacks — the engine's longest-first ordering guarantees
+  // every service-specific phrase above has already been consumed.
+  ['Amazon', { gcp: 'Google', azure: 'Microsoft', onprem: 'the vendor' }],
+  ['AWS', { gcp: 'Google Cloud', azure: 'Azure', onprem: 'on-premises' }]
+];
+
+/**
+ * Known EDR products. `detect` strings are matched case-insensitively
+ * against the profile's securityTools/infrastructure entries; `name` is
+ * the canonical string inserted into procedures. An entry whose chip also
+ * matches `exclude` does not count — that's how "Microsoft Defender for
+ * Cloud" (CSPM) and "Cortex XSOAR" (SOAR) avoid triggering an EDR swap.
+ * "sentinel" alone is deliberately absent — "Microsoft Sentinel" is a
+ * SIEM, not an EDR — and "elastic" requires an endpoint-flavored name so
+ * an "Elastic SIEM" chip never re-brands the EDR.
+ */
+export const EDR_PRODUCTS = [
+  { name: 'CrowdStrike Falcon', detect: ['crowdstrike', 'falcon'] },
+  { name: 'Microsoft Defender for Endpoint', detect: ['defender'], exclude: ['defender for cloud'] },
+  { name: 'Cortex XDR', detect: ['cortex'], exclude: ['xsoar'] },
+  { name: 'Carbon Black', detect: ['carbon black', 'carbonblack'] },
+  { name: 'Elastic Defend', detect: ['elastic defend', 'elastic security', 'elastic agent', 'elastic edr'] },
+  { name: 'Sophos Intercept X', detect: ['sophos'] },
+  { name: 'Trend Vision One', detect: ['trend micro', 'trend vision', 'vision one'] },
+  { name: 'Huntress', detect: ['huntress'] },
+  { name: 'Cybereason', detect: ['cybereason'] },
+  { name: 'Tanium', detect: ['tanium'] }
+];
+
+/**
+ * O365 → Google Workspace terms, applied only on an explicit Google
+ * Workspace / Gmail signal with no Microsoft-stack signal.
+ */
+export const GOOGLE_EMAIL_TERMS = [
+  ['O365 Advanced Threat Protection', 'Google Workspace email protection'],
+  ['O365 ATP', 'Google Workspace email protection'],
+  ['O365-protected email', 'Google Workspace-protected email'],
+  ['Microsoft Threat Intelligence', 'Google threat intelligence'],
+  ['Microsoft 365', 'Google Workspace'],
+  ['Office 365', 'Google Workspace'],
+  ['M365', 'Google Workspace'],
+  ['O365', 'Google Workspace'],
+  ['Advanced Threat Protection', 'advanced email protection'],
+  ['ATP', 'email protection']
+];


### PR DESCRIPTION
The org-profile tailoring tier only substituted the organization name — a profile naming Google Cloud still produced procedures reading 'AWS CloudTrail, GuardDuty, SentinelOne'. This adds a curated substitution engine driven by the profile answers:

- **Cloud**: AWS services map to real analogs (CloudTrail → Cloud Audit Logging / Azure Activity Log, GuardDuty → Security Command Center / Defender for Cloud, S3 → Cloud Storage / Blob Storage, …). Fires only when a non-AWS cloud is selected without AWS; on-prem profiles get capability-language neutralization.
- **EDR / email / chat**: SentinelOne → your named product, O365 → Google Workspace, Slack → Teams/Google Chat — on explicit signals only; a generic 'EDR' chip neutralizes to a role noun. Never guesses.
- **Surfaces**: second wizard checkbox with a live swap-plan disclosure (honest empty-state when no swaps apply) + per-item 'Adapt to my environment' so existing assessments benefit without re-creation.
- **Privacy**: swapped output carries tailored provenance → default share export swaps back to pristine (new producer-path leak test proves it). Full-bank sweeps assert zero AWS-vocabulary residue across all 106 procedures for all three targets.

No AI, no API key, fully offline. Closes the tailoring gap reported in field testing.