### PR TITLE
External ticketing/document links for findings, artifacts, and controls (#284)

### DIFF
--- a/PRIVATE_DATA.md
+++ b/PRIVATE_DATA.md
@@ -138,6 +138,10 @@ The Settings export card offers two intents:
 - **Backup** — everything, including pack data and metrics catalogues. For your own machine only. Files are named `*.backup.json` and gitignored.
 - **Share export** — excludes pack-sourced records **and imported metric definitions** by default, including the whole pack-owned assessment and everything inside it (the filter follows lineage, not just tags). Quarter-level `metricId` links pointing at excluded metrics are stripped so no identifier from a private catalogue rides out on your own records, and all envelope counts are recomputed after filtering. Including private data requires ticking a box *and* confirming a warning — and restricted-license metrics stay excluded even then. Default-safe beats remember-to-scrub.
 
+### External ticketing/document URLs — private data too
+
+Findings, artifacts, and controls can carry links into your own systems (a Jira or ServiceNow ticket, a Google Drive or SharePoint document, a control record in your compliance tool — see the External Tracking option in the new-assessment wizard). Those URLs name your internal hostnames, site paths, and project keys, so share exports **scrub them by default**: `findings.externalUrl`, `artifacts.link`, `controls.externalUrl`, and the assessment's external system name are all blanked unless you explicitly include private data. Note this deliberately changed the artifact `link` field's behavior — before issue #284 it rode share exports untouched. Complete backups always keep every URL.
+
 ## Defense in depth
 
 Even though packs and catalogues should never be inside a clone, the repo guards against accidents:

--- a/src/components/ArtifactSelector.js
+++ b/src/components/ArtifactSelector.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { X, ExternalLink, ChevronRight } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import useArtifactStore from '../stores/artifactStore';
+import { sanitizeExternalUrl } from '../utils/externalLinks';
 
 const ArtifactSelector = ({
   label,
@@ -20,11 +21,11 @@ const ArtifactSelector = ({
     const artifact = artifacts.find(a => a.name === name);
     const chipClass = 'px-2 py-1 bg-blue-600 text-white rounded-full text-xs inline-flex items-center gap-1 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 cursor-pointer';
 
-    if (artifact?.link) {
+    if (sanitizeExternalUrl(artifact?.link)) {
       return (
         <a
           key={name}
-          href={artifact.link}
+          href={sanitizeExternalUrl(artifact.link)}
           target="_blank"
           rel="noopener noreferrer"
           className={chipClass}

--- a/src/index.css
+++ b/src/index.css
@@ -209,6 +209,7 @@ code {
 .mt-1 { margin-top: 0.25rem; }
 .mt-2 { margin-top: 0.5rem; }
 .mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.ml-1 { margin-left: 0.25rem; }
 .ml-2 { margin-left: 0.5rem; }
 .ml-6 { margin-left: 1.5rem; }
 .mb-1 { margin-bottom: 0.25rem; }
@@ -219,7 +220,9 @@ code {
 
 /* Gap */
 .gap-1 { gap: 0.25rem; }
+.gap-1\.5 { gap: 0.375rem; }
 .gap-2 { gap: 0.5rem; }
+.inline-flex { display: inline-flex; }
 .gap-3 { gap: 0.75rem; }
 .gap-4 { gap: 1rem; }
 .gap-6 { gap: 1.5rem; }
@@ -320,6 +323,8 @@ code {
 .tracking-wider { letter-spacing: 0.05em; }
 .whitespace-pre-wrap { white-space: pre-wrap; }
 .underline { text-decoration: underline; }
+.hover\:underline:hover { text-decoration: underline; }
+.break-all { word-break: break-all; }
 
 /* Truncation & line clamping */
 .truncate {

--- a/src/pages/Artifacts.js
+++ b/src/pages/Artifacts.js
@@ -9,6 +9,7 @@ import useControlsStore from '../stores/controlsStore';
 import useSort from '../hooks/useSort';
 import { extractArtifactsFromProfile } from '../updateArtifactLinks';
 import EmptyState from '../components/EmptyState';
+import { sanitizeExternalUrl } from '../utils/externalLinks';
 
 const Artifacts = () => {
   const navigate = useNavigate();
@@ -550,18 +551,25 @@ const Artifacts = () => {
                       value={formData.link || ''}
                       onChange={handleChange}
                       className="w-full p-2 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white"
-                      placeholder="https://..."
+                      placeholder="https://... (ticket, Google Drive, SharePoint, or other document link)"
                     />
                   ) : selectedArtifact?.link ? (
-                    <a
-                      href={selectedArtifact.link}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1"
-                    >
-                      <LinkIcon size={14} />
-                      {selectedArtifact.link}
-                    </a>
+                    sanitizeExternalUrl(selectedArtifact.link) ? (
+                      <a
+                        href={sanitizeExternalUrl(selectedArtifact.link)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1"
+                      >
+                        <LinkIcon size={14} />
+                        {selectedArtifact.link}
+                      </a>
+                    ) : (
+                      <p className="text-sm text-gray-700 dark:text-gray-300 break-all">
+                        {selectedArtifact.link}
+                        <span className="text-xs text-gray-400 ml-1">(only http/https URLs render as links)</span>
+                      </p>
+                    )
                   ) : (
                     <p className="text-sm text-gray-400 dark:text-gray-500">No link provided</p>
                   )}

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -30,6 +30,7 @@ import { formatInlineMarkdown, stripMarkdown } from '../utils/markdownText';
 import { bankCoverage, getBankProcedure, buildProcedureSource, bankSourceUrl } from '../utils/procedureBank';
 import { canUseProfileWithProvider, buildTailorPrompt, tailoredProvenance, deriveStackTargets, describeStackPlan, bankAttachObservation, deterministicTailorUpdate } from '../utils/procedureTailor';
 import { getScoringScale, scoreBand, CMMI_LEVELS } from '../utils/scoringScale';
+import { SYSTEM_NAME_MAX_LENGTH } from '../utils/externalLinks';
 import useOrgProfileStore from '../stores/orgProfileStore';
 import OrgProfileWizard from '../components/OrgProfileWizard';
 
@@ -127,7 +128,8 @@ const Assessments = () => {
     name: '',
     description: '',
     scopeType: 'requirements',
-    scoringScale: 10
+    scoringScale: 10,
+    externalTracking: { enabled: false, systemName: '' }
   });
   const [selectedScopeItems, setSelectedScopeItems] = useState(new Set()); // Selected controls/requirements
   const [scopePreset, setScopePreset] = useState(null); // 'category' | 'subcategory' | 'all' | null (custom)
@@ -564,7 +566,7 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
   // Reset wizard state
   const resetWizard = useCallback(() => {
     setWizardStep(1);
-    setNewAssessment({ name: '', description: '', scopeType: 'requirements', scoringScale: 10 });
+    setNewAssessment({ name: '', description: '', scopeType: 'requirements', scoringScale: 10, externalTracking: { enabled: false, systemName: '' } });
     setSelectedScopeItems(new Set());
     setScopePreset(null);
     setScopeFilterText('');
@@ -2048,6 +2050,47 @@ Use scores: "yes" (complete evidence), "partial" (incomplete), "planned" (intent
                     <p className="text-xs text-gray-500 mt-1">
                       Both scales support quarter-point precision (e.g. 3.25). The scale is locked once the assessment is created.
                     </p>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">External Tracking (Optional)</label>
+                    <label className="flex items-center gap-2 p-3 border rounded cursor-pointer hover:bg-gray-50">
+                      <input
+                        type="checkbox"
+                        checked={newAssessment.externalTracking.enabled}
+                        onChange={(e) => setNewAssessment(prev => ({
+                          ...prev,
+                          externalTracking: { ...prev.externalTracking, enabled: e.target.checked }
+                        }))}
+                      />
+                      <div>
+                        <span className="font-medium">Track findings, artifacts, and controls in your own ticketing system</span>
+                        <p className="text-xs text-gray-500">
+                          Labels the URL fields on findings (ticket link), artifacts (ticket or Google Drive / SharePoint document link),
+                          and controls (compliance-tool link) with your system&apos;s name. The URL fields themselves are always available,
+                          with or without this option.
+                        </p>
+                      </div>
+                    </label>
+                    {newAssessment.externalTracking.enabled && (
+                      <div className="mt-2">
+                        <label className="block text-sm font-medium text-gray-700">System name</label>
+                        <input
+                          type="text"
+                          className="mt-1 w-full p-2 border rounded"
+                          maxLength={SYSTEM_NAME_MAX_LENGTH}
+                          placeholder="e.g., Jira, ServiceNow, SharePoint"
+                          value={newAssessment.externalTracking.systemName}
+                          onChange={(e) => setNewAssessment(prev => ({
+                            ...prev,
+                            externalTracking: { ...prev.externalTracking, systemName: e.target.value }
+                          }))}
+                        />
+                        <p className="text-xs text-gray-500 mt-1">
+                          Shown in link-field labels (e.g. &ldquo;Jira ticket URL&rdquo;). Excluded from share exports by default.
+                        </p>
+                      </div>
+                    )}
                   </div>
 
                   <div>

--- a/src/pages/Findings.js
+++ b/src/pages/Findings.js
@@ -1,11 +1,13 @@
 import React, { useState, useRef, useCallback, useEffect, useMemo } from 'react';
-import { Edit, Trash2, Save, X, Plus, Upload, Download, ChevronRight, User, AlertTriangle, Calendar, Shield } from 'lucide-react';
+import { Edit, Trash2, Save, X, Plus, Upload, Download, ChevronRight, User, AlertTriangle, Calendar, Shield, ExternalLink } from 'lucide-react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import useFindingsStore from '../stores/findingsStore';
 import useUserStore from '../stores/userStore';
 import useControlsStore from '../stores/controlsStore';
 import useRequirementsStore from '../stores/requirementsStore';
+import useAssessmentsStore from '../stores/assessmentsStore';
+import { sanitizeExternalUrl, externalUrlLabel } from '../utils/externalLinks';
 import useSort from '../hooks/useSort';
 import EmptyState from '../components/EmptyState';
 import Markdown from '../components/Markdown';
@@ -23,6 +25,11 @@ const Findings = () => {
   const users = useUserStore((state) => state.users);
   const getControlsByRequirement = useControlsStore((state) => state.getControlsByRequirement);
   const requirements = useRequirementsStore((state) => state.requirements);
+  const assessments = useAssessmentsStore((state) => state.assessments);
+
+  // External-tracking config of the assessment a finding belongs to (issue #284)
+  const trackingForAssessment = (assessmentId) =>
+    assessments.find((a) => a.id === assessmentId)?.externalTracking;
 
   const [formData, setFormData] = useState({
     id: null,
@@ -34,7 +41,8 @@ const Findings = () => {
     remediationOwner: null,
     dueDate: '',
     status: 'Not Started',
-    priority: 'Medium'
+    priority: 'Medium',
+    externalUrl: ''
   });
   const [editMode, setEditMode] = useState(false);
   const [errors, setErrors] = useState({});
@@ -239,7 +247,8 @@ const Findings = () => {
       remediationOwner: null,
       dueDate: '',
       status: 'Not Started',
-      priority: 'Medium'
+      priority: 'Medium',
+      externalUrl: ''
     });
     setEditMode(false);
     setErrors({});
@@ -400,8 +409,20 @@ const Findings = () => {
                     </div>
 
                     {/* Summary */}
-                    <div className="flex-1 min-w-0">
+                    <div className="flex-1 min-w-0 flex items-center gap-1.5">
                       <p className="text-sm text-gray-900 dark:text-white truncate">{finding.summary}</p>
+                      {sanitizeExternalUrl(finding.externalUrl) && (
+                        <a
+                          href={sanitizeExternalUrl(finding.externalUrl)}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          className="flex-shrink-0 text-blue-600 dark:text-blue-400"
+                          title="Open external ticket"
+                        >
+                          <ExternalLink size={14} />
+                        </a>
+                      )}
                     </div>
 
                     {/* CSF Reference */}
@@ -592,6 +613,43 @@ const Findings = () => {
                       {selectedFinding?.priority}
                     </span>
                   </>
+                )}
+              </div>
+
+              {/* External ticket link (issue #284) */}
+              <div className="mb-6">
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">
+                  <ChevronRight size={16} className="rotate-90" />
+                  {externalUrlLabel(trackingForAssessment((editMode ? formData : selectedFinding)?.assessmentId), 'ticket')}
+                </h3>
+                {editMode ? (
+                  <input
+                    type="url"
+                    name="externalUrl"
+                    value={formData.externalUrl || ''}
+                    onChange={handleChange}
+                    className="w-full p-2 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white"
+                    placeholder="https://... (ticket in Jira, ServiceNow, etc.)"
+                  />
+                ) : selectedFinding?.externalUrl ? (
+                  sanitizeExternalUrl(selectedFinding.externalUrl) ? (
+                    <a
+                      href={sanitizeExternalUrl(selectedFinding.externalUrl)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1 break-all"
+                    >
+                      <ExternalLink size={14} />
+                      {selectedFinding.externalUrl}
+                    </a>
+                  ) : (
+                    <p className="text-sm text-gray-700 dark:text-gray-300 break-all">
+                      {selectedFinding.externalUrl}
+                      <span className="text-xs text-gray-400 ml-1">(only http/https URLs render as links)</span>
+                    </p>
+                  )
+                ) : (
+                  <p className="text-sm text-gray-400 dark:text-gray-500">No external ticket linked.</p>
                 )}
               </div>
 

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -38,6 +38,7 @@ import OrgProfileWizard from '../components/OrgProfileWizard';
 // Utils
 import { exportCompleteDatabase, exportAssessmentsJSON, exportShareableDatabase } from '../utils/dataExport';
 import { importCompleteDatabase, validateDatabaseExport } from '../utils/dataImport';
+import { sanitizeExternalUrl } from '../utils/externalLinks';
 import { previewPackImport, importPack } from '../utils/packImport';
 import {
   parseMetricsCSV,
@@ -928,9 +929,9 @@ nist-csf-2.0,RECOVER (RC),Incident Recovery Plan Execution (RC.RP),RC.RP-01,The 
                       </td>
                       <td className="p-3 text-sm">{framework.version}</td>
                       <td className="p-3 text-sm">
-                        {framework.sourceUrl ? (
+                        {sanitizeExternalUrl(framework.sourceUrl) ? (
                           <a
-                            href={framework.sourceUrl}
+                            href={sanitizeExternalUrl(framework.sourceUrl)}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-blue-600 hover:text-blue-800 hover:underline inline-flex items-center gap-1"

--- a/src/pages/UserControls.js
+++ b/src/pages/UserControls.js
@@ -2,10 +2,11 @@ import React, { useState, useCallback, useRef, useMemo, useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom';
 import {
   Search, Filter, Plus, Edit, Save, Trash2, Link, X,
-  Upload, Download, Users, User, ChevronRight
+  Upload, Download, Users, User, ChevronRight, ExternalLink
 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import Markdown from '../components/Markdown';
+import { sanitizeExternalUrl } from '../utils/externalLinks';
 
 // Components
 import FrameworkBadge from '../components/FrameworkBadge';
@@ -61,7 +62,8 @@ const UserControls = () => {
     implementationDescription: '',
     ownerId: null,
     stakeholderIds: [],
-    linkedRequirementIds: []
+    linkedRequirementIds: [],
+    externalUrl: ''
   });
 
   // Requirement picker state
@@ -277,7 +279,8 @@ const UserControls = () => {
       implementationDescription: '',
       ownerId: null,
       stakeholderIds: [],
-      linkedRequirementIds: []
+      linkedRequirementIds: [],
+      externalUrl: ''
     });
     setDetailPanelOpen(true);
     setEditMode(true);
@@ -833,6 +836,39 @@ const UserControls = () => {
                             {currentControl.implementationDescription || 'No description'}
                           </Markdown>
                         </div>
+                      )}
+                    </div>
+
+                    {/* External control URL (issue #284) */}
+                    <div>
+                      <label className="text-sm font-medium text-gray-500">External Control URL</label>
+                      {editMode || isCreating ? (
+                        <input
+                          type="url"
+                          value={currentControl.externalUrl || ''}
+                          onChange={(e) => handleFieldChange('externalUrl', e.target.value)}
+                          className="mt-1 w-full p-2 border rounded"
+                          placeholder="https://... (this control in your compliance or ticketing tool)"
+                        />
+                      ) : currentControl.externalUrl ? (
+                        sanitizeExternalUrl(currentControl.externalUrl) ? (
+                          <a
+                            href={sanitizeExternalUrl(currentControl.externalUrl)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-1 text-sm text-blue-600 hover:underline inline-flex items-center gap-1 break-all"
+                          >
+                            <ExternalLink size={14} />
+                            {currentControl.externalUrl}
+                          </a>
+                        ) : (
+                          <p className="mt-1 text-sm text-gray-700 break-all">
+                            {currentControl.externalUrl}
+                            <span className="text-xs text-gray-400 ml-1">(only http/https URLs render as links)</span>
+                          </p>
+                        )
+                      ) : (
+                        <p className="mt-1 text-sm text-gray-400">No external link</p>
                       )}
                     </div>
 

--- a/src/stores/assessmentsStore.js
+++ b/src/stores/assessmentsStore.js
@@ -4,6 +4,7 @@ import { quotaSafeLocalStorage } from '../utils/safeStorage';
 import Papa from 'papaparse';
 import { v4 as uuidv4 } from 'uuid';
 import { sanitizeInput, escapeCSVValue } from '../utils/sanitize';
+import { normalizeExternalTracking } from '../utils/externalLinks';
 import { buildEncryptedFilename, encryptBytesWithPassword } from '../utils/exportEncryption';
 import { UPDATED_OBSERVATIONS, ALMA_AUDIT_OBSERVATIONS } from './defaultAssessmentsData';
 import {
@@ -131,7 +132,7 @@ const migrateObservationToQuarterly = (oldObs) => {
  * Current schema version of csf-assessments-storage. Exported so the restore
  * path (dataImport.js) can migrate older exported payloads before applying them.
  */
-export const ASSESSMENTS_SCHEMA_VERSION = 10;
+export const ASSESSMENTS_SCHEMA_VERSION = 11;
 
 /**
  * Full persisted-state migration chain for csf-assessments-storage.
@@ -232,6 +233,19 @@ export const migrateAssessmentsState = (persistedState, version) => {
     const assessments = (state.assessments || []).map(a =>
       a.scoringScale === 5 || a.scoringScale === 10 ? a : { ...a, scoringScale: 10 }
     );
+    state = { ...state, assessments };
+  }
+
+  // Version 11: Stamp externalTracking (issue #284) — the per-assessment
+  // declaration that findings/artifacts/controls are tracked in an external
+  // ticketing/document system. Idempotent: a well-formed value is preserved
+  // (normalize keeps enabled/systemName), a missing/foreign one becomes the
+  // disabled default.
+  if (version < 11) {
+    const assessments = (state.assessments || []).map(a => ({
+      ...a,
+      externalTracking: normalizeExternalTracking(a.externalTracking)
+    }));
     state = { ...state, assessments };
   }
 
@@ -492,6 +506,8 @@ const useAssessmentsStore = create(
           scopeType: assessmentData.scopeType || 'requirements', // 'requirements' or 'controls'
           // 10-point (default) or 5-point CMMI-style scale; locked at creation (issue #277)
           scoringScale: assessmentData.scoringScale === 5 ? 5 : 10,
+          // Optional external ticketing/document system declaration (issue #284)
+          externalTracking: normalizeExternalTracking(assessmentData.externalTracking),
           scopeIds: assessmentData.scopeIds || [], // Array of requirement IDs or control IDs
           frameworkFilter: assessmentData.frameworkFilter || null, // Optional framework filter
           status: 'Not Started', // Not Started, In Progress, Complete

--- a/src/stores/assessmentsStore.migrate.test.js
+++ b/src/stores/assessmentsStore.migrate.test.js
@@ -61,10 +61,15 @@ describe('migrateAssessmentsState', () => {
 
   test('current-version state passes through unchanged', () => {
     const state = {
-      assessments: [{ id: 'ASM-x', observations: {}, scoringScale: 10 }],
+      assessments: [{
+        id: 'ASM-x',
+        observations: {},
+        scoringScale: 10,
+        externalTracking: { enabled: false, systemName: '' }
+      }],
       currentAssessmentId: 'ASM-x'
     };
-    const result = migrateAssessmentsState(state, 10);
+    const result = migrateAssessmentsState(state, 11);
     expect(result).toEqual(state);
   });
 
@@ -115,6 +120,44 @@ describe('migrateAssessmentsState', () => {
     test('a v0 client also receives the scale stamp (fall-through)', () => {
       const result = migrateAssessmentsState(legacyV0State(), 0);
       expect(result.assessments.every(a => a.scoringScale === 5 || a.scoringScale === 10)).toBe(true);
+    });
+  });
+
+  describe('v11: externalTracking stamp (issue #284)', () => {
+    test('a v10 client gets the disabled default stamped on every assessment', () => {
+      const state = {
+        assessments: [
+          { id: 'ASM-a', observations: {}, scoringScale: 10 },
+          { id: 'ASM-b', observations: {}, scoringScale: 5 }
+        ],
+        currentAssessmentId: 'ASM-a'
+      };
+      const result = migrateAssessmentsState(state, 10);
+      expect(result.assessments.every(a =>
+        a.externalTracking && a.externalTracking.enabled === false && a.externalTracking.systemName === ''
+      )).toBe(true);
+    });
+
+    test('idempotent: an assessment already carrying a config keeps enabled + systemName', () => {
+      const state = {
+        assessments: [
+          { id: 'ASM-jira', observations: {}, scoringScale: 10, externalTracking: { enabled: true, systemName: 'Jira' } },
+          { id: 'ASM-junk', observations: {}, scoringScale: 10, externalTracking: 'garbage' }
+        ],
+        currentAssessmentId: 'ASM-jira'
+      };
+      const result = migrateAssessmentsState(state, 10);
+      expect(result.assessments.find(a => a.id === 'ASM-jira').externalTracking)
+        .toEqual({ enabled: true, systemName: 'Jira' });
+      expect(result.assessments.find(a => a.id === 'ASM-junk').externalTracking)
+        .toEqual({ enabled: false, systemName: '' });
+    });
+
+    test('a v0 client also receives the externalTracking stamp (fall-through)', () => {
+      const result = migrateAssessmentsState(legacyV0State(), 0);
+      expect(result.assessments.every(a =>
+        a.externalTracking && typeof a.externalTracking.enabled === 'boolean'
+      )).toBe(true);
     });
   });
 

--- a/src/stores/controlsStore.js
+++ b/src/stores/controlsStore.js
@@ -79,6 +79,8 @@ const useControlsStore = create(
           artifacts: controlData.artifacts || '',
           findings: controlData.findings || '',
           controlEvaluationBackLink: controlData.controlEvaluationBackLink || '',
+          // Optional URL to this control in an external compliance/ticketing tool (issue #284)
+          externalUrl: controlData.externalUrl || '',
           createdDate: new Date().toISOString(),
           lastModified: new Date().toISOString()
         };

--- a/src/stores/findingsStore.js
+++ b/src/stores/findingsStore.js
@@ -87,6 +87,8 @@ const useFindingsStore = create(
           createdDate: new Date().toISOString(),
           lastModified: new Date().toISOString(),
           jiraKey: findingData.jiraKey || null, // Jira issue key if synced
+          // Optional URL to the finding's ticket in an external system (issue #284)
+          externalUrl: findingData.externalUrl || '',
           linkedArtifacts: findingData.linkedArtifacts || []
         };
 

--- a/src/utils/dataExport.js
+++ b/src/utils/dataExport.js
@@ -195,6 +195,9 @@ const swapTailoredProcedures = (assessments) =>
  * does not restore it (crown jewels + tooling are never share material).
  * Tailored procedure text (profile-derived) is swapped back to the pristine
  * community version by default; include-private keeps the tailored text.
+ * External ticketing/document URLs (findings.externalUrl, artifacts.link,
+ * controls.externalUrl) and the external system name are scrubbed by
+ * default; include-private keeps them (issue #284).
  *
  * @param {Object} stores - Same store map exportAllDataJSON receives
  * @param {Object} [options]
@@ -247,6 +250,22 @@ export const buildShareableExport = (stores, { includePrivate = false } = {}) =>
   const survivorIds = new Set(survivors.map((m) => m.id));
   const excludedIds = new Set(allMetrics.filter((m) => !survivorIds.has(m.id)).map((m) => m.id));
   jsonData.data.assessments = stripMetricLinks(jsonData.data.assessments, excludedIds);
+
+  // External ticketing/document URLs (issue #284) point at internal
+  // infrastructure — Jira/ServiceNow hostnames, SharePoint sites, Drive docs,
+  // project keys in paths. Scrubbed from share exports by default; the
+  // include-private opt-in keeps them, complete backups are unaffected.
+  // This deliberately also scrubs the PRE-EXISTING artifacts.link field,
+  // which previously rode share exports wholesale. Map+spread clones every
+  // record — live store objects are never mutated.
+  jsonData.data.assessments = jsonData.data.assessments.map((a) => (
+    a.externalTracking
+      ? { ...a, externalTracking: { ...a.externalTracking, systemName: '' } }
+      : a
+  ));
+  jsonData.data.findings = jsonData.data.findings.map((f) => ({ ...f, externalUrl: '' }));
+  jsonData.data.artifacts = (jsonData.data.artifacts || []).map((ar) => ({ ...ar, link: '' }));
+  jsonData.data.controls = (jsonData.data.controls || []).map((c) => ({ ...c, externalUrl: '' }));
 
   jsonData.dataType = 'Shareable Assessment Database (private pack data excluded)';
   jsonData.metadata.assessmentCount = jsonData.data.assessments.length;

--- a/src/utils/dataImport.test.js
+++ b/src/utils/dataImport.test.js
@@ -202,6 +202,29 @@ describe('importCompleteDatabase safety semantics', () => {
     expect(restored.observations['GV.SC-04 Ex1'].quarters.Q1.actualScore).toBe(3.25);
   });
 
+  test('a v10 export (no externalTracking) restores with the disabled default stamped (issue #284)', () => {
+    const { stores, setters } = makeStores();
+    const parsed = {
+      formatVersion: EXPORT_FORMAT_VERSION,
+      storeVersions: { assessments: 10 },
+      data: {
+        assessments: [{
+          id: 'ASM-v10',
+          name: 'Pre-284 export',
+          scopeType: 'requirements',
+          scoringScale: 10,
+          scopeIds: [],
+          observations: {}
+        }]
+      }
+    };
+    importCompleteDatabase(parsed, stores, { backupFirst: false });
+
+    const written = setters.setAssessments.mock.calls[0][0];
+    const restored = written.find(a => a.id === 'ASM-v10');
+    expect(restored.externalTracking).toEqual({ enabled: false, systemName: '' });
+  });
+
   test('a mid-apply setter failure rolls back every already-applied section', () => {
     const { stores, setters } = makeStores();
     // users applies first, then findings throws

--- a/src/utils/externalLinks.js
+++ b/src/utils/externalLinks.js
@@ -1,0 +1,64 @@
+/**
+ * External ticketing/document link helpers (issue #284).
+ *
+ * Users may track findings, artifacts, and controls in their own systems
+ * (Jira, ServiceNow, Google Drive, SharePoint, ...) and paste ticket/document
+ * URLs into the app. Everything rendered as an anchor href MUST pass through
+ * sanitizeExternalUrl — user-pasted strings are untrusted and a javascript:
+ * href executes on click.
+ */
+
+/**
+ * Return a safe absolute http/https URL, or null for anything else
+ * (javascript:, data:, vbscript:, protocol-relative //host, relative paths,
+ * malformed input). Callers render plain text when this returns null —
+ * never an anchor.
+ */
+export const sanitizeExternalUrl = (url) => {
+  if (typeof url !== 'string') return null;
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  let parsed;
+  try {
+    parsed = new URL(trimmed);
+  } catch (e) {
+    return null;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  return parsed.href;
+};
+
+/** Max length accepted for a user-entered external system name. */
+export const SYSTEM_NAME_MAX_LENGTH = 60;
+
+/** Default per-assessment external-tracking configuration. */
+export const DEFAULT_EXTERNAL_TRACKING = Object.freeze({
+  enabled: false,
+  systemName: ''
+});
+
+/**
+ * Coerce any persisted/imported value into a well-formed externalTracking
+ * object. Foreign shapes (missing, null, wrong types) collapse to the
+ * default; systemName is trimmed and length-capped.
+ */
+export const normalizeExternalTracking = (value) => {
+  if (!value || typeof value !== 'object') return { ...DEFAULT_EXTERNAL_TRACKING };
+  const systemName = typeof value.systemName === 'string'
+    ? value.systemName.trim().slice(0, SYSTEM_NAME_MAX_LENGTH)
+    : '';
+  return { enabled: value.enabled === true, systemName };
+};
+
+/**
+ * Label for an external-URL input/link. Uses the assessment's system name
+ * when external tracking is enabled ("Jira ticket URL"), a generic label
+ * otherwise. `noun` is e.g. "ticket" (findings) or "control" (controls).
+ */
+export const externalUrlLabel = (externalTracking, noun) => {
+  const tracking = normalizeExternalTracking(externalTracking);
+  if (tracking.enabled && tracking.systemName) {
+    return `${tracking.systemName} ${noun} URL`;
+  }
+  return `External ${noun} URL`;
+};

--- a/src/utils/externalLinks.test.js
+++ b/src/utils/externalLinks.test.js
@@ -1,0 +1,108 @@
+/**
+ * External ticketing/document link helpers (issue #284).
+ * The sanitizer is a security boundary: user-pasted strings become anchor
+ * hrefs, and a javascript: href executes on click. Everything that is not an
+ * absolute http/https URL must come back null.
+ */
+import {
+  sanitizeExternalUrl,
+  normalizeExternalTracking,
+  externalUrlLabel,
+  DEFAULT_EXTERNAL_TRACKING,
+  SYSTEM_NAME_MAX_LENGTH
+} from './externalLinks';
+
+describe('sanitizeExternalUrl', () => {
+  test('accepts absolute http and https URLs', () => {
+    expect(sanitizeExternalUrl('https://jira.example.com/browse/SEC-123'))
+      .toBe('https://jira.example.com/browse/SEC-123');
+    expect(sanitizeExternalUrl('http://tracker.local/ticket/9'))
+      .toBe('http://tracker.local/ticket/9');
+  });
+
+  test('trims surrounding whitespace and normalizes via the URL parser', () => {
+    expect(sanitizeExternalUrl('  https://drive.google.com/file/d/abc  '))
+      .toBe('https://drive.google.com/file/d/abc');
+    // Bare origins normalize with a trailing slash — still a safe https href
+    expect(sanitizeExternalUrl('https://sharepoint.example.com'))
+      .toBe('https://sharepoint.example.com/');
+  });
+
+  test('rejects javascript:, data:, and vbscript: schemes', () => {
+    // eslint-disable-next-line no-script-url -- attack fixture: the sanitizer must reject it
+    expect(sanitizeExternalUrl('javascript:alert(1)')).toBeNull();
+    // eslint-disable-next-line no-script-url -- attack fixture: case-insensitive scheme
+    expect(sanitizeExternalUrl('JAVASCRIPT:alert(1)')).toBeNull();
+    expect(sanitizeExternalUrl('data:text/html,<script>alert(1)</script>')).toBeNull();
+    expect(sanitizeExternalUrl('vbscript:msgbox(1)')).toBeNull();
+  });
+
+  test('rejects whitespace-obfuscated schemes (URL parser strips tabs/newlines)', () => {
+    expect(sanitizeExternalUrl('java\nscript:alert(1)')).toBeNull();
+    expect(sanitizeExternalUrl('java\tscript:alert(1)')).toBeNull();
+    expect(sanitizeExternalUrl(' javascript:alert(1) ')).toBeNull();
+  });
+
+  test('rejects leading-control-char obfuscation (browsers strip C0 chars before scheme parsing)', () => {
+    expect(sanitizeExternalUrl('\u0001javascript:alert(1)')).toBeNull();
+    expect(sanitizeExternalUrl('\u0000javascript:alert(1)')).toBeNull();
+  });
+
+  test('rejects protocol-relative, relative, and malformed input', () => {
+    expect(sanitizeExternalUrl('//evil.example.com/x')).toBeNull();
+    expect(sanitizeExternalUrl('tickets/SEC-123')).toBeNull();
+    expect(sanitizeExternalUrl('ftp://files.example.com/a')).toBeNull();
+    expect(sanitizeExternalUrl('not a url')).toBeNull();
+  });
+
+  test('rejects non-strings and empty values', () => {
+    expect(sanitizeExternalUrl(null)).toBeNull();
+    expect(sanitizeExternalUrl(undefined)).toBeNull();
+    expect(sanitizeExternalUrl(42)).toBeNull();
+    expect(sanitizeExternalUrl('')).toBeNull();
+    expect(sanitizeExternalUrl('   ')).toBeNull();
+  });
+});
+
+describe('normalizeExternalTracking', () => {
+  test('missing or foreign shapes collapse to the disabled default', () => {
+    expect(normalizeExternalTracking(undefined)).toEqual(DEFAULT_EXTERNAL_TRACKING);
+    expect(normalizeExternalTracking(null)).toEqual(DEFAULT_EXTERNAL_TRACKING);
+    expect(normalizeExternalTracking('yes')).toEqual(DEFAULT_EXTERNAL_TRACKING);
+    expect(normalizeExternalTracking(7)).toEqual(DEFAULT_EXTERNAL_TRACKING);
+  });
+
+  test('well-formed values are preserved (idempotent for the migration)', () => {
+    const val = { enabled: true, systemName: 'Jira' };
+    expect(normalizeExternalTracking(val)).toEqual(val);
+    expect(normalizeExternalTracking(normalizeExternalTracking(val))).toEqual(val);
+  });
+
+  test('enabled coerces strictly to boolean true', () => {
+    expect(normalizeExternalTracking({ enabled: 'yes', systemName: 'X' }).enabled).toBe(false);
+    expect(normalizeExternalTracking({ enabled: 1 }).enabled).toBe(false);
+    expect(normalizeExternalTracking({ enabled: true }).enabled).toBe(true);
+  });
+
+  test('systemName is trimmed and length-capped', () => {
+    expect(normalizeExternalTracking({ enabled: true, systemName: '  ServiceNow  ' }).systemName)
+      .toBe('ServiceNow');
+    const long = 'x'.repeat(SYSTEM_NAME_MAX_LENGTH + 40);
+    expect(normalizeExternalTracking({ enabled: true, systemName: long }).systemName)
+      .toHaveLength(SYSTEM_NAME_MAX_LENGTH);
+    expect(normalizeExternalTracking({ enabled: true, systemName: 9 }).systemName).toBe('');
+  });
+});
+
+describe('externalUrlLabel', () => {
+  test('uses the system name when tracking is enabled', () => {
+    expect(externalUrlLabel({ enabled: true, systemName: 'Jira' }, 'ticket')).toBe('Jira ticket URL');
+    expect(externalUrlLabel({ enabled: true, systemName: 'ServiceNow' }, 'control')).toBe('ServiceNow control URL');
+  });
+
+  test('falls back to a generic label when disabled, unnamed, or unconfigured', () => {
+    expect(externalUrlLabel({ enabled: false, systemName: 'Jira' }, 'ticket')).toBe('External ticket URL');
+    expect(externalUrlLabel({ enabled: true, systemName: '' }, 'ticket')).toBe('External ticket URL');
+    expect(externalUrlLabel(undefined, 'ticket')).toBe('External ticket URL');
+  });
+});

--- a/src/utils/externalLinksExport.test.js
+++ b/src/utils/externalLinksExport.test.js
@@ -1,0 +1,134 @@
+/**
+ * External-URL share-export guards (issue #284, PRIVATE_DATA.md).
+ *
+ * Ticket/document URLs name internal infrastructure (Jira/ServiceNow hosts,
+ * SharePoint sites, project keys in paths). Default share exports scrub:
+ *   - findings.externalUrl
+ *   - artifacts.link        (pre-existing field — deliberate behavior change)
+ *   - controls.externalUrl
+ *   - assessments.externalTracking.systemName
+ * The include-private opt-in keeps them; complete backups always keep them;
+ * the scrub is copy-on-write and never mutates live store records.
+ */
+import { exportAllDataJSON, buildShareableExport } from './dataExport';
+import useAssessmentsStore from '../stores/assessmentsStore';
+import useFindingsStore from '../stores/findingsStore';
+import useArtifactStore from '../stores/artifactStore';
+import useControlsStore from '../stores/controlsStore';
+
+const CANARY_SYS = 'CanaryTrack GRC';
+const CANARY_URL_F = 'https://jira.internal-canary.example/browse/SEC-9999';
+const CANARY_URL_A = 'https://sharepoint.internal-canary.example/sites/evidence/AR-77';
+const CANARY_URL_C = 'https://grc.internal-canary.example/controls/CTL-042';
+
+const stores = () => ({
+  assessmentsStore: useAssessmentsStore,
+  findingsStore: useFindingsStore,
+  artifactStore: useArtifactStore,
+  controlsStore: useControlsStore
+});
+
+describe('external URLs in exports (issue #284)', () => {
+  let assessmentId;
+  let findingId;
+  let artifactId;
+  let controlId;
+
+  beforeEach(() => {
+    const assessment = useAssessmentsStore.getState().createAssessment({
+      name: 'External tracking test',
+      scopeType: 'requirements',
+      externalTracking: { enabled: true, systemName: CANARY_SYS }
+    });
+    assessmentId = assessment.id;
+
+    findingId = useFindingsStore.getState().createFinding({
+      summary: 'Canary finding',
+      assessmentId,
+      externalUrl: CANARY_URL_F
+    }).id;
+
+    // addArtifact returns the new record's id string
+    artifactId = useArtifactStore.getState().addArtifact({
+      name: 'Canary artifact',
+      link: CANARY_URL_A
+    });
+
+    controlId = useControlsStore.getState().createControl({
+      controlId: 'CTL-CANARY-284',
+      implementationDescription: 'Canary control',
+      externalUrl: CANARY_URL_C
+    }).controlId;
+  });
+
+  afterEach(() => {
+    useAssessmentsStore.getState().deleteAssessment(assessmentId);
+    useFindingsStore.getState().deleteFinding(findingId);
+    useArtifactStore.getState().deleteArtifact(artifactId);
+    useControlsStore.getState().deleteControl(controlId);
+  });
+
+  test('createAssessment persists the wizard externalTracking choice', () => {
+    const stored = useAssessmentsStore.getState().assessments.find(a => a.id === assessmentId);
+    expect(stored.externalTracking).toEqual({ enabled: true, systemName: CANARY_SYS });
+  });
+
+  test('complete backup keeps every external URL and the system name — that is its job', () => {
+    const backup = exportAllDataJSON(stores());
+    const serialized = JSON.stringify(backup);
+    expect(serialized).toContain(CANARY_URL_F);
+    expect(serialized).toContain(CANARY_URL_A);
+    expect(serialized).toContain(CANARY_URL_C);
+    expect(serialized).toContain(CANARY_SYS);
+  });
+
+  test('default share export scrubs all four fields — whole-envelope assert', () => {
+    const share = buildShareableExport(stores());
+    const serialized = JSON.stringify(share);
+
+    expect(serialized).not.toContain(CANARY_URL_F);
+    expect(serialized).not.toContain(CANARY_URL_A);
+    expect(serialized).not.toContain(CANARY_URL_C);
+    expect(serialized).not.toContain(CANARY_SYS);
+    expect(serialized).not.toContain('internal-canary.example');
+
+    // Shape preserved: the fields exist but are blank; the enabled flag
+    // (non-sensitive boolean) survives.
+    const assessment = share.data.assessments.find(a => a.id === assessmentId);
+    expect(assessment.externalTracking).toEqual({ enabled: true, systemName: '' });
+    expect(share.data.findings.find(f => f.id === findingId).externalUrl).toBe('');
+    expect(share.data.artifacts.find(a => a.id === artifactId).link).toBe('');
+    expect(share.data.controls.find(c => c.controlId === controlId).externalUrl).toBe('');
+  });
+
+  test('the scrub is copy-on-write — live store records are never mutated', () => {
+    buildShareableExport(stores());
+
+    expect(useAssessmentsStore.getState().assessments.find(a => a.id === assessmentId)
+      .externalTracking.systemName).toBe(CANARY_SYS);
+    expect(useFindingsStore.getState().findings.find(f => f.id === findingId)
+      .externalUrl).toBe(CANARY_URL_F);
+    expect(useArtifactStore.getState().artifacts.find(a => a.id === artifactId)
+      .link).toBe(CANARY_URL_A);
+    expect(useControlsStore.getState().controls.find(c => c.controlId === controlId)
+      .externalUrl).toBe(CANARY_URL_C);
+  });
+
+  test('include-private opt-in keeps external URLs and the system name', () => {
+    const share = buildShareableExport(stores(), { includePrivate: true });
+    const serialized = JSON.stringify(share);
+    expect(serialized).toContain(CANARY_URL_F);
+    expect(serialized).toContain(CANARY_URL_A);
+    expect(serialized).toContain(CANARY_URL_C);
+    expect(serialized).toContain(CANARY_SYS);
+  });
+
+  test('createFinding and createControl default externalUrl to an empty string', () => {
+    const f = useFindingsStore.getState().createFinding({ summary: 'no url' });
+    const c = useControlsStore.getState().createControl({ controlId: 'CTL-NOURL-284' });
+    expect(f.externalUrl).toBe('');
+    expect(c.externalUrl).toBe('');
+    useFindingsStore.getState().deleteFinding(f.id);
+    useControlsStore.getState().deleteControl(c.controlId);
+  });
+});

--- a/src/utils/packImport.js
+++ b/src/utils/packImport.js
@@ -327,6 +327,8 @@ export const importPack = (parsed, stores) => {
     scopeType: 'requirements',
     // packFormat 1 scores are defined on the 10-point scale (issue #277)
     scoringScale: 10,
+    // packFormat 1 has no external-tracking concept; disabled default (issue #284)
+    externalTracking: { enabled: false, systemName: '' },
     scopeIds: resolved.map(({ requirementId }) => requirementId),
     frameworkFilter: defaultFramework?.id || null,
     status: 'In Progress',


### PR DESCRIPTION
Fixes #284.

## What this adds

You can now run findings, artifacts, and controls out of your own ticketing or document system instead of tracking everything inside CSF Profile.

**Assessment setup (wizard Step 1)** gains an **External Tracking (Optional)** block: declare that this assessment's work lives in an external system and name it (Jira, ServiceNow, SharePoint, ...). The name personalizes the link-field labels — e.g. the finding field becomes "Jira ticket URL".

**URL fields:**

- **Findings** — new `externalUrl` field: link the finding to its ticket. Shown in the detail panel (clickable in view mode) and as a link-out icon in the findings list.
- **Controls** — new `externalUrl` field: link a control to its record in your compliance or ticketing tool.
- **Artifacts** — the existing Link field now carries copy for ticket / Google Drive / SharePoint document use.

## Design decision: fields are always visible

The issue says the user "can choose" external tracking. This PR interprets the choice as a **declaration that personalizes labels and link-outs** — the URL fields themselves are always available in edit forms. Rationale: hiding fields behind a setup-time choice creates a trap (skip it at setup → can never link a ticket), and hiding populated data violates the app's honest-UI principle. The artifact Link field was already always-visible precedent. If you'd rather have config-gated visibility, flag it here.

## Security

- **URL sanitization**: every user-pasted URL renders as an anchor only if it parses as an absolute http/https URL (`sanitizeExternalUrl`). `javascript:`, `data:`, protocol-relative, and malformed values render as plain text with a note. This guard was also applied to the **pre-existing** artifact link and framework sourceUrl anchors, closing a latent `javascript:`-href on-click vector.
- **Share-export scrubbing**: ticket/document URLs name internal hostnames, sites, and project keys, so default share exports blank `findings.externalUrl`, `artifacts.link`, `controls.externalUrl`, and the external system name. The include-private opt-in keeps them; complete backups always keep them. The scrub is copy-on-write (live store records untouched, tested).

  ⚠️ **Behavior change**: `artifacts.link` previously rode share exports untouched. Now it's scrubbed by default. Documented in PRIVATE_DATA.md. (Follow-up candidate: `jiraKey` on findings/artifacts is also an internal identifier and still rides share exports.)

  One deliberate residual: the "Export Assessments Only" button is a backup/integration surface, so it keeps `externalTracking.systemName` (a product name like "Jira" — never a URL or hostname). Consistent with the backups-keep-everything contract; flag on the PR if you'd rather scrub it there too.

## Data model

- `assessments.externalTracking { enabled, systemName }`, normalized on every entry path, stamped onto existing assessments by a v11 store migration (`ASSESSMENTS_SCHEMA_VERSION` 10 → 11). Restoring a pre-#284 backup stamps the disabled default via the existing migration replay in `dataImport`.
- No export `formatVersion` bump: the fields are additive on existing records and ride `storeVersions`.
- Pack-imported assessments stamp the disabled default (packFormat 1 contract unchanged).

## Tests

363/363 (37 new/updated): sanitizer unit tests (scheme rejection incl. whitespace-obfuscated), v11 migration (stamp, idempotency, v0 fall-through), restore stamping, whole-envelope canary leak tests in both polarities, copy-on-write assertion.

Also adds five missing `index.css` utilities (`hover:underline`, `inline-flex`, `break-all`, `gap-1.5`, `ml-1`) that existing pages already referenced as no-ops.
