### PR TITLE
Reference: Simply Cyber Academy citation + course policy/process CMMI table

### DIFF
--- a/SCREENSHOTS.md
+++ b/SCREENSHOTS.md
@@ -46,7 +46,7 @@ Some exports support optional password protection. When you choose to encrypt an
 ---
 ## Scoring Legend (Reference Tab)
 
-The Scoring Legend provides guidance for evaluating security controls using the scoring system from Mastering Cyber Resilience by AKYLADE. Color-coded rows indicate security posture: yellow for "Some Security," green for "Just Right," and red for insufficient or excessive security.
+The Scoring Legend provides guidance for evaluating security controls using the scoring system from Simply Cyber Academy. Color-coded rows indicate security posture: yellow for "Some Security," green for "Just Right," and red for insufficient or excessive security.
 
 ![Scoring Legend](public/screenshots/References.png)
 

--- a/src/pages/ScoringLegend.js
+++ b/src/pages/ScoringLegend.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Papa from 'papaparse';
-import { CMMI_LEVELS } from '../utils/scoringScale';
+import { CMMI_EXPECTATIONS } from '../utils/scoringScale';
 
 const ScoringLegend = () => {
   const [legendData, setLegendData] = useState([]);
@@ -153,22 +153,23 @@ const ScoringLegend = () => {
           Assessments created with the 5-point scale use CMMI-style maturity levels (0&ndash;5), as popularized
           for CSF assessments by the NIST CSF Maturity Toolkit. Both scales support quarter-point precision
           (e.g. 3.25 indicates partial progress toward the next level). The scale is chosen when an assessment
-          is created and locked afterward.
+          is created and locked afterward. Level 0 (Not Performed) means the activity is not performed at all;
+          levels 1&ndash;5 carry the policy and process expectations below.
         </p>
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-100">
             <tr>
-              <th className="p-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Level</th>
-              <th className="p-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-              <th className="p-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+              <th className="p-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Maturity Level</th>
+              <th className="p-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Expectation of Policy Maturity Level</th>
+              <th className="p-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Expectation of Process Maturity Level</th>
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
-            {CMMI_LEVELS.map((level) => (
+            {CMMI_EXPECTATIONS.map((level) => (
               <tr key={level.level}>
-                <td className="p-3 text-sm font-medium">{level.level}</td>
-                <td className="p-3 text-sm">{level.name}</td>
-                <td className="p-3 text-sm">{level.description}</td>
+                <td className="p-3 text-sm font-medium whitespace-nowrap align-top">Level {level.level} - {level.name}</td>
+                <td className="p-3 text-sm align-top">{level.policy}</td>
+                <td className="p-3 text-sm align-top">{level.process}</td>
               </tr>
             ))}
           </tbody>

--- a/src/pages/ScoringLegend.js
+++ b/src/pages/ScoringLegend.js
@@ -145,7 +145,7 @@ const ScoringLegend = () => {
         </div>
       </div>
 
-      <p className="text-sm text-gray-600 mt-6 mb-2 italic">Scoring Legend from Mastering Cyber Resilience by AKYLADE</p>
+      <p className="text-sm text-gray-600 mt-6 mb-2 italic">Scoring Legend from Simply Cyber Academy</p>
 
       <h1 className="text-2xl font-bold mb-4 mt-4">5-Point Maturity Scale (CMMI-Style)</h1>
       <div className="bg-white p-4 rounded-lg shadow-sm border overflow-x-auto">

--- a/src/utils/scoringScale.js
+++ b/src/utils/scoringScale.js
@@ -40,6 +40,47 @@ export const CMMI_LEVELS = [
 ];
 
 /**
+ * Per-level policy/process maturity expectations for the 5-point CMMI-style
+ * scale, from the Cyber Resilience courses in Simply Cyber Academy. Levels
+ * 1-5 only by design — level 0 (Not Performed) means the activity does not
+ * occur at all, so there is no policy/process expectation to state. Rendered
+ * on the Reference page; CMMI_LEVELS above stays the short-label source for
+ * dropdowns, the wizard, and report legends.
+ */
+export const CMMI_EXPECTATIONS = [
+  {
+    level: 1,
+    name: 'Initial',
+    policy: 'Policy or standard does not exist or is not formally approved by management.',
+    process: 'Standard process does not exist.'
+  },
+  {
+    level: 2,
+    name: 'Repeatable',
+    policy: 'Policy or standard exists, but has not been reviewed in more than 2 years.',
+    process: 'Ad-hoc process exists and is done informally.'
+  },
+  {
+    level: 3,
+    name: 'Defined',
+    policy: 'Policy and standard exists with formal management approval. Policy exceptions are documented, approved and occur less than 5% of the time.',
+    process: 'Formal process exists and is documented. Evidence can be provided for most activities. Less than 10% exceptions.'
+  },
+  {
+    level: 4,
+    name: 'Managed',
+    policy: 'Policy and standard exists with formal management approval. Policy exceptions are documented, approved and occur less than 3% of the time.',
+    process: 'Formal process exists and is documented. Evidence can be provided for all activities and detailed metrics of the process are captured and reported. Minimal target for metrics has been established. Less than 5% of process exceptions occur with minimal reoccurring exceptions.'
+  },
+  {
+    level: 5,
+    name: 'Optimizing',
+    policy: 'Policy and standard exists with formal management approval. Policy exceptions are documented, approved and occur less than 0.5% of the time.',
+    process: 'Formal process exists and is documented. Evidence can be provided for all activities and detailed metrics of the process are captured and reported. Minimal target for metrics has been established and continually improving. Less than 1% of process exceptions occur.'
+  }
+];
+
+/**
  * Resolve an assessment's scoring scale. Anything other than an explicit
  * 5 resolves to the default 10 — including legacy assessments created
  * before the field existed.

--- a/src/utils/scoringScale.test.js
+++ b/src/utils/scoringScale.test.js
@@ -3,6 +3,7 @@ import {
   SCALE_OPTIONS,
   QUARTER_FRACTIONS,
   CMMI_LEVELS,
+  CMMI_EXPECTATIONS,
   getScoringScale,
   wholeScoreOptions,
   scaleRatio,
@@ -154,5 +155,34 @@ describe('scoringScale utilities', () => {
       expect(CMMI_LEVELS[0].name).toBe('Not Performed');
       expect(CMMI_LEVELS[5].name).toBe('Optimizing');
     });
+  });
+});
+
+describe('CMMI_EXPECTATIONS (Reference-page policy/process table)', () => {
+  test('covers exactly levels 1-5 with policy and process expectations', () => {
+    expect(CMMI_EXPECTATIONS.map((e) => e.level)).toEqual([1, 2, 3, 4, 5]);
+    CMMI_EXPECTATIONS.forEach((e) => {
+      expect(typeof e.policy).toBe('string');
+      expect(e.policy.length).toBeGreaterThan(0);
+      expect(typeof e.process).toBe('string');
+      expect(e.process.length).toBeGreaterThan(0);
+    });
+  });
+
+  test('level names stay consistent with CMMI_LEVELS (dropdowns/reports source)', () => {
+    CMMI_EXPECTATIONS.forEach((e) => {
+      expect(e.name).toBe(CMMI_LEVELS.find((l) => l.level === e.level).name);
+    });
+  });
+
+  test('exception thresholds match the course table', () => {
+    const policyByLevel = Object.fromEntries(CMMI_EXPECTATIONS.map((e) => [e.level, e.policy]));
+    expect(policyByLevel[3]).toContain('less than 5%');
+    expect(policyByLevel[4]).toContain('less than 3%');
+    expect(policyByLevel[5]).toContain('less than 0.5%');
+    const processByLevel = Object.fromEntries(CMMI_EXPECTATIONS.map((e) => [e.level, e.process]));
+    expect(processByLevel[3]).toContain('Less than 10% exceptions');
+    expect(processByLevel[4]).toContain('Less than 5% of process exceptions');
+    expect(processByLevel[5]).toContain('Less than 1% of process exceptions');
   });
 });


### PR DESCRIPTION
Two Reference-tab fixes: (1) the About Scoring legend caption (and its SCREENSHOTS.md mirror) still cited "Mastering Cyber Resilience by AKYLADE" — now "Simply Cyber Academy", matching #285. (2) The 5-Point Maturity Scale table is replaced with the Simply Cyber Academy course table: per-level Expectation of Policy / Expectation of Process, Levels 1-5; level 0 (Not Performed) stays explained in the intro prose. CMMI_LEVELS is untouched so wizard/dropdown/report labels are unchanged. Lint clean, 384/384 jest (+3 consistency tests on the new table data).