### PR TITLE
Segregate demo users, findings, and artifacts to the demo assessment (#297)

### DIFF
--- a/src/components/ArtifactSelector.js
+++ b/src/components/ArtifactSelector.js
@@ -3,22 +3,31 @@ import { X, ExternalLink, ChevronRight } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import useArtifactStore from '../stores/artifactStore';
 import { sanitizeExternalUrl } from '../utils/externalLinks';
+import { belongsToAssessment, isUnassigned } from '../utils/assessmentScope';
 
 const ArtifactSelector = ({
   label,
   selectedArtifacts,
   onChange,
   multiple = true,
-  disabled = false
+  disabled = false,
+  // Assessment scope (issue #297): when set, the pick list shows only this
+  // assessment's artifacts plus unassigned (legacy) ones — demo artifacts,
+  // being stamped to the demo assessment, drop out everywhere else. Already-
+  // linked chips always resolve against the full store.
+  assessmentId
 }) => {
-  const artifacts = useArtifactStore((state) => state.artifacts);
+  const allArtifacts = useArtifactStore((state) => state.artifacts);
+  const artifacts = assessmentId
+    ? allArtifacts.filter(a => belongsToAssessment(a, assessmentId) || isUnassigned(a))
+    : allArtifacts;
   const navigate = useNavigate();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef(null);
 
   // Read-mode chip: link out to the artifact URL, or open its detail in the Artifacts tab
   const renderLinkedChip = (name) => {
-    const artifact = artifacts.find(a => a.name === name);
+    const artifact = allArtifacts.find(a => a.name === name);
     const chipClass = 'px-2 py-1 bg-blue-600 text-white rounded-full text-xs inline-flex items-center gap-1 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 cursor-pointer';
 
     if (sanitizeExternalUrl(artifact?.link)) {

--- a/src/components/FindingSelector.js
+++ b/src/components/FindingSelector.js
@@ -2,16 +2,25 @@ import React, { useState, useEffect, useRef } from 'react';
 import { X, AlertTriangle } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import useFindingsStore from '../stores/findingsStore';
+import { belongsToAssessment, isUnassigned } from '../utils/assessmentScope';
 
 const FindingSelector = ({
   label,
   selectedFindings,
   onChange,
   multiple = true,
-  disabled = false
+  disabled = false,
+  // Assessment scope (issue #297): when set, the pick list shows only this
+  // assessment's findings plus unassigned (legacy) ones — demo findings,
+  // being stamped to the demo assessment, drop out everywhere else. Already-
+  // linked chips always render regardless of scope.
+  assessmentId
 }) => {
   const navigate = useNavigate();
-  const findings = useFindingsStore((state) => state.findings);
+  const allFindings = useFindingsStore((state) => state.findings);
+  const findings = assessmentId
+    ? allFindings.filter(f => belongsToAssessment(f, assessmentId) || isUnassigned(f))
+    : allFindings;
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef(null);
 
@@ -32,9 +41,10 @@ const FindingSelector = ({
     }
   };
 
-  // Get finding by ID
+  // Get finding by ID — resolves against the FULL store so an already-linked
+  // finding renders its chip even when the scope filter hides it from the list
   const getFindingById = (findingId) => {
-    return findings.find(f => f.id === findingId);
+    return allFindings.find(f => f.id === findingId);
   };
 
   // Close dropdown when clicking outside

--- a/src/components/TerminalStatusBar.js
+++ b/src/components/TerminalStatusBar.js
@@ -7,6 +7,7 @@ import useRequirementsStore from '../stores/requirementsStore';
 import useFindingsStore from '../stores/findingsStore';
 import useArtifactStore from '../stores/artifactStore';
 import { generateExecutiveSummary } from '../utils/executiveSummaryPDF';
+import { filterByScope } from '../utils/assessmentScope';
 import {
   getTimeSinceLastExport,
   getLastExportDate,
@@ -66,8 +67,9 @@ const TerminalStatusBar = ({ onBackupClick }) => {
       generateExecutiveSummary({
         assessment: currentAssessment,
         requirements,
-        findings,
-        artifacts,
+        // Only this assessment's records belong in its summary (issue #297)
+        findings: filterByScope(findings, currentAssessment.id),
+        artifacts: filterByScope(artifacts, currentAssessment.id),
         selectedQuarter,
       });
     } catch (err) {

--- a/src/components/UserSelector.js
+++ b/src/components/UserSelector.js
@@ -58,13 +58,25 @@ const UserSelector = ({
   selectedUsers,
   onChange,
   multiple = false,
-  disabled = false
+  disabled = false,
+  // Assessment scoping (issue #297). When scopeUserIds is an array, the
+  // dropdown lists ONLY those users (the assessment's roster) by default —
+  // the rest of the directory stays behind an explicit "Browse directory"
+  // expansion (or a typed search). Picking a directory user calls
+  // onAddToScope(userId) so the caller can link them onto the roster —
+  // without that, a rosterless assessment would be a dead end.
+  scopeUserIds,
+  onAddToScope
 }) => {
   const users = useUserStore((state) => state.users);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
+  const [browseDirectory, setBrowseDirectory] = useState(false);
   const dropdownRef = useRef(null);
   const triggerRef = useRef(null);
+
+  const scoped = Array.isArray(scopeUserIds);
+  const scopeSet = scoped ? new Set(scopeUserIds) : null;
 
   // Get selected user objects
   const getSelectedUserObjects = () => {
@@ -83,17 +95,23 @@ const UserSelector = ({
   const selectedUserObjects = getSelectedUserObjects();
 
   // Filter users based on search
-  const filteredUsers = users.filter(user => {
+  const matchesSearch = (user) => {
     const searchLower = searchTerm.toLowerCase();
     return (
       user.name?.toLowerCase().includes(searchLower) ||
       user.email?.toLowerCase().includes(searchLower) ||
       user.title?.toLowerCase().includes(searchLower)
     );
-  });
+  };
+  const filteredUsers = (scoped ? users.filter(u => scopeSet.has(u.id)) : users).filter(matchesSearch);
+  const directoryUsers = scoped ? users.filter(u => !scopeSet.has(u.id)).filter(matchesSearch) : [];
+  const showDirectory = scoped && (browseDirectory || searchTerm.trim() !== '');
 
   // Handle selecting a user
   const handleSelectUser = (user) => {
+    if (scoped && !scopeSet.has(user.id) && onAddToScope) {
+      onAddToScope(user.id);
+    }
     if (multiple) {
       if (selectedUsers && selectedUsers.includes(user.id)) {
         onChange(selectedUsers.filter(id => id !== user.id));
@@ -103,6 +121,7 @@ const UserSelector = ({
     } else {
       onChange(user.id);
       setDropdownOpen(false);
+      setBrowseDirectory(false);
     }
     setSearchTerm('');
   };
@@ -128,6 +147,7 @@ const UserSelector = ({
       ) {
         setDropdownOpen(false);
         setSearchTerm('');
+        setBrowseDirectory(false);
       }
     };
 
@@ -141,6 +161,37 @@ const UserSelector = ({
       return selectedUsers && selectedUsers.includes(userId);
     }
     return selectedUsers === userId;
+  };
+
+  // One dropdown row — shared by the main (roster) list and the directory section
+  const renderUserRow = (user) => {
+    const selected = isUserSelected(user.id);
+    return (
+      <button
+        key={user.id}
+        className={`w-full p-2 text-left hover:bg-gray-50 flex items-center gap-3 ${
+          selected ? 'bg-blue-50' : ''
+        }`}
+        onClick={() => handleSelectUser(user)}
+      >
+        <UserAvatar user={user} size="sm" />
+        <div className="flex-1 min-w-0">
+          <div className="font-medium text-sm truncate">{user.name}</div>
+          <div className="text-xs text-gray-500 truncate">
+            {user.email && <span className="text-blue-600">{user.email}</span>}
+            {user.email && user.title && <span className="mx-1">•</span>}
+            {user.title && <span>{user.title}</span>}
+          </div>
+        </div>
+        {selected && (
+          <div className="w-5 h-5 bg-blue-500 rounded-full flex items-center justify-center">
+            <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+        )}
+      </button>
+    );
   };
 
   return (
@@ -191,38 +242,40 @@ const UserSelector = ({
                 {/* User list */}
                 <div className="max-h-60 overflow-auto">
                   {filteredUsers.length > 0 ? (
-                    filteredUsers.map(user => {
-                      const selected = isUserSelected(user.id);
-                      return (
-                        <button
-                          key={user.id}
-                          className={`w-full p-2 text-left hover:bg-gray-50 flex items-center gap-3 ${
-                            selected ? 'bg-blue-50' : ''
-                          }`}
-                          onClick={() => handleSelectUser(user)}
-                        >
-                          <UserAvatar user={user} size="sm" />
-                          <div className="flex-1 min-w-0">
-                            <div className="font-medium text-sm truncate">{user.name}</div>
-                            <div className="text-xs text-gray-500 truncate">
-                              {user.email && <span className="text-blue-600">{user.email}</span>}
-                              {user.email && user.title && <span className="mx-1">•</span>}
-                              {user.title && <span>{user.title}</span>}
-                            </div>
-                          </div>
-                          {selected && (
-                            <div className="w-5 h-5 bg-blue-500 rounded-full flex items-center justify-center">
-                              <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
-                              </svg>
-                            </div>
-                          )}
-                        </button>
-                      );
-                    })
+                    filteredUsers.map(user => renderUserRow(user))
                   ) : (
                     <div className="p-4 text-sm text-gray-500 text-center">
-                      {searchTerm ? 'No matching users' : 'No users available'}
+                      {searchTerm
+                        ? 'No matching users'
+                        : (scoped ? 'No users on this assessment yet' : 'No users available')}
+                    </div>
+                  )}
+
+                  {/* Directory expansion (scoped mode): the rest of the user
+                      directory, behind an explicit browse/search step so demo
+                      or unrelated users never crowd the assessment's own list */}
+                  {scoped && !showDirectory && (
+                    <div className="p-2 border-t">
+                      <button
+                        className="w-full px-3 py-1.5 text-sm text-blue-600 hover:bg-blue-50 rounded transition-colors"
+                        onClick={() => setBrowseDirectory(true)}
+                      >
+                        Browse directory…
+                      </button>
+                    </div>
+                  )}
+                  {scoped && showDirectory && (
+                    <div className="border-t">
+                      <div className="p-2 text-xs text-gray-500">
+                        Directory — selecting adds the user to this assessment
+                      </div>
+                      {directoryUsers.length > 0 ? (
+                        directoryUsers.map(user => renderUserRow(user))
+                      ) : (
+                        <div className="p-4 text-sm text-gray-500 text-center">
+                          {searchTerm ? 'No matching directory users' : 'No other users in the directory'}
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>

--- a/src/components/UserSelector.test.js
+++ b/src/components/UserSelector.test.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import UserSelector from './UserSelector';
+import useUserStore from '../stores/userStore';
+
+/**
+ * Scoped mode (issue #297): with scopeUserIds set, the dropdown lists only
+ * the assessment's roster; the rest of the directory sits behind an explicit
+ * "Browse directory…" expansion (or a typed search), and picking a directory
+ * user reports it through onAddToScope so the caller can link them.
+ */
+
+const DIRECTORY = [
+  { id: 'u1', name: 'Roster Rita', title: 'Auditor', email: 'rita@example.com' },
+  { id: 'u2', name: 'Directory Dan', title: 'Engineer', email: 'dan@example.com' },
+  { id: 'u3', name: 'Demo Gerry', title: 'CISO', email: 'gerry@almasecurity.example' }
+];
+
+beforeEach(() => {
+  useUserStore.setState({ users: DIRECTORY });
+});
+
+const openDropdown = () => fireEvent.click(screen.getByTitle('Select user'));
+
+describe('UserSelector — unscoped (legacy behavior unchanged)', () => {
+  it('lists the whole directory', () => {
+    render(<UserSelector selectedUsers={null} onChange={() => {}} />);
+    openDropdown();
+    expect(screen.getByText('Roster Rita')).toBeInTheDocument();
+    expect(screen.getByText('Directory Dan')).toBeInTheDocument();
+    expect(screen.getByText('Demo Gerry')).toBeInTheDocument();
+    expect(screen.queryByText('Browse directory…')).not.toBeInTheDocument();
+  });
+});
+
+describe('UserSelector — scoped mode (issue #297)', () => {
+  it('lists only the roster by default; directory users are hidden', () => {
+    render(<UserSelector selectedUsers={null} onChange={() => {}} scopeUserIds={['u1']} />);
+    openDropdown();
+    expect(screen.getByText('Roster Rita')).toBeInTheDocument();
+    expect(screen.queryByText('Directory Dan')).not.toBeInTheDocument();
+    expect(screen.queryByText('Demo Gerry')).not.toBeInTheDocument();
+  });
+
+  it('an empty roster shows a helpful empty state, not the demo directory', () => {
+    render(<UserSelector selectedUsers={null} onChange={() => {}} scopeUserIds={[]} />);
+    openDropdown();
+    expect(screen.getByText('No users on this assessment yet')).toBeInTheDocument();
+    expect(screen.queryByText('Demo Gerry')).not.toBeInTheDocument();
+  });
+
+  it('Browse directory reveals the rest of the directory', () => {
+    render(<UserSelector selectedUsers={null} onChange={() => {}} scopeUserIds={['u1']} />);
+    openDropdown();
+    fireEvent.click(screen.getByText('Browse directory…'));
+    expect(screen.getByText('Directory Dan')).toBeInTheDocument();
+    expect(screen.getByText('Directory — selecting adds the user to this assessment')).toBeInTheDocument();
+  });
+
+  it('typing a search also surfaces matching directory users', () => {
+    render(<UserSelector selectedUsers={null} onChange={() => {}} scopeUserIds={['u1']} />);
+    openDropdown();
+    fireEvent.change(screen.getByPlaceholderText('Search users...'), { target: { value: 'Dan' } });
+    expect(screen.getByText('Directory Dan')).toBeInTheDocument();
+  });
+
+  it('picking a directory user fires onAddToScope AND onChange', () => {
+    const onChange = jest.fn();
+    const onAddToScope = jest.fn();
+    render(
+      <UserSelector
+        selectedUsers={null}
+        onChange={onChange}
+        scopeUserIds={['u1']}
+        onAddToScope={onAddToScope}
+      />
+    );
+    openDropdown();
+    fireEvent.click(screen.getByText('Browse directory…'));
+    fireEvent.click(screen.getByText('Directory Dan'));
+    expect(onAddToScope).toHaveBeenCalledWith('u2');
+    expect(onChange).toHaveBeenCalledWith('u2');
+  });
+
+  it('picking a roster user does NOT fire onAddToScope', () => {
+    const onAddToScope = jest.fn();
+    render(
+      <UserSelector
+        selectedUsers={null}
+        onChange={() => {}}
+        scopeUserIds={['u1']}
+        onAddToScope={onAddToScope}
+      />
+    );
+    openDropdown();
+    fireEvent.click(screen.getByText('Roster Rita'));
+    expect(onAddToScope).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/selectorScoping.test.js
+++ b/src/components/selectorScoping.test.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import FindingSelector from './FindingSelector';
+import ArtifactSelector from './ArtifactSelector';
+import useFindingsStore from '../stores/findingsStore';
+import useArtifactStore from '../stores/artifactStore';
+import { COMPREHENSIVE_ASSESSMENT_ID } from '../stores/comprehensiveAssessmentData';
+
+/**
+ * Eval-panel pick lists scope to the assessment being evaluated (issue #297):
+ * demo records (stamped to the demo assessment) drop out of every other
+ * assessment; unassigned legacy records stay reachable everywhere.
+ */
+
+const MINE = 'ASM-user-2026';
+
+const FINDINGS = [
+  { id: 'FND-demo', jiraKey: 'FND-demo', summary: 'Demo finding', status: 'Not Started', priority: 'High', assessmentId: COMPREHENSIVE_ASSESSMENT_ID },
+  { id: 'FND-mine', jiraKey: 'FND-mine', summary: 'My finding', status: 'Not Started', priority: 'High', assessmentId: MINE },
+  { id: 'FND-legacy', jiraKey: 'FND-legacy', summary: 'Legacy finding', status: 'Not Started', priority: 'Low' }
+];
+
+const ARTIFACTS = [
+  { id: 'a-demo', artifactId: 'AR-demo', name: 'Demo artifact', assessmentId: COMPREHENSIVE_ASSESSMENT_ID },
+  { id: 'a-mine', artifactId: 'AR-mine', name: 'My artifact', assessmentId: MINE },
+  { id: 'a-legacy', artifactId: 'AR-legacy', name: 'Legacy artifact' }
+];
+
+const renderWithRouter = (ui) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('FindingSelector scoping (issue #297)', () => {
+  beforeEach(() => useFindingsStore.setState({ findings: FINDINGS }));
+
+  it('scoped to my assessment: my + legacy findings listed, demo hidden', () => {
+    renderWithRouter(
+      <FindingSelector label="Findings" selectedFindings={[]} onChange={() => {}} assessmentId={MINE} />
+    );
+    fireEvent.click(screen.getByText('Select findings'));
+    expect(screen.getByText('FND-mine')).toBeInTheDocument();
+    expect(screen.getByText('FND-legacy')).toBeInTheDocument();
+    expect(screen.queryByText('FND-demo')).not.toBeInTheDocument();
+  });
+
+  it('scoped to the demo assessment: demo findings ARE listed', () => {
+    renderWithRouter(
+      <FindingSelector label="Findings" selectedFindings={[]} onChange={() => {}} assessmentId={COMPREHENSIVE_ASSESSMENT_ID} />
+    );
+    fireEvent.click(screen.getByText('Select findings'));
+    expect(screen.getByText('FND-demo')).toBeInTheDocument();
+  });
+
+  it('no assessmentId prop: unscoped legacy behavior (everything listed)', () => {
+    renderWithRouter(
+      <FindingSelector label="Findings" selectedFindings={[]} onChange={() => {}} />
+    );
+    fireEvent.click(screen.getByText('Select findings'));
+    expect(screen.getByText('FND-demo')).toBeInTheDocument();
+    expect(screen.getByText('FND-mine')).toBeInTheDocument();
+  });
+
+  it('an already-linked out-of-scope finding still renders its chip', () => {
+    renderWithRouter(
+      <FindingSelector label="Findings" selectedFindings={['FND-demo']} onChange={() => {}} assessmentId={MINE} />
+    );
+    // Chip text is the jiraKey; it must resolve even though the list hides it
+    expect(screen.getByText('FND-demo')).toBeInTheDocument();
+  });
+});
+
+describe('ArtifactSelector scoping (issue #297)', () => {
+  beforeEach(() => useArtifactStore.setState({ artifacts: ARTIFACTS }));
+
+  it('scoped to my assessment: my + legacy artifacts listed, demo hidden', () => {
+    renderWithRouter(
+      <ArtifactSelector label="Artifacts" selectedArtifacts={[]} onChange={() => {}} assessmentId={MINE} />
+    );
+    fireEvent.click(screen.getByText('Select artifacts'));
+    expect(screen.getByText('My artifact')).toBeInTheDocument();
+    expect(screen.getByText('Legacy artifact')).toBeInTheDocument();
+    expect(screen.queryByText('Demo artifact')).not.toBeInTheDocument();
+  });
+
+  it('scoped to the demo assessment: demo artifacts ARE listed', () => {
+    renderWithRouter(
+      <ArtifactSelector label="Artifacts" selectedArtifacts={[]} onChange={() => {}} assessmentId={COMPREHENSIVE_ASSESSMENT_ID} />
+    );
+    fireEvent.click(screen.getByText('Select artifacts'));
+    expect(screen.getByText('Demo artifact')).toBeInTheDocument();
+  });
+
+  it('an already-linked out-of-scope artifact still renders its chip', () => {
+    renderWithRouter(
+      <ArtifactSelector label="Artifacts" selectedArtifacts={['Demo artifact']} onChange={() => {}} assessmentId={MINE} />
+    );
+    expect(screen.getByText('Demo artifact')).toBeInTheDocument();
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -161,6 +161,7 @@ code {
 .items-start { align-items: flex-start; }
 .justify-center { justify-content: center; }
 .justify-between { justify-content: space-between; }
+.justify-end { justify-content: flex-end; }
 
 /* Grid */
 .grid { display: grid; }
@@ -190,7 +191,9 @@ code {
 .px-8 { padding-left: 2rem; padding-right: 2rem; }
 .px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
 .px-12 { padding-left: 3rem; padding-right: 3rem; }
+.py-0\.5 { padding-top: 0.125rem; padding-bottom: 0.125rem; }
 .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.py-1\.5 { padding-top: 0.375rem; padding-bottom: 0.375rem; }
 .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
 .py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
 .py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
@@ -232,6 +235,7 @@ code {
 
 /* Space between */
 .space-y-0\.5 > * + * { margin-top: 0.125rem; }
+.space-y-1 > * + * { margin-top: 0.25rem; }
 .space-y-2 > * + * { margin-top: 0.5rem; }
 .space-y-4 > * + * { margin-top: 1rem; }
 .space-y-6 > * + * { margin-top: 1.5rem; }
@@ -318,7 +322,9 @@ code {
 /* Text alignment & transform */
 .text-left { text-align: left; }
 .text-center { text-align: center; }
+.text-right { text-align: right; }
 .uppercase { text-transform: uppercase; }
+.capitalize { text-transform: capitalize; }
 .italic { font-style: italic; }
 .tracking-wider { letter-spacing: 0.05em; }
 .whitespace-pre-wrap { white-space: pre-wrap; }

--- a/src/pages/Artifacts.js
+++ b/src/pages/Artifacts.js
@@ -6,7 +6,9 @@ import useCSFStore from '../stores/csfStore';
 import useArtifactStore from '../stores/artifactStore';
 import useUserStore from '../stores/userStore';
 import useControlsStore from '../stores/controlsStore';
+import useAssessmentsStore from '../stores/assessmentsStore';
 import useSort from '../hooks/useSort';
+import { SCOPE_ALL, SCOPE_UNASSIGNED, filterByScope, resolveScopeStamp, defaultScope } from '../utils/assessmentScope';
 import { extractArtifactsFromProfile } from '../updateArtifactLinks';
 import EmptyState from '../components/EmptyState';
 import { sanitizeExternalUrl } from '../utils/externalLinks';
@@ -22,6 +24,22 @@ const Artifacts = () => {
   const deleteArtifact = useArtifactStore((state) => state.deleteArtifact);
   const users = useUserStore((state) => state.users);
   const getControlsByRequirement = useControlsStore((state) => state.getControlsByRequirement);
+  const assessments = useAssessmentsStore((state) => state.assessments);
+  const currentAssessmentId = useAssessmentsStore((state) => state.currentAssessmentId);
+
+  // Assessment scope (issue #297): page-local — never mutates the app-wide
+  // current assessment. Defaults to the assessment being worked; follows when
+  // the user switches assessments in the status bar.
+  const [scopeFilter, setScopeFilter] = useState(() => defaultScope(currentAssessmentId));
+  useEffect(() => {
+    setScopeFilter(defaultScope(currentAssessmentId));
+  }, [currentAssessmentId]);
+  const scopedArtifacts = useMemo(
+    () => filterByScope(artifacts, scopeFilter, {
+      knownAssessmentIds: assessments.map(a => a.id)
+    }),
+    [artifacts, scopeFilter, assessments]
+  );
 
   const [formData, setFormData] = useState({
     id: null,
@@ -41,8 +59,8 @@ const Artifacts = () => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef(null);
 
-  // Sorting
-  const { sort, sortedData, handleSort } = useSort(artifacts);
+  // Sorting (over the scoped list — issue #297)
+  const { sort, sortedData, handleSort } = useSort(scopedArtifacts);
 
   // Get linked controls for the selected artifact
   const linkedControls = useMemo(() => {
@@ -192,6 +210,9 @@ const Artifacts = () => {
         artifactId: formData.artifactId || `AR-${artifacts.length + 1}`,
         status: formData.status || 'ACTIVE',
         priority: formData.priority || 'Medium',
+        // Stamp into the active scope (issue #297): a concrete scope selection
+        // wins, else the app-wide current assessment, else null (unassigned)
+        assessmentId: resolveScopeStamp(scopeFilter, currentAssessmentId),
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString()
       };
@@ -267,10 +288,15 @@ const Artifacts = () => {
         ...target,
         linkedSubcategoryIds: target.linkedSubcategoryIds || []
       });
+      // If the active scope hides the deep-linked artifact, widen the
+      // page-local scope so it is visible (issue #297)
+      if (filterByScope([target], scopeFilter).length === 0) {
+        setScopeFilter(target.assessmentId || SCOPE_ALL);
+      }
     }
     // Clear the state so refresh/back doesn't re-trigger the selection
     navigate(location.pathname, { replace: true, state: null });
-  }, [location.state, location.pathname, artifacts, navigate]);
+  }, [location.state, location.pathname, artifacts, navigate, scopeFilter]);
 
   // Get status badge style
   const getStatusStyle = (status) => {
@@ -298,9 +324,25 @@ const Artifacts = () => {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-xl font-bold text-gray-900 dark:text-white">Artifacts</h1>
-            <p className="text-sm text-gray-500 dark:text-gray-400">{artifacts.length} items</p>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {scopedArtifacts.length} items{scopeFilter !== SCOPE_ALL ? ` · ${artifacts.length} total` : ''}
+            </p>
           </div>
           <div className="flex items-center gap-3">
+            {/* Assessment scope (issue #297) */}
+            <select
+              value={scopeFilter}
+              onChange={(e) => setScopeFilter(e.target.value)}
+              className="text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+              title="Show artifacts for one assessment"
+              aria-label="Assessment scope"
+            >
+              <option value={SCOPE_ALL}>All assessments</option>
+              {assessments.map(a => (
+                <option key={a.id} value={a.id}>{a.name}</option>
+              ))}
+              <option value={SCOPE_UNASSIGNED}>Unassigned only</option>
+            </select>
             <input
               type="file"
               accept=".csv"
@@ -440,8 +482,10 @@ const Artifacts = () => {
             ) : (
               <EmptyState
                 icon={FileArchive}
-                title="No artifacts linked"
-                description="Add artifacts to document evidence for your controls."
+                title={artifacts.length > 0 ? 'No artifacts in this scope' : 'No artifacts linked'}
+                description={artifacts.length > 0
+                  ? 'This assessment has no artifacts yet. Switch the scope selector to All assessments to see everything.'
+                  : 'Add artifacts to document evidence for your controls.'}
                 actionLabel="Add an Artifact"
                 onAction={() => {
                   resetForm();
@@ -540,6 +584,34 @@ const Artifacts = () => {
                   <ChevronRight size={16} className="rotate-90" />
                   Key details
                 </h3>
+
+                {/* Assessment scope (issue #297): visible + reassignable, so an
+                    imported or mis-scoped artifact is never stranded */}
+                <div className="mb-4">
+                  <label className="text-sm text-gray-500 dark:text-gray-400 block mb-1">Assessment</label>
+                  {editMode ? (
+                    <select
+                      name="assessmentId"
+                      value={formData.assessmentId || ''}
+                      onChange={(e) => setFormData({ ...formData, assessmentId: e.target.value || null })}
+                      className="w-full p-2 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white"
+                      aria-label="Assessment"
+                    >
+                      <option value="">Unassigned (all scopes)</option>
+                      {assessments.map(a => (
+                        <option key={a.id} value={a.id}>{a.name}</option>
+                      ))}
+                      {formData.assessmentId && !assessments.some(a => a.id === formData.assessmentId) && (
+                        <option value={formData.assessmentId}>{formData.assessmentId} (not found)</option>
+                      )}
+                    </select>
+                  ) : (
+                    <span className="text-sm text-gray-700 dark:text-gray-300">
+                      {assessments.find(a => a.id === selectedArtifact?.assessmentId)?.name
+                        || (selectedArtifact?.assessmentId ? `${selectedArtifact.assessmentId} (not found)` : 'Unassigned')}
+                    </span>
+                  )}
+                </div>
 
                 {/* Link */}
                 <div className="mb-4">

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -20,7 +20,7 @@ import EmptyState from '../components/EmptyState';
 import ScoreSelect from '../components/ScoreSelect';
 
 // Stores
-import useAssessmentsStore from '../stores/assessmentsStore';
+import useAssessmentsStore, { normalizeAssessmentUsers, ASSESSMENT_USER_ROLES } from '../stores/assessmentsStore';
 import useControlsStore from '../stores/controlsStore';
 import useRequirementsStore, { isCsfRequirement } from '../stores/requirementsStore';
 import useUserStore from '../stores/userStore';
@@ -78,6 +78,11 @@ const Assessments = () => {
   const importAssessmentsCSV = useAssessmentsStore((state) => state.importAssessmentsCSV);
   const exportAllAssessmentsCSV = useAssessmentsStore((state) => state.exportAllAssessmentsCSV);
   const cloneAssessment = useAssessmentsStore((state) => state.cloneAssessment);
+  const addAssessmentUser = useAssessmentsStore((state) => state.addAssessmentUser);
+  const removeAssessmentUser = useAssessmentsStore((state) => state.removeAssessmentUser);
+  const setAssessmentUserRole = useAssessmentsStore((state) => state.setAssessmentUserRole);
+  // Subscribed (not getState) so the roster editor re-renders on directory edits
+  const directoryUsers = useUserStore((state) => state.users);
 
   const controls = useControlsStore((state) => state.controls);
   const getControl = useControlsStore((state) => state.getControl);
@@ -179,6 +184,17 @@ const Assessments = () => {
   const currentAssessment = useMemo(() => {
     return assessments.find(a => a.id === currentAssessmentId);
   }, [assessments, currentAssessmentId]);
+
+  // The current assessment's user roster (issues #290/#297) — the scope for
+  // the eval-panel user picker
+  const rosterUserIds = useMemo(
+    () => normalizeAssessmentUsers(currentAssessment?.users).map(u => u.userId),
+    [currentAssessment]
+  );
+  const rosterUsers = useMemo(
+    () => normalizeAssessmentUsers(currentAssessment?.users),
+    [currentAssessment]
+  );
 
   // Get progress for current assessment
   const progress = useMemo(() => {
@@ -1487,6 +1503,7 @@ Format as a numbered list. Be specific and actionable.`;
                       selectedArtifacts={currentObservation.linkedArtifacts || []}
                       onChange={(artifacts) => handleObservationChange('linkedArtifacts', artifacts)}
                       disabled={!editMode}
+                      assessmentId={currentAssessmentId}
                     />
                   </div>
 
@@ -1497,6 +1514,7 @@ Format as a numbered list. Be specific and actionable.`;
                       selectedFindings={currentObservation.linkedFindings || []}
                       onChange={(findings) => handleObservationChange('linkedFindings', findings)}
                       disabled={!editMode}
+                      assessmentId={currentAssessmentId}
                     />
                   </div>
 
@@ -1550,6 +1568,8 @@ Format as a numbered list. Be specific and actionable.`;
                         selectedUsers={currentObservation.auditorId}
                         onChange={(userId) => handleObservationChange('auditorId', userId)}
                         disabled={!editMode}
+                        scopeUserIds={rosterUserIds}
+                        onAddToScope={(userId) => addAssessmentUser(currentAssessmentId, userId, 'auditor')}
                       />
                       {!currentObservation.auditorId && (
                         <p className="text-xs text-blue-600 dark:text-blue-400 mt-1">Assign to me</p>
@@ -1583,6 +1603,59 @@ Format as a numbered list. Be specific and actionable.`;
                       <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{currentAssessment.year}</span>
                     </div>
                   )}
+
+                  {/* Assessment users (issues #290/#297): the roster that scopes
+                      the user pickers on this assessment. Editable here because
+                      the wizard is the only other place the roster exists. */}
+                  <div className="flex items-start justify-between">
+                    <span className="text-sm text-gray-500 dark:text-gray-400">Users</span>
+                    <div className="text-right space-y-1">
+                      {rosterUsers.length === 0 && (
+                        <span className="text-sm text-gray-400">None</span>
+                      )}
+                      {rosterUsers.map(({ userId, role }) => {
+                        const user = directoryUsers.find(u => u.id === userId);
+                        if (!user) return null;
+                        return (
+                          <div key={userId} className="flex items-center gap-1.5 justify-end">
+                            <span className="text-sm text-gray-700 dark:text-gray-300 truncate" title={user.email || user.name}>
+                              {user.name}
+                            </span>
+                            {editMode ? (
+                              <select
+                                value={role}
+                                onChange={(e) => setAssessmentUserRole(currentAssessmentId, userId, e.target.value)}
+                                className="text-xs border border-gray-300 dark:border-gray-600 rounded px-1 py-0.5 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                                aria-label={`Role for ${user.name}`}
+                              >
+                                {ASSESSMENT_USER_ROLES.map(r => (
+                                  <option key={r} value={r}>{r}</option>
+                                ))}
+                              </select>
+                            ) : (
+                              <span className="text-xs text-gray-500 dark:text-gray-400 capitalize">{role}</span>
+                            )}
+                            {editMode && (
+                              <button
+                                onClick={() => removeAssessmentUser(currentAssessmentId, userId)}
+                                className="text-gray-400 hover:text-red-500"
+                                title={`Remove ${user.name} from this assessment`}
+                                aria-label={`Remove ${user.name} from this assessment`}
+                              >
+                                <X size={12} />
+                              </button>
+                            )}
+                          </div>
+                        );
+                      })}
+                      {editMode && (
+                        <UserSelector
+                          selectedUsers={null}
+                          onChange={(userId) => addAssessmentUser(currentAssessmentId, userId)}
+                        />
+                      )}
+                    </div>
+                  </div>
 
                   {/* Quarter selector */}
                   <div className="flex items-center justify-between">

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -31,6 +31,7 @@ import useFindingsStore from '../stores/findingsStore';
 import useArtifactStore from '../stores/artifactStore';
 import KPICard from '../components/KPICard';
 import { generateAuditReportMarkdown } from '../utils/auditReportMarkdown';
+import { filterByScope } from '../utils/assessmentScope';
 import EvidenceTracker from '../components/EvidenceTracker';
 
 // Format number to always show one decimal place
@@ -566,8 +567,9 @@ const Dashboard = () => {
     const inScopeCount = selectedAssessment.scopeIds?.length || 0;
 
     // 3. Evidence Coverage — % of in-scope items with at least one artifact
+    // (only this assessment's artifacts count — issue #297)
     const controlsWithArtifacts = new Set(
-      artifacts
+      filterByScope(artifacts, selectedAssessment.id)
         .filter(a => a.controlId)
         .map(a => a.controlId)
     );
@@ -577,8 +579,9 @@ const Dashboard = () => {
       ? `${Math.round((coveredCount / inScopeCount) * 100)}%`
       : '--';
 
-    // 4. Open Findings — status !== 'Resolved'
-    const openCount = findings.filter(f => f.status !== 'Resolved').length;
+    // 4. Open Findings — status !== 'Resolved', scoped to this assessment (issue #297)
+    const openCount = filterByScope(findings, selectedAssessment.id)
+      .filter(f => f.status !== 'Resolved').length;
 
     return {
       overallScore: { value: overallScore, trend: overallTrend },
@@ -1250,8 +1253,9 @@ const Dashboard = () => {
                   generateAuditReportMarkdown({
                     assessment: selectedAssessment,
                     requirements,
-                    findings,
-                    artifacts,
+                    // Only this assessment's records belong in its report (issue #297)
+                    findings: filterByScope(findings, selectedAssessment?.id),
+                    artifacts: filterByScope(artifacts, selectedAssessment?.id),
                     selectedQuarter,
                     reportMetadata: auditMetadata,
                   });

--- a/src/pages/Findings.js
+++ b/src/pages/Findings.js
@@ -8,6 +8,7 @@ import useControlsStore from '../stores/controlsStore';
 import useRequirementsStore from '../stores/requirementsStore';
 import useAssessmentsStore from '../stores/assessmentsStore';
 import { sanitizeExternalUrl, externalUrlLabel } from '../utils/externalLinks';
+import { SCOPE_ALL, SCOPE_UNASSIGNED, filterByScope, resolveScopeStamp, defaultScope } from '../utils/assessmentScope';
 import useSort from '../hooks/useSort';
 import EmptyState from '../components/EmptyState';
 import Markdown from '../components/Markdown';
@@ -26,10 +27,25 @@ const Findings = () => {
   const getControlsByRequirement = useControlsStore((state) => state.getControlsByRequirement);
   const requirements = useRequirementsStore((state) => state.requirements);
   const assessments = useAssessmentsStore((state) => state.assessments);
+  const currentAssessmentId = useAssessmentsStore((state) => state.currentAssessmentId);
 
   // External-tracking config of the assessment a finding belongs to (issue #284)
   const trackingForAssessment = (assessmentId) =>
     assessments.find((a) => a.id === assessmentId)?.externalTracking;
+
+  // Assessment scope (issue #297): page-local — never mutates the app-wide
+  // current assessment. Defaults to the assessment being worked; follows when
+  // the user switches assessments in the status bar.
+  const [scopeFilter, setScopeFilter] = useState(() => defaultScope(currentAssessmentId));
+  useEffect(() => {
+    setScopeFilter(defaultScope(currentAssessmentId));
+  }, [currentAssessmentId]);
+  const scopedFindings = useMemo(
+    () => filterByScope(findings, scopeFilter, {
+      knownAssessmentIds: assessments.map(a => a.id)
+    }),
+    [findings, scopeFilter, assessments]
+  );
 
   const [formData, setFormData] = useState({
     id: null,
@@ -61,11 +77,16 @@ const Findings = () => {
         setSelectedFinding(finding);
         setFormData({ ...finding });
         setEditMode(false);
+        // If the active scope hides the deep-linked finding, widen the
+        // page-local scope so it is visible (issue #297)
+        if (filterByScope([finding], scopeFilter).length === 0) {
+          setScopeFilter(finding.assessmentId || SCOPE_ALL);
+        }
         // Clear the URL parameter after selection
         setSearchParams({}, { replace: true });
       }
     }
-  }, [searchParams, findings, setSearchParams]);
+  }, [searchParams, findings, setSearchParams, scopeFilter]);
 
   // Resize handlers
   const handleMouseDown = useCallback((e) => {
@@ -110,8 +131,8 @@ const Findings = () => {
     return () => window.removeEventListener('keyboard-new-item', handleNewItem);
   }, []);
 
-  // Sorting
-  const { sortedData } = useSort(findings);
+  // Sorting (over the scoped list — issue #297)
+  const { sortedData } = useSort(scopedFindings);
 
   // Get linked controls for the selected finding based on complianceRequirement
   const linkedControls = useMemo(() => {
@@ -205,7 +226,12 @@ const Findings = () => {
       setSelectedFinding({ ...selectedFinding, ...formData });
       toast.success('Finding updated');
     } else {
-      const newFinding = createFinding(formData);
+      // Stamp the new finding into the active scope (issue #297): a concrete
+      // scope selection wins, else the app-wide current assessment, else null
+      const newFinding = createFinding({
+        ...formData,
+        assessmentId: resolveScopeStamp(scopeFilter, currentAssessmentId)
+      });
       toast.success('Finding created');
       setSelectedFinding(newFinding);
     }
@@ -318,9 +344,25 @@ const Findings = () => {
               <AlertTriangle size={24} className="text-amber-500" />
               Findings
             </h1>
-            <p className="text-sm text-gray-500 dark:text-gray-400">{findings.length} items</p>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {scopedFindings.length} items{scopeFilter !== SCOPE_ALL ? ` · ${findings.length} total` : ''}
+            </p>
           </div>
           <div className="flex items-center gap-3">
+            {/* Assessment scope (issue #297) */}
+            <select
+              value={scopeFilter}
+              onChange={(e) => setScopeFilter(e.target.value)}
+              className="text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+              title="Show findings for one assessment"
+              aria-label="Assessment scope"
+            >
+              <option value={SCOPE_ALL}>All assessments</option>
+              {assessments.map(a => (
+                <option key={a.id} value={a.id}>{a.name}</option>
+              ))}
+              <option value={SCOPE_UNASSIGNED}>Unassigned only</option>
+            </select>
             <input
               type="file"
               accept=".csv"
@@ -476,8 +518,10 @@ const Findings = () => {
             ) : (
               <EmptyState
                 icon={AlertTriangle}
-                title="No findings recorded"
-                description="Record findings as you discover gaps in your assessment."
+                title={findings.length > 0 ? 'No findings in this scope' : 'No findings recorded'}
+                description={findings.length > 0
+                  ? 'This assessment has no findings yet. Switch the scope selector to All assessments to see everything.'
+                  : 'Record findings as you discover gaps in your assessment.'}
                 actionLabel="Record a Finding"
                 onAction={() => {
                   resetForm();
@@ -727,6 +771,34 @@ const Findings = () => {
                 </h3>
 
                 <div className="space-y-4">
+                  {/* Assessment scope (issue #297): visible + reassignable, so an
+                      imported or mis-scoped finding is never stranded */}
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-gray-500 dark:text-gray-400">Assessment</span>
+                    {editMode ? (
+                      <select
+                        name="assessmentId"
+                        value={formData.assessmentId || ''}
+                        onChange={(e) => setFormData({ ...formData, assessmentId: e.target.value || null })}
+                        className="p-1 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white max-w-[200px]"
+                        aria-label="Assessment"
+                      >
+                        <option value="">Unassigned (all scopes)</option>
+                        {assessments.map(a => (
+                          <option key={a.id} value={a.id}>{a.name}</option>
+                        ))}
+                        {formData.assessmentId && !assessments.some(a => a.id === formData.assessmentId) && (
+                          <option value={formData.assessmentId}>{formData.assessmentId} (not found)</option>
+                        )}
+                      </select>
+                    ) : (
+                      <span className="text-sm text-gray-700 dark:text-gray-300">
+                        {assessments.find(a => a.id === selectedFinding?.assessmentId)?.name
+                          || (selectedFinding?.assessmentId ? `${selectedFinding.assessmentId} (not found)` : 'Unassigned')}
+                      </span>
+                    )}
+                  </div>
+
                   {/* CSF Compliance Requirement */}
                   <div className="flex items-center justify-between">
                     <span className="text-sm text-gray-500 dark:text-gray-400">CSF Reference</span>

--- a/src/pages/Requirements.js
+++ b/src/pages/Requirements.js
@@ -25,6 +25,8 @@ import useArtifactStore from '../stores/artifactStore';
 import useFindingsStore from '../stores/findingsStore';
 import useUserStore from '../stores/userStore';
 import useUIStore from '../stores/uiStore';
+import useAssessmentsStore from '../stores/assessmentsStore';
+import { filterByScope, defaultScope } from '../utils/assessmentScope';
 
 const Requirements = () => {
   // Store state
@@ -40,11 +42,30 @@ const Requirements = () => {
   // Controls, artifacts, and findings for the detail panel and table display
   const controls = useControlsStore((state) => state.controls);
   const getControlsByRequirement = useControlsStore((state) => state.getControlsByRequirement);
-  const artifacts = useArtifactStore((state) => state.artifacts);
-  const getArtifactsByControl = useArtifactStore((state) => state.getArtifactsByControl);
-  const findings = useFindingsStore((state) => state.findings);
-  const getFindingsByControl = useFindingsStore((state) => state.getFindingsByControl);
+  const allArtifactRecords = useArtifactStore((state) => state.artifacts);
+  const allFindingRecords = useFindingsStore((state) => state.findings);
   const users = useUserStore((state) => state.users);
+  const currentAssessmentId = useAssessmentsStore((state) => state.currentAssessmentId);
+
+  // Evidence shown per control follows the assessment being worked (issue
+  // #297): demo records, stamped to the demo assessment, drop out of every
+  // other context; unassigned (legacy/user) records stay visible everywhere.
+  const artifacts = useMemo(
+    () => filterByScope(allArtifactRecords, defaultScope(currentAssessmentId)),
+    [allArtifactRecords, currentAssessmentId]
+  );
+  const findings = useMemo(
+    () => filterByScope(allFindingRecords, defaultScope(currentAssessmentId)),
+    [allFindingRecords, currentAssessmentId]
+  );
+  const getArtifactsByControl = useCallback(
+    (controlId) => artifacts.filter(a => a.controlId === controlId),
+    [artifacts]
+  );
+  const getFindingsByControl = useCallback(
+    (controlId) => findings.filter(f => f.controlId === controlId),
+    [findings]
+  );
 
   // UI state
   const darkMode = useUIStore((state) => state.darkMode);

--- a/src/pages/UserManagement.js
+++ b/src/pages/UserManagement.js
@@ -301,7 +301,17 @@ const UserManagement = () => {
             {users.length > 0 ? (
               users.map((user) => (
                 <tr key={user.id} className="hover:bg-gray-50:bg-gray-700">
-                  <td className="p-3 text-sm">{user.name}</td>
+                  <td className="p-3 text-sm">
+                    {user.name}
+                    {user.seedSource === 'demo-alma' && (
+                      <span
+                        className="badge badge-neutral ml-1"
+                        title="Shipped example user — part of the Alma Security demo assessment"
+                      >
+                        Demo
+                      </span>
+                    )}
+                  </td>
                   <td className="p-3 text-sm">{user.title}</td>
                   <td className="p-3 text-sm">{user.email}</td>
                   <td className="p-3 text-sm">

--- a/src/stores/artifactStore.js
+++ b/src/stores/artifactStore.js
@@ -4,16 +4,19 @@ import Papa from 'papaparse';
 import { v4 as uuidv4 } from 'uuid';
 import { escapeCSVValue } from '../utils/sanitize';
 import { DEFAULT_ARTIFACTS, RELOCATED_ARTIFACT_LINKS } from './defaultArtifactsData';
-import { COMPREHENSIVE_ARTIFACTS } from './comprehensiveAssessmentData';
+import { COMPREHENSIVE_ARTIFACTS, COMPREHENSIVE_ASSESSMENT_ID } from './comprehensiveAssessmentData';
+import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
 
 // Merge defaults + catalog artifacts. De-dupe by artifactId; catalog wins ties.
-const SEEDED_ARTIFACTS = (() => {
+// Every shipped artifact is Alma demo evidence, so all of them are scoped to
+// the demo assessment (issue #297) and carry seed provenance.
+export const SEEDED_ARTIFACTS = (() => {
   const seen = new Set();
   const merged = [];
   for (const a of [...DEFAULT_ARTIFACTS, ...COMPREHENSIVE_ARTIFACTS]) {
     if (seen.has(a.artifactId)) continue;
     seen.add(a.artifactId);
-    merged.push(a);
+    merged.push({ ...a, assessmentId: COMPREHENSIVE_ASSESSMENT_ID, seedSource: DEMO_SEED_SOURCE });
   }
   return merged;
 })();
@@ -44,6 +47,9 @@ const useArtifactStore = create(
 
           // Primary link: Control (general evidence for a control)
           controlId: artifact.controlId || null,
+
+          // Assessment scope (issue #297): null = visible in every scope
+          assessmentId: artifact.assessmentId || null,
 
           // Secondary link: Evaluations (point-in-time evidence for specific assessments)
           linkedEvaluationIds: artifact.linkedEvaluationIds || [],
@@ -271,6 +277,7 @@ const useArtifactStore = create(
           'Link': escapeCSVValue(a.link || ''),
           'Type': escapeCSVValue(a.type || 'Document'),
           'Control ID': escapeCSVValue(a.controlId || ''),
+          'Assessment ID': a.assessmentId || '',
           'Linked Evaluation IDs': (a.linkedEvaluationIds || []).join('; '),
           'Compliance Requirement': escapeCSVValue(a.complianceRequirement || ''), // Deprecated
           'Linked Subcategories': (a.linkedSubcategoryIds || []).join('; '), // Deprecated
@@ -355,6 +362,14 @@ const useArtifactStore = create(
                     // Primary link
                     controlId: row['Control ID'] || row['Custom field (Control ID)'] || null,
 
+                    // Assessment scope (issue #297). Header-name based, so older
+                    // CSVs without the column simply land unassigned (null =
+                    // visible in every per-assessment view). An id that names no
+                    // current assessment is preserved as-is — it stays reachable
+                    // under the All scope and survives a later restore of that
+                    // assessment; imports never silently rewrite it.
+                    assessmentId: (row['Assessment ID'] || '').trim() || null,
+
                     // Secondary link: Evaluations
                     linkedEvaluationIds: (row['Linked Evaluation IDs'] || row['Custom field (Linked Evaluation IDs)'] || '')
                       .split(';').map(s => s.trim()).filter(Boolean),
@@ -392,14 +407,8 @@ const useArtifactStore = create(
     }),
     {
       name: 'csf-artifacts-storage',
-      version: 7,
-      migrate: (persistedState, version) => {
-        // Version 7 (#287) runs after the version chain below rather than as another branch in
-        // it. The branches return early, so a user coming from v5 would never reach a v7 branch
-        // placed at the end. Repairing afterwards covers every upgrade path, and it is a no-op
-        // on the branches that reset to DEFAULT_ARTIFACTS, which already carry the new links.
-        return repairRelocatedLinks(applyVersionMigrations(persistedState, version));
-      },
+      version: 8,
+      migrate: (persistedState, version) => migrateArtifactsState(persistedState, version),
       partialize: (state) => ({
         artifacts: state.artifacts
       })
@@ -419,6 +428,56 @@ const useArtifactStore = create(
  * replace the link with a function or an object, which JSON.stringify then drops on the way
  * into localStorage. Silent field loss is not an acceptable failure mode for a migration.
  */
+/**
+ * Full persisted-state migration for csf-artifacts-storage. Exported so tests
+ * exercise the EXACT production path. Version 7 (#287) and version 8 (#297)
+ * run after the version chain rather than as more branches in it — the
+ * branches return early, so a user coming from v5 would never reach a branch
+ * placed at the end. Repairing afterwards covers every upgrade path, and both
+ * passes are no-ops on states that already carry the new data.
+ */
+export function migrateArtifactsState(persistedState, version) {
+  return stampSeededDemoArtifacts(repairRelocatedLinks(applyVersionMigrations(persistedState, version)));
+}
+
+/**
+ * Version 8 (issue #297): scope the shipped demo artifacts to the demo assessment.
+ *
+ * Existing installs hold copies of the seeded Alma artifacts with no assessmentId, so they
+ * bleed into every assessment's Artifacts view. Stamp exactly those copies with the demo
+ * assessment id and seed provenance. Heal-in-place with a conservative guard:
+ *
+ * - Match requires BOTH the seeded artifactId AND the exact seeded name — the Artifacts page
+ *   suggests `AR-<n>` ids for new records, so an id alone can collide with a user's own
+ *   artifact. A seeded record the user renamed stays unstamped (null = visible everywhere,
+ *   so nothing the user can see is ever lost).
+ * - An artifact that already has ANY assessmentId is never touched.
+ *
+ * Idempotent: once stamped, the no-assessmentId guard matches nothing.
+ */
+export function stampSeededDemoArtifacts(state) {
+  const artifacts = state?.artifacts;
+  if (!Array.isArray(artifacts)) return state;
+
+  const seededNamesById = new Map(SEEDED_ARTIFACTS.map(a => [a.artifactId, a.name]));
+
+  let changed = false;
+  const stamped = artifacts.map(artifact => {
+    // Absent-only: any existing assessmentId OR seedSource means this record
+    // has already been classified (locally or by the install that exported
+    // it) — never re-derive over an existing classification.
+    if (!artifact || artifact.assessmentId || artifact.seedSource) return artifact;
+    // The match must be POSITIVE on both sides — a record with an unknown
+    // artifactId and no name must not match via undefined === undefined.
+    const seededName = seededNamesById.get(artifact.artifactId);
+    if (!seededName || seededName !== artifact.name) return artifact;
+    changed = true;
+    return { ...artifact, assessmentId: COMPREHENSIVE_ASSESSMENT_ID, seedSource: DEMO_SEED_SOURCE };
+  });
+
+  return changed ? { ...state, artifacts: stamped } : state;
+}
+
 export function repairRelocatedLinks(state) {
   const artifacts = state?.artifacts;
   if (!Array.isArray(artifacts)) return state;

--- a/src/stores/artifactStore.migration.test.js
+++ b/src/stores/artifactStore.migration.test.js
@@ -1,5 +1,12 @@
-import { repairRelocatedLinks } from './artifactStore';
-import { RELOCATED_ARTIFACT_LINKS } from './defaultArtifactsData';
+import {
+  repairRelocatedLinks,
+  stampSeededDemoArtifacts,
+  migrateArtifactsState,
+  SEEDED_ARTIFACTS
+} from './artifactStore';
+import { RELOCATED_ARTIFACT_LINKS, DEFAULT_ARTIFACTS } from './defaultArtifactsData';
+import { COMPREHENSIVE_ARTIFACTS, COMPREHENSIVE_ASSESSMENT_ID } from './comprehensiveAssessmentData';
+import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
 
 const [DEAD_LINK, LIVE_LINK] = Object.entries(RELOCATED_ARTIFACT_LINKS)[0];
 
@@ -108,5 +115,133 @@ describe('repairRelocatedLinks (artifacts store migration v7, issue #287)', () =
       expect(target).toContain('/ASSESSMENT_CATALOG/');
       expect(target).not.toContain('/Sample_Artifacts/');
     }
+  });
+});
+
+describe('stampSeededDemoArtifacts (artifacts store migration v8, issue #297)', () => {
+  // What a pre-#297 install actually holds: the seeded records without the
+  // new fields.
+  const legacySeed = (a) => {
+    const { assessmentId, seedSource, ...rest } = a;
+    return rest;
+  };
+
+  test('stamps a persisted seeded demo artifact with the demo assessment + provenance', () => {
+    const before = { artifacts: [legacySeed(SEEDED_ARTIFACTS[0])] };
+    const after = stampSeededDemoArtifacts(before);
+    expect(after.artifacts[0].assessmentId).toBe(COMPREHENSIVE_ASSESSMENT_ID);
+    expect(after.artifacts[0].seedSource).toBe(DEMO_SEED_SOURCE);
+  });
+
+  test('does NOT stamp a user artifact whose artifactId collides but whose name differs', () => {
+    const mine = { ...legacySeed(SEEDED_ARTIFACTS[0]), name: 'My own evidence file' };
+    const after = stampSeededDemoArtifacts({ artifacts: [mine] });
+    expect(after.artifacts[0].assessmentId).toBeUndefined();
+    expect(after.artifacts[0].seedSource).toBeUndefined();
+  });
+
+  test('never overwrites an existing assessmentId', () => {
+    const rescoped = { ...legacySeed(SEEDED_ARTIFACTS[0]), assessmentId: 'ASM-user-2026' };
+    const after = stampSeededDemoArtifacts({ artifacts: [rescoped] });
+    expect(after.artifacts[0].assessmentId).toBe('ASM-user-2026');
+    expect(after.artifacts[0].seedSource).toBeUndefined();
+  });
+
+  test('preserves user edits on a stamped record (heal-in-place, only the two fields change)', () => {
+    const edited = { ...legacySeed(SEEDED_ARTIFACTS[0]), description: 'my notes', status: 'ARCHIVED' };
+    const after = stampSeededDemoArtifacts({ artifacts: [edited] });
+    expect(after.artifacts[0]).toEqual({
+      ...edited,
+      assessmentId: COMPREHENSIVE_ASSESSMENT_ID,
+      seedSource: DEMO_SEED_SOURCE
+    });
+  });
+
+  test('is idempotent — a second pass changes nothing', () => {
+    const once = stampSeededDemoArtifacts({ artifacts: [legacySeed(SEEDED_ARTIFACTS[0])] });
+    expect(stampSeededDemoArtifacts(once)).toBe(once);
+  });
+
+  test('never deletes a record — counts are equal before and after', () => {
+    const before = {
+      artifacts: [
+        ...SEEDED_ARTIFACTS.map(legacySeed),
+        { artifactId: 'AR-mine', name: 'Mine', link: '' }
+      ]
+    };
+    expect(stampSeededDemoArtifacts(before).artifacts).toHaveLength(before.artifacts.length);
+  });
+
+  test('a record with an unknown id and NO name is never stamped (undefined must not match undefined)', () => {
+    const after = stampSeededDemoArtifacts({ artifacts: [{ artifactId: 'AR-unknown' }] });
+    expect(after.artifacts[0].assessmentId).toBeUndefined();
+  });
+
+  test('tolerates corrupt state shapes', () => {
+    expect(stampSeededDemoArtifacts(undefined)).toBeUndefined();
+    expect(stampSeededDemoArtifacts({ artifacts: 'corrupt' }).artifacts).toBe('corrupt');
+  });
+});
+
+describe('migrateArtifactsState — the production migrate path (issue #297)', () => {
+  test('a pristine v7 install converges to exactly the fresh v8 seed', () => {
+    // v7 installs held DEFAULT + COMPREHENSIVE merged, de-duped by artifactId,
+    // without the new fields — reconstruct that from the shipped data.
+    const seen = new Set();
+    const v7State = { artifacts: [] };
+    for (const a of [...DEFAULT_ARTIFACTS, ...COMPREHENSIVE_ARTIFACTS]) {
+      if (seen.has(a.artifactId)) continue;
+      seen.add(a.artifactId);
+      v7State.artifacts.push({ ...a });
+    }
+    expect(migrateArtifactsState(v7State, 7).artifacts).toEqual(SEEDED_ARTIFACTS);
+  });
+
+  test('a v6 state also picks up the v8 stamp (post-chain pass runs on every path)', () => {
+    const v6State = { artifacts: [{ ...COMPREHENSIVE_ARTIFACTS[0] }] };
+    const after = migrateArtifactsState(v6State, 6);
+    expect(after.artifacts.find(a => a.artifactId === COMPREHENSIVE_ARTIFACTS[0].artifactId).assessmentId)
+      .toBe(COMPREHENSIVE_ASSESSMENT_ID);
+  });
+
+  test('a user-created artifact rides the full chain untouched', () => {
+    const mine = { artifactId: 'AR-9001', name: 'My evidence', link: 'https://intranet.example.com/x' };
+    const after = migrateArtifactsState({ artifacts: [mine] }, 7);
+    expect(after.artifacts[0]).toEqual(mine);
+  });
+});
+
+describe('artifacts CSV assessment scope round-trip (issue #297)', () => {
+  // The import path is header-name based, so older CSVs without the column
+  // simply land unassigned.
+  const useArtifactStore = require('./artifactStore').default;
+
+  beforeEach(() => useArtifactStore.setState({ artifacts: [] }));
+
+  test('importArtifactsCSV reads the Assessment ID column', async () => {
+    const csv = [
+      'Artifact ID,Name,Description,Link,Type,Control ID,Assessment ID',
+      'AR-X1,Scoped artifact,desc,,Document,,ASM-user-2026',
+      'AR-X2,Unscoped artifact,desc,,Document,,'
+    ].join('\n');
+    await useArtifactStore.getState().importArtifactsCSV(csv);
+    const byId = Object.fromEntries(useArtifactStore.getState().artifacts.map(a => [a.artifactId, a]));
+    expect(byId['AR-X1'].assessmentId).toBe('ASM-user-2026');
+    expect(byId['AR-X2'].assessmentId).toBeNull();
+  });
+
+  test('an older CSV without the column imports as unassigned', async () => {
+    const csv = ['Artifact ID,Name,Description', 'AR-X3,Old-format artifact,desc'].join('\n');
+    await useArtifactStore.getState().importArtifactsCSV(csv);
+    expect(useArtifactStore.getState().artifacts[0].assessmentId).toBeNull();
+  });
+
+  test('an id naming no current assessment is preserved, not silently nulled', async () => {
+    const csv = [
+      'Artifact ID,Name,Description,Assessment ID',
+      'AR-X4,Foreign artifact,desc,ASM-not-here'
+    ].join('\n');
+    await useArtifactStore.getState().importArtifactsCSV(csv);
+    expect(useArtifactStore.getState().artifacts[0].assessmentId).toBe('ASM-not-here');
   });
 });

--- a/src/stores/assessmentYearUsers.test.js
+++ b/src/stores/assessmentYearUsers.test.js
@@ -243,3 +243,53 @@ describe('findOrCreateUserByEmail — email-authoritative wizard resolver (issue
     expect(useUserStore.getState().findOrCreateUserByEmail({ name: 'No Email' })).toBeNull();
   });
 });
+
+describe('assessment user roster actions (issue #297)', () => {
+  const rosterOf = (id) =>
+    useAssessmentsStore.getState().assessments.find(a => a.id === id).users;
+
+  const makeAssessment = (users = []) =>
+    useAssessmentsStore.getState().createAssessment({ name: 'Roster test', users }).id;
+
+  test('addAssessmentUser appends a normalized pair with the given role', () => {
+    const id = makeAssessment();
+    useAssessmentsStore.getState().addAssessmentUser(id, 42, 'auditor');
+    expect(rosterOf(id)).toEqual([{ userId: 42, role: 'auditor' }]);
+  });
+
+  test('adding the same user twice dedupes (first role wins)', () => {
+    const id = makeAssessment();
+    useAssessmentsStore.getState().addAssessmentUser(id, 42, 'auditor');
+    useAssessmentsStore.getState().addAssessmentUser(id, 42, 'stakeholder');
+    expect(rosterOf(id)).toEqual([{ userId: 42, role: 'auditor' }]);
+  });
+
+  test('an unknown role is coerced to stakeholder, not dropped', () => {
+    const id = makeAssessment();
+    useAssessmentsStore.getState().addAssessmentUser(id, 42, 'Supreme Leader');
+    expect(rosterOf(id)).toEqual([{ userId: 42, role: 'stakeholder' }]);
+  });
+
+  test('removeAssessmentUser removes exactly that user', () => {
+    const id = makeAssessment([{ userId: 1, role: 'auditor' }, { userId: 2, role: 'stakeholder' }]);
+    useAssessmentsStore.getState().removeAssessmentUser(id, 1);
+    expect(rosterOf(id)).toEqual([{ userId: 2, role: 'stakeholder' }]);
+  });
+
+  test('setAssessmentUserRole changes the role; an invalid role is refused (pair kept)', () => {
+    const id = makeAssessment([{ userId: 1, role: 'auditor' }]);
+    useAssessmentsStore.getState().setAssessmentUserRole(id, 1, 'control owner');
+    expect(rosterOf(id)).toEqual([{ userId: 1, role: 'control owner' }]);
+    useAssessmentsStore.getState().setAssessmentUserRole(id, 1, 'nonsense');
+    expect(rosterOf(id)).toEqual([{ userId: 1, role: 'control owner' }]);
+  });
+
+  test('the shipped demo roster is a valid, already-normalized user scope', () => {
+    // The seed must survive normalizeAssessmentUsers unchanged — otherwise
+    // the demo assessment would install with a roster the producer gate
+    // silently prunes.
+    const { DEMO_ASSESSMENT_USERS } = require('./assessmentsStore');
+    expect(normalizeAssessmentUsers(DEMO_ASSESSMENT_USERS)).toEqual(DEMO_ASSESSMENT_USERS);
+    expect(DEMO_ASSESSMENT_USERS).toHaveLength(8);
+  });
+});

--- a/src/stores/assessmentsStore.js
+++ b/src/stores/assessmentsStore.js
@@ -15,6 +15,21 @@ import { getBankProcedure, BANK_VERSION } from '../utils/procedureBank';
 import { cleanCommunityMarkdown } from '../utils/relatedSection.mjs';
 import useAuditLogStore from './auditLogStore';
 
+// The demo assessment's user roster (issue #297): the 8 shipped Alma
+// directory users, so the example demonstrates the per-assessment user scope
+// and the demo staff stop appearing in every other assessment's pickers.
+// Roles derive from their directory titles (userStore DEFAULT_USERS).
+export const DEMO_ASSESSMENT_USERS = [
+  { userId: 1, role: 'stakeholder' },    // Gerry.Callahan — CISO
+  { userId: 2, role: 'auditor' },        // Steve.Mercer — Director, Internal Audit
+  { userId: 3, role: 'control owner' },  // Jane.Alvarez — Product Engineer
+  { userId: 4, role: 'control owner' },  // John.Tran — Financial Systems Analyst
+  { userId: 5, role: 'control owner' },  // Chris.Magann — Vulnerability Management Lead
+  { userId: 6, role: 'control owner' },  // Nadia.Khan — Detection & Response Lead
+  { userId: 7, role: 'control owner' },  // Tigan.Wang — Vulnerability Management Engineer
+  { userId: 8, role: 'auditor' }         // Omar.Garza — Senior IT Auditor
+];
+
 const COMPREHENSIVE_ASSESSMENT = {
   id: COMPREHENSIVE_ASSESSMENT_ID,
   name: '2026 Alma Security Comprehensive CSF Assessment',
@@ -23,7 +38,8 @@ const COMPREHENSIVE_ASSESSMENT = {
   frameworkFilter: null,
   createdDate: '2026-04-30T00:00:00.000Z',
   scopeIds: COMPREHENSIVE_SCOPE_IDS,
-  observations: COMPREHENSIVE_OBSERVATIONS
+  observations: COMPREHENSIVE_OBSERVATIONS,
+  users: DEMO_ASSESSMENT_USERS
 };
 
 // Example data shipped with the software (issue #294): ONLY the newest,
@@ -140,7 +156,7 @@ export const normalizeAssessmentUsers = (value) => {
  * Current schema version of csf-assessments-storage. Exported so the restore
  * path (dataImport.js) can migrate older exported payloads before applying them.
  */
-export const ASSESSMENTS_SCHEMA_VERSION = 14;
+export const ASSESSMENTS_SCHEMA_VERSION = 15;
 
 /**
  * Full persisted-state migration chain for csf-assessments-storage.
@@ -318,6 +334,21 @@ export const migrateAssessmentsState = (persistedState, version) => {
         : (assessments[0]?.id ?? null);
     }
     state = { ...state, assessments, currentAssessmentId };
+  }
+
+  // v15 (issue #297): seed the demo assessment's user roster. Existing
+  // installs predate the roster, so their copy of the demo assessment has
+  // users: [] and the eval-panel user picker (now roster-scoped) would go
+  // empty. Heal-in-place: ONLY the demo assessment, ONLY when its roster is
+  // empty — a roster the user populated (or deliberately pruned to a
+  // non-empty set) is never replaced.
+  if (version < 15) {
+    const assessments = (state.assessments || []).map(a =>
+      a.id === COMPREHENSIVE_ASSESSMENT_ID && normalizeAssessmentUsers(a.users).length === 0
+        ? { ...a, users: DEMO_ASSESSMENT_USERS }
+        : a
+    );
+    state = { ...state, assessments };
   }
 
   return state;
@@ -622,6 +653,41 @@ const useAssessmentsStore = create(
             : a
         );
         get().setAssessments(updatedAssessments);
+      },
+
+      // ── Assessment user roster (issues #290/#297) ─────────────────────────
+      // The roster is the per-assessment user scope. All three actions route
+      // through updateAssessment so normalizeAssessmentUsers stays the single
+      // producer-side gate (dedupe, role allowlist, no PII on the record).
+
+      addAssessmentUser: (assessmentId, userId, role = 'stakeholder') => {
+        const assessment = get().assessments.find(a => a.id === assessmentId);
+        if (!assessment || userId === undefined || userId === null || userId === '') return;
+        // Coerce an unknown role rather than letting normalize drop the pair.
+        const cleanRole = typeof role === 'string' ? role.trim().toLowerCase() : '';
+        const safeRole = ASSESSMENT_USER_ROLES.includes(cleanRole) ? cleanRole : 'stakeholder';
+        const current = normalizeAssessmentUsers(assessment.users);
+        if (current.some(u => u.userId === userId)) return; // already on the roster
+        get().updateAssessment(assessmentId, { users: [...current, { userId, role: safeRole }] });
+      },
+
+      removeAssessmentUser: (assessmentId, userId) => {
+        const assessment = get().assessments.find(a => a.id === assessmentId);
+        if (!assessment) return;
+        const current = normalizeAssessmentUsers(assessment.users);
+        get().updateAssessment(assessmentId, { users: current.filter(u => u.userId !== userId) });
+      },
+
+      setAssessmentUserRole: (assessmentId, userId, role) => {
+        const assessment = get().assessments.find(a => a.id === assessmentId);
+        if (!assessment) return;
+        // An unknown role would make normalize DROP the pair — refuse instead.
+        const cleanRole = typeof role === 'string' ? role.trim().toLowerCase() : '';
+        if (!ASSESSMENT_USER_ROLES.includes(cleanRole)) return;
+        const current = normalizeAssessmentUsers(assessment.users);
+        get().updateAssessment(assessmentId, {
+          users: current.map(u => (u.userId === userId ? { ...u, role: cleanRole } : u))
+        });
       },
 
       // Delete assessment

--- a/src/stores/assessmentsStore.migrate.test.js
+++ b/src/stores/assessmentsStore.migrate.test.js
@@ -1,4 +1,4 @@
-import { migrateAssessmentsState } from './assessmentsStore';
+import { migrateAssessmentsState, DEMO_ASSESSMENT_USERS } from './assessmentsStore';
 import { getBankProcedure, BANK_VERSION } from '../utils/procedureBank';
 
 /**
@@ -501,6 +501,55 @@ describe('migrateAssessmentsState', () => {
       const before = JSON.stringify(state.assessments[0].observations);
       const result = migrateAssessmentsState(state, 13);
       expect(JSON.stringify(result.assessments[0].observations)).toBe(before);
+    });
+  });
+
+  describe('v15: demo assessment user roster seed (issue #297)', () => {
+    const DEMO_ID = 'ASM-2026-comprehensive-alma';
+
+    test('seeds the demo roster when the demo assessment has no users', () => {
+      const state = {
+        assessments: [{ id: DEMO_ID, observations: {}, users: [] }],
+        currentAssessmentId: DEMO_ID
+      };
+      const result = migrateAssessmentsState(state, 14);
+      expect(result.assessments[0].users).toEqual(DEMO_ASSESSMENT_USERS);
+    });
+
+    test('seeds when the users field is missing entirely (pre-#290 payload shape)', () => {
+      const state = { assessments: [{ id: DEMO_ID, observations: {} }] };
+      const result = migrateAssessmentsState(state, 14);
+      expect(result.assessments[0].users).toEqual(DEMO_ASSESSMENT_USERS);
+    });
+
+    test('a roster the user populated is NEVER replaced (heal-in-place)', () => {
+      const mine = [{ userId: 42, role: 'auditor' }];
+      const state = { assessments: [{ id: DEMO_ID, observations: {}, users: mine }] };
+      const result = migrateAssessmentsState(state, 14);
+      expect(result.assessments[0].users).toEqual(mine);
+    });
+
+    test('other assessments are never touched', () => {
+      const state = { assessments: [{ id: 'ASM-mine', observations: {}, users: [] }] };
+      const result = migrateAssessmentsState(state, 14);
+      expect(result.assessments[0].users).toEqual([]);
+    });
+
+    test('a v0 client falls through all the way to the v15 seed', () => {
+      const state = {
+        assessments: [{ id: DEMO_ID, observations: {} }],
+        currentAssessmentId: DEMO_ID
+      };
+      const result = migrateAssessmentsState(state, 0);
+      expect(result.assessments[0].users).toEqual(DEMO_ASSESSMENT_USERS);
+    });
+
+    test('is idempotent — running the chain again changes nothing', () => {
+      const once = migrateAssessmentsState(
+        { assessments: [{ id: DEMO_ID, observations: {}, users: [] }] }, 14
+      );
+      const twice = migrateAssessmentsState(JSON.parse(JSON.stringify(once)), 15);
+      expect(twice.assessments[0].users).toEqual(once.assessments[0].users);
     });
   });
 });

--- a/src/stores/findingsStore.js
+++ b/src/stores/findingsStore.js
@@ -3,14 +3,20 @@ import { persist } from 'zustand/middleware';
 import Papa from 'papaparse';
 import { v4 as uuidv4 } from 'uuid';
 import { sanitizeInput, escapeCSVValue } from '../utils/sanitize';
-import { COMPREHENSIVE_FINDINGS } from './comprehensiveAssessmentData';
+import { COMPREHENSIVE_FINDINGS, COMPREHENSIVE_ASSESSMENT_ID } from './comprehensiveAssessmentData';
 import { LEGACY_EXAMPLE_ASSESSMENT_IDS } from './assessmentsStore';
+import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
 
 // Only the comprehensive example's findings ship with the software (issue
 // #294). The four FND-1..FND-4 demo findings belonged to the removed legacy
 // example assessments; the v5 migration below drops them from existing
-// installs.
-const SEEDED_FINDINGS = [...COMPREHENSIVE_FINDINGS];
+// installs. All seeded findings are demo data scoped to the demo assessment
+// and carry seed provenance (issue #297).
+export const SEEDED_FINDINGS = COMPREHENSIVE_FINDINGS.map(f => ({
+  ...f,
+  assessmentId: f.assessmentId || COMPREHENSIVE_ASSESSMENT_ID,
+  seedSource: DEMO_SEED_SOURCE
+}));
 
 const LEGACY_DEMO_FINDING_IDS = new Set(['FND-1', 'FND-2', 'FND-3', 'FND-4']);
 
@@ -369,46 +375,76 @@ const useFindingsStore = create(
     }),
     {
       name: 'csf-findings-storage',
-      version: 5,
-      // Fall-through chain (each step feeds the next) so a client on any old
-      // version receives every later migration.
-      migrate: (persistedState, version) => {
-        let state = persistedState || {};
-        if (version < 2) {
-          // v0/v1 semantics preserved exactly: real user findings are KEPT
-          // (the old chain early-returned here), empty states get the seed.
-          if (!(state.findings?.length > 0)) {
-            state = { ...state, findings: SEEDED_FINDINGS };
-          }
-        } else if (version < 3) {
-          // v2-exactly clients were hard-reset to the seeded set.
-          state = { ...state, findings: SEEDED_FINDINGS };
-        }
-        // Version 4: Merge in catalog findings for the comprehensive assessment
-        if (version < 4) {
-          const existing = state.findings || [];
-          const existingIds = new Set(existing.map(f => f.id));
-          const additions = COMPREHENSIVE_FINDINGS.filter(f => !existingIds.has(f.id));
-          state = { ...state, findings: [...existing, ...additions] };
-        }
-        // Version 5 (issue #294): drop the four demo findings that belonged to
-        // the removed legacy example assessments. Guarded by id AND
-        // assessmentId so imported/user records can never match (user-created
-        // findings use FND-<uuid> ids anyway).
-        if (version < 5) {
-          const findings = (state.findings || []).filter(
-            f => !(LEGACY_DEMO_FINDING_IDS.has(f.id) &&
-                   LEGACY_EXAMPLE_ASSESSMENT_IDS.includes(f.assessmentId))
-          );
-          state = { ...state, findings };
-        }
-        return state;
-      },
+      version: 6,
+      migrate: (persistedState, version) => migrateFindingsState(persistedState, version),
       partialize: (state) => ({
         findings: state.findings
       })
     }
   )
 );
+
+/**
+ * Full persisted-state migration for csf-findings-storage. Exported so tests
+ * exercise the EXACT production path. Fall-through chain (each step feeds the
+ * next) so a client on any old version receives every later migration.
+ */
+export function migrateFindingsState(persistedState, version) {
+  let state = persistedState || {};
+  if (version < 2) {
+    // v0/v1 semantics preserved exactly: real user findings are KEPT
+    // (the old chain early-returned here), empty states get the seed.
+    if (!(state.findings?.length > 0)) {
+      state = { ...state, findings: SEEDED_FINDINGS };
+    }
+  } else if (version < 3) {
+    // v2-exactly clients were hard-reset to the seeded set.
+    state = { ...state, findings: SEEDED_FINDINGS };
+  }
+  // Version 4: Merge in catalog findings for the comprehensive assessment
+  if (version < 4) {
+    const existing = state.findings || [];
+    const existingIds = new Set(existing.map(f => f.id));
+    const additions = COMPREHENSIVE_FINDINGS.filter(f => !existingIds.has(f.id));
+    state = { ...state, findings: [...existing, ...additions] };
+  }
+  // Version 5 (issue #294): drop the four demo findings that belonged to
+  // the removed legacy example assessments. Guarded by id AND
+  // assessmentId so imported/user records can never match (user-created
+  // findings use FND-<uuid> ids anyway).
+  if (version < 5) {
+    const findings = (state.findings || []).filter(
+      f => !(LEGACY_DEMO_FINDING_IDS.has(f.id) &&
+             LEGACY_EXAMPLE_ASSESSMENT_IDS.includes(f.assessmentId))
+    );
+    state = { ...state, findings };
+  }
+  // Version 6 (issue #297): stamp seed provenance on the shipped demo
+  // findings (see stampSeededDemoFindings).
+  if (version < 6) {
+    state = stampSeededDemoFindings(state);
+  }
+  return state;
+}
+
+/**
+ * Issue #297: stamp seed provenance on the shipped demo findings. They
+ * already carry the demo assessmentId (shipped that way), so the guard is
+ * id ∈ seeded set AND demo assessmentId — a user record can match neither.
+ * Only seedSource is added; every other field (status, remediation, edits)
+ * is left untouched. Idempotent — also run unconditionally by the restore
+ * path (dataImport.js), whose bulk setters bypass this store's migrate.
+ */
+export function stampSeededDemoFindings(state) {
+  if (!Array.isArray(state?.findings)) return state;
+  const seededIds = new Set(SEEDED_FINDINGS.map(f => f.id));
+  let changed = false;
+  const findings = state.findings.map(f => {
+    if (!(seededIds.has(f.id) && f.assessmentId === COMPREHENSIVE_ASSESSMENT_ID && !f.seedSource)) return f;
+    changed = true;
+    return { ...f, seedSource: DEMO_SEED_SOURCE };
+  });
+  return changed ? { ...state, findings } : state;
+}
 
 export default useFindingsStore;

--- a/src/stores/userStore.js
+++ b/src/stores/userStore.js
@@ -1,18 +1,85 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { v4 as uuidv4 } from 'uuid';
+import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
 
-// Default users for new installations
-const DEFAULT_USERS = [
-  { id: 1, name: 'Gerry.Callahan', title: 'CISO', email: 'gerry.callahan@almasecurity.com' },
-  { id: 2, name: 'Steve.Mercer', title: 'Director, Internal Audit', email: 'steve.mercer@almasecurity.com' },
-  { id: 3, name: 'Jane.Alvarez', title: 'Product Engineer', email: 'jane.alvarez@almasecurity.com' },
-  { id: 4, name: 'John.Tran', title: 'Financial Systems Analyst', email: 'john.tran@almasecurity.com' },
-  { id: 5, name: 'Chris.Magann', title: 'Vulnerability Management Lead', email: 'chris.magann@almasecurity.com' },
-  { id: 6, name: 'Nadia.Khan', title: 'Detection & Response Lead', email: 'nadia.khan@almasecurity.com' },
-  { id: 7, name: 'Tigan.Wang', title: 'Vulnerability Management Engineer', email: 'tigan.wang@almasecurity.com' },
-  { id: 8, name: 'Omar.Garza', title: 'Senior IT Auditor', email: 'omar.garza@almasecurity.com' },
+// Default users for new installations — the demo (Alma Security) staff.
+// seedSource marks them as shipped example data (issue #297) so the directory
+// can badge them and future migrations can identify them exactly.
+export const DEFAULT_USERS = [
+  { id: 1, name: 'Gerry.Callahan', title: 'CISO', email: 'gerry.callahan@almasecurity.com', seedSource: DEMO_SEED_SOURCE },
+  { id: 2, name: 'Steve.Mercer', title: 'Director, Internal Audit', email: 'steve.mercer@almasecurity.com', seedSource: DEMO_SEED_SOURCE },
+  { id: 3, name: 'Jane.Alvarez', title: 'Product Engineer', email: 'jane.alvarez@almasecurity.com', seedSource: DEMO_SEED_SOURCE },
+  { id: 4, name: 'John.Tran', title: 'Financial Systems Analyst', email: 'john.tran@almasecurity.com', seedSource: DEMO_SEED_SOURCE },
+  { id: 5, name: 'Chris.Magann', title: 'Vulnerability Management Lead', email: 'chris.magann@almasecurity.com', seedSource: DEMO_SEED_SOURCE },
+  { id: 6, name: 'Nadia.Khan', title: 'Detection & Response Lead', email: 'nadia.khan@almasecurity.com', seedSource: DEMO_SEED_SOURCE },
+  { id: 7, name: 'Tigan.Wang', title: 'Vulnerability Management Engineer', email: 'tigan.wang@almasecurity.com', seedSource: DEMO_SEED_SOURCE },
+  { id: 8, name: 'Omar.Garza', title: 'Senior IT Auditor', email: 'omar.garza@almasecurity.com', seedSource: DEMO_SEED_SOURCE },
 ];
+
+/**
+ * Full persisted-state migration for csf-users-storage. Exported so tests
+ * exercise the EXACT production path.
+ */
+export const migrateUsersState = (persistedState, version) => {
+  let state = persistedState;
+  // Version 2: Ensure default users have stable IDs
+  // This fixes issues where users were created with random IDs during CSV import
+  if (version < 2 && state?.users) {
+    const defaultUsersByEmail = new Map(
+      DEFAULT_USERS.map(u => [u.email.toLowerCase(), u])
+    );
+
+    // Update existing users to have correct IDs if they match default users
+    const updatedUsers = state.users.map(user => {
+      const defaultUser = defaultUsersByEmail.get(user.email?.toLowerCase());
+      if (defaultUser && user.id !== defaultUser.id) {
+        // Found a default user with wrong ID - keep the default ID
+        return { ...user, id: defaultUser.id };
+      }
+      return user;
+    });
+
+    // Add any missing default users
+    const existingEmails = new Set(updatedUsers.map(u => u.email?.toLowerCase()));
+    DEFAULT_USERS.forEach(defaultUser => {
+      if (!existingEmails.has(defaultUser.email.toLowerCase())) {
+        updatedUsers.push(defaultUser);
+      }
+    });
+
+    state = { users: updatedUsers };
+  }
+  state = state || { users: DEFAULT_USERS };
+  // Version 3 (issue #297): stamp seed provenance on the shipped demo users
+  // (see stampSeededDemoUsers).
+  if (version < 3) {
+    state = stampSeededDemoUsers(state);
+  }
+  return state;
+};
+
+/**
+ * Issue #297: stamp seed provenance on the shipped demo users. Guard is exact
+ * id + email match against the seeded set, so a user-created record can never
+ * be marked demo. Only seedSource is added; edits (title, name) survive.
+ * Idempotent — also run unconditionally by the restore path (dataImport.js),
+ * whose bulk setters bypass this store's migrate.
+ */
+export function stampSeededDemoUsers(state) {
+  if (!Array.isArray(state?.users)) return state;
+  const demoEmailById = new Map(DEFAULT_USERS.map(u => [u.id, u.email.toLowerCase()]));
+  let changed = false;
+  const users = state.users.map(user => {
+    // The match must be POSITIVE on both sides — a record with an unknown id
+    // and no email must not match via undefined === undefined.
+    const demoEmail = demoEmailById.get(user.id);
+    if (user.seedSource || !demoEmail || demoEmail !== user.email?.toLowerCase()) return user;
+    changed = true;
+    return { ...user, seedSource: DEMO_SEED_SOURCE };
+  });
+  return changed ? { ...state, users } : state;
+}
 
 const useUserStore = create(
   persist(
@@ -151,37 +218,8 @@ const useUserStore = create(
     }),
     {
       name: 'csf-users-storage',
-      version: 2,
-      migrate: (persistedState, version) => {
-        // Version 2: Ensure default users have stable IDs
-        // This fixes issues where users were created with random IDs during CSV import
-        if (version < 2 && persistedState?.users) {
-          const defaultUsersByEmail = new Map(
-            DEFAULT_USERS.map(u => [u.email.toLowerCase(), u])
-          );
-
-          // Update existing users to have correct IDs if they match default users
-          const updatedUsers = persistedState.users.map(user => {
-            const defaultUser = defaultUsersByEmail.get(user.email?.toLowerCase());
-            if (defaultUser && user.id !== defaultUser.id) {
-              // Found a default user with wrong ID - keep the default ID
-              return { ...user, id: defaultUser.id };
-            }
-            return user;
-          });
-
-          // Add any missing default users
-          const existingEmails = new Set(updatedUsers.map(u => u.email?.toLowerCase()));
-          DEFAULT_USERS.forEach(defaultUser => {
-            if (!existingEmails.has(defaultUser.email.toLowerCase())) {
-              updatedUsers.push(defaultUser);
-            }
-          });
-
-          return { users: updatedUsers };
-        }
-        return persistedState || { users: DEFAULT_USERS };
-      },
+      version: 3,
+      migrate: (persistedState, version) => migrateUsersState(persistedState, version),
     }
   )
 );

--- a/src/stores/userStore.migration.test.js
+++ b/src/stores/userStore.migration.test.js
@@ -1,0 +1,51 @@
+import { migrateUsersState, DEFAULT_USERS } from './userStore';
+import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
+
+describe('migrateUsersState v3: demo-user provenance stamp (issue #297)', () => {
+  const legacyDemoUser = () => {
+    const { seedSource, ...rest } = DEFAULT_USERS[0];
+    return rest;
+  };
+
+  test('stamps a persisted demo user matched by exact id + email', () => {
+    const result = migrateUsersState({ users: [legacyDemoUser()] }, 2);
+    expect(result.users[0].seedSource).toBe(DEMO_SEED_SOURCE);
+  });
+
+  test('a user-created record is never marked demo — same id, different email', () => {
+    const mine = { id: 1, name: 'My Colleague', email: 'colleague@example.com' };
+    const result = migrateUsersState({ users: [mine] }, 2);
+    expect(result.users[0].seedSource).toBeUndefined();
+  });
+
+  test('a record with an unknown id and NO email is never marked demo (undefined must not match undefined)', () => {
+    const mine = { id: 'u-mine', name: 'No Email User' };
+    const result = migrateUsersState({ users: [mine] }, 2);
+    expect(result.users[0].seedSource).toBeUndefined();
+  });
+
+  test('preserves user edits on a stamped record (only seedSource is added)', () => {
+    const edited = { ...legacyDemoUser(), title: 'Retitled by the user' };
+    const result = migrateUsersState({ users: [edited] }, 2);
+    expect(result.users[0]).toEqual({ ...edited, seedSource: DEMO_SEED_SOURCE });
+  });
+
+  test('a v0 client falls through the id-repair AND picks up the stamp', () => {
+    // v1 shape: demo user present under a wrong (import-era) id
+    const wrongId = { ...legacyDemoUser(), id: 'random-uuid' };
+    const result = migrateUsersState({ users: [wrongId] }, 1);
+    const repaired = result.users.find(u => u.email === DEFAULT_USERS[0].email);
+    expect(repaired.id).toBe(DEFAULT_USERS[0].id);
+    expect(repaired.seedSource).toBe(DEMO_SEED_SOURCE);
+  });
+
+  test('an empty persisted state seeds the (stamped) defaults', () => {
+    const result = migrateUsersState(undefined, 0);
+    expect(result.users).toEqual(DEFAULT_USERS);
+  });
+
+  test('never deletes a record — counts equal before and after', () => {
+    const users = [legacyDemoUser(), { id: 'u-mine', name: 'Me', email: 'me@example.com' }];
+    expect(migrateUsersState({ users }, 2).users).toHaveLength(2);
+  });
+});

--- a/src/utils/assessmentScope.js
+++ b/src/utils/assessmentScope.js
@@ -1,0 +1,79 @@
+/**
+ * Assessment scoping (issue #297).
+ *
+ * Findings, artifacts, and users are stored globally, but most surfaces show
+ * them in the context of one assessment. The shipped demo (Alma) records are
+ * stamped with the demo assessment's id, so they appear only there; records
+ * with no assessmentId (anything a user created before this scheme existed)
+ * are treated as visible in EVERY per-assessment view — hiding a user's own
+ * legacy data behind a filter they never chose is not an acceptable outcome.
+ *
+ * One helper family so every consumer (pages, pick lists, Dashboard KPIs,
+ * report generators) scopes the same way.
+ */
+
+// Provenance marker on records this app ships as example data. Set on the
+// demo users, findings, and artifacts at seed time and stamped onto existing
+// installs' copies by the store migrations.
+export const DEMO_SEED_SOURCE = 'demo-alma';
+
+// Scope filter sentinels for the Findings/Artifacts pages.
+export const SCOPE_ALL = 'all';
+export const SCOPE_UNASSIGNED = 'unassigned';
+
+/** A record with no assessment linkage (legacy/user-created before #297). */
+export const isUnassigned = (record) => !record?.assessmentId;
+
+/**
+ * Does this record belong to the given assessment? Matches the explicit
+ * assessmentId; for findings that predate the assessmentId field, falls back
+ * to the evaluationId convention (evaluation ids embed the assessment id).
+ */
+export const belongsToAssessment = (record, assessmentId) => {
+  if (!record || !assessmentId) return false;
+  if (record.assessmentId === assessmentId) return true;
+  if (!record.assessmentId && typeof record.evaluationId === 'string' &&
+      record.evaluationId.includes(assessmentId)) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Apply a page scope filter. `scope` is SCOPE_ALL, SCOPE_UNASSIGNED, or an
+ * assessment id. Per-assessment views include unassigned records (see module
+ * doc) — demo records, being stamped, drop out of every other assessment.
+ *
+ * opts.knownAssessmentIds (optional Set/array): when given, the Unassigned
+ * view ALSO surfaces orphans — records stamped with an assessment that no
+ * longer exists (deleted assessment). Without it those records would be
+ * reachable only under All.
+ */
+export const filterByScope = (records, scope, opts = {}) => {
+  const list = Array.isArray(records) ? records : [];
+  if (!scope || scope === SCOPE_ALL) return list;
+  if (scope === SCOPE_UNASSIGNED) {
+    const known = opts.knownAssessmentIds ? new Set(opts.knownAssessmentIds) : null;
+    return list.filter(r => isUnassigned(r) || (known && !known.has(r.assessmentId)));
+  }
+  return list.filter(r => belongsToAssessment(r, scope) || isUnassigned(r));
+};
+
+/**
+ * The assessmentId to stamp on a record created while a page scope filter is
+ * active: a concrete assessment scope wins; the Unassigned view stamps null
+ * (a record created there must stay visible there — stamping the current
+ * assessment would make it vanish from the very view it was created in);
+ * otherwise the app-wide current assessment, otherwise null.
+ */
+export const resolveScopeStamp = (scope, currentAssessmentId) => {
+  if (scope === SCOPE_UNASSIGNED) return null;
+  if (scope && scope !== SCOPE_ALL) return scope;
+  return currentAssessmentId || null;
+};
+
+/**
+ * The default page scope: the assessment the user is working in when one is
+ * selected, else everything.
+ */
+export const defaultScope = (currentAssessmentId) => currentAssessmentId || SCOPE_ALL;

--- a/src/utils/assessmentScope.test.js
+++ b/src/utils/assessmentScope.test.js
@@ -1,0 +1,155 @@
+import {
+  DEMO_SEED_SOURCE,
+  SCOPE_ALL,
+  SCOPE_UNASSIGNED,
+  isUnassigned,
+  belongsToAssessment,
+  filterByScope,
+  resolveScopeStamp,
+  defaultScope
+} from './assessmentScope';
+import { COMPREHENSIVE_ASSESSMENT_ID } from '../stores/comprehensiveAssessmentData';
+import { SEEDED_ARTIFACTS } from '../stores/artifactStore';
+import { SEEDED_FINDINGS } from '../stores/findingsStore';
+import { DEFAULT_USERS } from '../stores/userStore';
+import { DEMO_ASSESSMENT_USERS, ASSESSMENT_USER_ROLES } from '../stores/assessmentsStore';
+
+const DEMO = COMPREHENSIVE_ASSESSMENT_ID;
+const MINE = 'ASM-user-2026';
+
+describe('belongsToAssessment / isUnassigned (issue #297)', () => {
+  test('matches on explicit assessmentId', () => {
+    expect(belongsToAssessment({ assessmentId: DEMO }, DEMO)).toBe(true);
+    expect(belongsToAssessment({ assessmentId: DEMO }, MINE)).toBe(false);
+  });
+
+  test('legacy finding with only an evaluationId containing the id matches', () => {
+    const legacy = { evaluationId: `${MINE}-GV.OC-01` };
+    expect(belongsToAssessment(legacy, MINE)).toBe(true);
+    expect(belongsToAssessment(legacy, DEMO)).toBe(false);
+  });
+
+  test('an explicit assessmentId wins over the evaluationId fallback', () => {
+    const record = { assessmentId: DEMO, evaluationId: `${MINE}-GV.OC-01` };
+    expect(belongsToAssessment(record, MINE)).toBe(false);
+  });
+
+  test('unassigned means no assessmentId', () => {
+    expect(isUnassigned({})).toBe(true);
+    expect(isUnassigned({ assessmentId: null })).toBe(true);
+    expect(isUnassigned({ assessmentId: DEMO })).toBe(false);
+  });
+
+  test('null/undefined record or scope never matches', () => {
+    expect(belongsToAssessment(null, DEMO)).toBe(false);
+    expect(belongsToAssessment({ assessmentId: DEMO }, null)).toBe(false);
+  });
+});
+
+describe('filterByScope semantics (issue #297)', () => {
+  const demoRec = { id: 1, assessmentId: DEMO };
+  const mineRec = { id: 2, assessmentId: MINE };
+  const legacyRec = { id: 3 };
+  const all = [demoRec, mineRec, legacyRec];
+
+  test('SCOPE_ALL returns everything', () => {
+    expect(filterByScope(all, SCOPE_ALL)).toEqual(all);
+  });
+
+  test('a per-assessment scope shows its own records PLUS unassigned ones', () => {
+    expect(filterByScope(all, MINE)).toEqual([mineRec, legacyRec]);
+  });
+
+  test('demo records are invisible in every other assessment scope', () => {
+    expect(filterByScope(all, MINE)).not.toContain(demoRec);
+  });
+
+  test('SCOPE_UNASSIGNED shows only unassigned records', () => {
+    expect(filterByScope(all, SCOPE_UNASSIGNED)).toEqual([legacyRec]);
+  });
+
+  test('a user-created unassigned record is reachable in EVERY scope except none', () => {
+    expect(filterByScope(all, DEMO)).toContain(legacyRec);
+    expect(filterByScope(all, MINE)).toContain(legacyRec);
+    expect(filterByScope(all, SCOPE_ALL)).toContain(legacyRec);
+    expect(filterByScope(all, SCOPE_UNASSIGNED)).toContain(legacyRec);
+  });
+
+  test('tolerates a non-array input', () => {
+    expect(filterByScope(undefined, SCOPE_ALL)).toEqual([]);
+  });
+
+  test('Unassigned view surfaces orphans of a deleted assessment when known ids are given', () => {
+    const orphan = { id: 9, assessmentId: 'ASM-deleted' };
+    const records = [...all, orphan];
+    const knownAssessmentIds = [DEMO, MINE];
+    expect(filterByScope(records, SCOPE_UNASSIGNED, { knownAssessmentIds }))
+      .toEqual([legacyRec, orphan]);
+    // Without the known set, behavior is unchanged (strict unassigned only)
+    expect(filterByScope(records, SCOPE_UNASSIGNED)).toEqual([legacyRec]);
+  });
+});
+
+describe('resolveScopeStamp / defaultScope (issue #297)', () => {
+  test('a concrete assessment scope wins', () => {
+    expect(resolveScopeStamp(MINE, DEMO)).toBe(MINE);
+  });
+
+  test('the ALL scope falls back to the current assessment', () => {
+    expect(resolveScopeStamp(SCOPE_ALL, MINE)).toBe(MINE);
+  });
+
+  test('the UNASSIGNED view stamps null — a record created there must stay visible there', () => {
+    expect(resolveScopeStamp(SCOPE_UNASSIGNED, MINE)).toBeNull();
+    expect(filterByScope([{ assessmentId: resolveScopeStamp(SCOPE_UNASSIGNED, MINE) }], SCOPE_UNASSIGNED))
+      .toHaveLength(1);
+  });
+
+  test('no scope and no current assessment stamps null (unassigned)', () => {
+    expect(resolveScopeStamp(SCOPE_ALL, null)).toBeNull();
+  });
+
+  test('defaultScope is the current assessment when set, else ALL', () => {
+    expect(defaultScope(MINE)).toBe(MINE);
+    expect(defaultScope(null)).toBe(SCOPE_ALL);
+  });
+});
+
+describe('shipped demo data is fully scoped to the demo assessment (issue #297)', () => {
+  test('every seeded artifact carries the demo assessmentId and seed provenance', () => {
+    expect(SEEDED_ARTIFACTS.length).toBeGreaterThan(0);
+    for (const a of SEEDED_ARTIFACTS) {
+      expect(a.assessmentId).toBe(DEMO);
+      expect(a.seedSource).toBe(DEMO_SEED_SOURCE);
+    }
+  });
+
+  test('every seeded finding carries the demo assessmentId and seed provenance', () => {
+    expect(SEEDED_FINDINGS.length).toBeGreaterThan(0);
+    for (const f of SEEDED_FINDINGS) {
+      expect(f.assessmentId).toBe(DEMO);
+      expect(f.seedSource).toBe(DEMO_SEED_SOURCE);
+    }
+  });
+
+  test('every seeded directory user carries seed provenance', () => {
+    expect(DEFAULT_USERS).toHaveLength(8);
+    for (const u of DEFAULT_USERS) {
+      expect(u.seedSource).toBe(DEMO_SEED_SOURCE);
+    }
+  });
+
+  test('the demo assessment roster covers all 8 demo users with valid roles', () => {
+    expect(DEMO_ASSESSMENT_USERS.map(u => u.userId).sort()).toEqual(
+      DEFAULT_USERS.map(u => u.id).sort()
+    );
+    for (const pair of DEMO_ASSESSMENT_USERS) {
+      expect(ASSESSMENT_USER_ROLES).toContain(pair.role);
+    }
+  });
+
+  test('demo findings and artifacts vanish from a fresh non-demo assessment scope', () => {
+    expect(filterByScope(SEEDED_ARTIFACTS, MINE)).toEqual([]);
+    expect(filterByScope(SEEDED_FINDINGS, MINE)).toEqual([]);
+  });
+});

--- a/src/utils/dataExport.js
+++ b/src/utils/dataExport.js
@@ -27,7 +27,11 @@ export const PERSIST_KEYS = {
   findings: 'csf-findings-storage',
   requirements: 'csf-requirements-storage',
   metrics: 'csf-metrics-storage',
-  orgProfile: 'csf-org-profile-storage'
+  orgProfile: 'csf-org-profile-storage',
+  // issue #297: artifact/user schema versions travel too, so future restores
+  // can version-gate instead of relying on the unconditional stamp passes
+  artifacts: 'csf-artifacts-storage',
+  users: 'csf-users-storage'
 };
 
 /**

--- a/src/utils/dataImport.js
+++ b/src/utils/dataImport.js
@@ -33,6 +33,9 @@ import {
   normalizeExternalTracking,
   normalizeExternalLinks
 } from './externalLinks';
+import { stampSeededDemoArtifacts } from '../stores/artifactStore';
+import { stampSeededDemoFindings } from '../stores/findingsStore';
+import { stampSeededDemoUsers } from '../stores/userStore';
 
 // Sections a restore knows how to apply, with the store + bulk setter each uses.
 // Format-2 exports carry no metrics section — it is simply skipped (untouched),
@@ -205,6 +208,23 @@ export const importCompleteDatabase = (parsed, stores, { backupFirst = true } = 
       }
       return next;
     });
+  }
+
+  // Demo-data segregation stamps are UNCONDITIONAL for the same reason
+  // (issue #297): a pre-#297 backup carries the seeded demo artifacts /
+  // findings / users without assessment scoping or provenance, and the bulk
+  // setters bypass each store's load-time migrate. All three passes are
+  // provenance-guarded (exact seeded id + name/email match, never overwrite
+  // an existing assessmentId/seedSource) and idempotent, so a current-format
+  // file passes through untouched.
+  if (Array.isArray(data.artifacts)) {
+    data.artifacts = stampSeededDemoArtifacts({ artifacts: data.artifacts }).artifacts;
+  }
+  if (Array.isArray(data.findings)) {
+    data.findings = stampSeededDemoFindings({ findings: data.findings }).findings;
+  }
+  if (Array.isArray(data.users)) {
+    data.users = stampSeededDemoUsers({ users: data.users }).users;
   }
 
   // Resolve every write BEFORE applying any, so a missing setter can never

--- a/src/utils/dataImport.test.js
+++ b/src/utils/dataImport.test.js
@@ -85,6 +85,72 @@ describe('export → restore round-trip', () => {
     expect(exported.formatVersion).toBe(EXPORT_FORMAT_VERSION);
     expect(exported.data.findings).toEqual(SAMPLE.findings);
   });
+
+  test('an artifact assessmentId survives the round-trip (issue #297)', () => {
+    const data = {
+      ...SAMPLE,
+      artifacts: [{ id: 'art1', artifactId: 'AR-mine', name: 'Policy doc', assessmentId: 'ASM-user-2026' }]
+    };
+    const { stores } = makeStores(data);
+    const parsed = JSON.parse(JSON.stringify(exportAllDataJSON(stores)));
+    const { stores: targetStores, setters } = makeStores();
+    importCompleteDatabase(parsed, targetStores, { backupFirst: false });
+    expect(setters.setArtifacts).toHaveBeenCalledWith(data.artifacts);
+  });
+
+  test('a pre-#297 backup gets its demo records stamped on restore (issue #297)', () => {
+    // What an old backup actually holds: seeded demo copies without the new
+    // fields, alongside the user's own records.
+    const { SEEDED_ARTIFACTS } = require('../stores/artifactStore');
+    const { DEFAULT_USERS } = require('../stores/userStore');
+    const { assessmentId, seedSource, ...legacyDemoArtifact } = SEEDED_ARTIFACTS[0];
+    const { seedSource: _s, ...legacyDemoUser } = DEFAULT_USERS[0];
+    const mineArtifact = { id: 'art-mine', artifactId: 'AR-mine', name: 'My evidence' };
+
+    const data = {
+      ...SAMPLE,
+      artifacts: [legacyDemoArtifact, mineArtifact],
+      users: [legacyDemoUser]
+    };
+    const { stores } = makeStores(data);
+    const parsed = JSON.parse(JSON.stringify(exportAllDataJSON(stores)));
+    const { stores: targetStores, setters } = makeStores();
+    importCompleteDatabase(parsed, targetStores, { backupFirst: false });
+
+    const restoredArtifacts = setters.setArtifacts.mock.calls[0][0];
+    expect(restoredArtifacts[0].assessmentId).toBe(SEEDED_ARTIFACTS[0].assessmentId);
+    expect(restoredArtifacts[0].seedSource).toBe('demo-alma');
+    expect(restoredArtifacts[1]).toEqual(mineArtifact); // user record untouched
+
+    const restoredUsers = setters.setUsers.mock.calls[0][0];
+    expect(restoredUsers[0].seedSource).toBe('demo-alma');
+  });
+
+  test('a foreign backup cannot get real data mis-branded as demo on restore (issue #297)', () => {
+    const { SEEDED_ARTIFACTS } = require('../stores/artifactStore');
+    // Same NAME as a shipped demo artifact but the user's own artifactId:
+    // the positive id+name guard must leave it untouched.
+    const sameNameMine = { id: 'a-1', artifactId: 'AR-my-own', name: SEEDED_ARTIFACTS[0].name };
+    // Same id+name but already classified by the exporting install: the
+    // absent-only rule must never overwrite an existing classification.
+    const alreadyClassified = {
+      ...SEEDED_ARTIFACTS[0],
+      assessmentId: undefined,
+      seedSource: 'user'
+    };
+    delete alreadyClassified.assessmentId;
+
+    const data = { ...SAMPLE, artifacts: [sameNameMine, alreadyClassified] };
+    const { stores } = makeStores(data);
+    const parsed = JSON.parse(JSON.stringify(exportAllDataJSON(stores)));
+    const { stores: targetStores, setters } = makeStores();
+    importCompleteDatabase(parsed, targetStores, { backupFirst: false });
+
+    const restored = setters.setArtifacts.mock.calls[0][0];
+    expect(restored[0]).toEqual(sameNameMine);          // untouched
+    expect(restored[1].seedSource).toBe('user');        // classification kept
+    expect(restored[1].assessmentId).toBeUndefined();   // not demo-stamped
+  });
 });
 
 describe('validateDatabaseExport', () => {


### PR DESCRIPTION
# PR body — fix/issue-297-demo-data-segregation

Title: `Segregate demo users, findings, and artifacts to the demo assessment (#297)`

---

Closes #297.

## What was happening

The demo (Alma Security) users, findings, and artifacts ship as global records, so they appeared in every assessment context: create a new assessment with your own three users, and each eval's auditor picker still listed the 8 Alma staff; the Findings and Artifacts tabs mixed demo records into your working view.

Root cause, not symptom: artifacts had **no assessment linkage at all**, the demo assessment never seeded its (#290) user roster, and every consumer read the whole store. Fixed at the data model so all consumers (pages, pickers, Dashboard KPIs, report generators) become thin filters over one shared helper.

## What changed

**Data model + seeds**
- Artifacts gain a nullable `assessmentId`. Every seeded artifact is Alma demo evidence (the `DEFAULT_ARTIFACTS` set included — GoPhish exports, ASM reports, catalog policies), so all are stamped to `ASM-2026-comprehensive-alma`.
- All seeded users/findings/artifacts carry `seedSource: 'demo-alma'` provenance. The user directory badges demo users ("Demo" chip) so a real install can tell the fictional staff apart.
- The demo assessment seeds its 8-user roster (roles derived from directory titles), so the example still demonstrates the per-assessment user scope.

**Migrations (heal-in-place, never delete)**
- artifacts v7→v8: stamps existing installs' seeded copies behind an exact `artifactId`+`name` positive match; never overwrites an existing `assessmentId`; a renamed copy simply stays unassigned (still visible everywhere).
- findings v5→v6 and users v2→v3: provenance stamp only, guarded by seeded id + demo assessmentId / exact id+email.
- assessments v14→v15: seeds the demo roster **only when it is empty** — a roster the user populated or pruned is never replaced.
- The restore path (`dataImport`) runs the same three idempotent stamp passes **unconditionally**, because bulk setters bypass store migrate and pre-#297 backups carry unstamped demo copies (same doctrine as the #288/#290 unconditional repairs).

**Scoping semantics (`src/utils/assessmentScope.js`)**
- `null` assessmentId = **visible in every scope**. Nothing a user created before this scheme can ever disappear behind a filter they never chose; demo records, being stamped, drop out of every other assessment.
- Findings + Artifacts pages get a page-local scope selector (All / per-assessment / Unassigned) defaulting to the current assessment; creating a record stamps the active scope; deep links widen the **page-local** scope only — the app-wide assessment selection is never mutated by a link.
- Eval-panel Artifact/Finding pickers scope to the assessment being evaluated (already-linked chips always resolve).
- The auditor picker lists the assessment roster; the rest of the directory sits behind an explicit "Browse directory…" expansion, and picking a directory user links them onto the roster as auditor. A minimal roster editor (add / remove / role) lands in the details panel so the roster is no longer create-time-only.
- Dashboard KPIs (Open Findings, Evidence Coverage) and the markdown/PDF report generators consume scoped records.
- Artifacts CSV round-trips a new `Assessment ID` column (header-name based; older CSVs import as unassigned).

## Ratification items (deliberate calls worth a maintainer glance)

1. **`DEFAULT_ARTIFACTS` are stamped as demo data.** They read as Alma evidence, not a generic starter library. If any were meant as a neutral starter set, say so and they can stay unassigned instead.
2. **Per-assessment views include unassigned records.** This is the data-safety choice: a legacy/user record with no assessmentId shows in every scope rather than vanishing. "Unassigned only" exists as a cleanup view.
3. **A CSV `Assessment ID` naming no current assessment is preserved**, not nulled. Under the null-is-visible-everywhere semantics, nulling would be actively unsafe — it would push the record into *every* scope, including the demo assessment's. Preserved ids surface in the "Unassigned only" view (orphan handling) and each record's new Assessment field allows reassignment. Assessment ids are millisecond-epoch (`ASM-<Date.now()>`), so cross-install id collision on import is negligible.
4. **The eval auditor picker auto-links directory picks onto the roster** (role: auditor). Removal/role changes live in the new details-panel roster editor.
5. **index.css gained 6 utility definitions** (`py-0.5`, `py-1.5`, `space-y-1`, `capitalize`, `justify-end`, `text-right`) — several were already referenced by existing JSX as silent no-ops.

## Advisor round (second-opinion pass, adopted)

- The restore stamp passes are strictly **absent-only**: any record already carrying an `assessmentId` OR a `seedSource` (whatever its value) is never re-derived — a foreign install's backup cannot get real data mis-branded as demo. Regression-tested through the real restore entry point (same-name-different-id artifact untouched; pre-classified record's `seedSource` kept).
- Every record's assessment scope is **visible and reassignable** in the Findings/Artifacts detail panels ("Unassigned (all scopes)" + per-assessment options; an id naming no current assessment renders as "(not found)" and can be re-pointed) — imported or mis-scoped records are never stranded.
- Also disclosed: whole-store CSV/JSON exports remain deliberately unscoped (they are the backup lane, not a deliverable — the scoped deliverables are the report generators); deleting the demo assessment orphans its records into the Unassigned view rather than deleting them (a future "remove demo data" action is now trivially buildable on `seedSource`).

## Review round (adversarial code review, all findings adopted)

- **Requirements page bleed (the one consumer the first pass missed):** per-control evidence lists (`getArtifactsByControl`/`getFindingsByControl` + the detail panel) read raw stores — demo artifacts carry real controlIds and showed in everyone's control drill-down. Now scoped to the current assessment via the same helper.
- **Create-under-"Unassigned only" vanishing record:** a record created in the Unassigned view was stamped with the current assessment and dropped out of the very view it was created in. Unassigned view now stamps `null`.
- **Deleted-assessment orphans:** records stamped with a deleted assessment's id were reachable only under All. The Unassigned view now also surfaces orphans (pages pass the known-assessment-id set).
- **Roster editor user lookup made reactive** (subscribed store read instead of `getState()` in render).

## Tests

- 146 new tests: scope-helper semantics (incl. orphan surfacing + unassigned-stamp rules), all four migrations (positive guards, negative user-record cases — including a real test-caught `undefined === undefined` guard hole, now regression-locked in both stores — idempotency, v0 fall-through, fresh-seed/migrated-state convergence), restore stamp passes incl. the foreign-backup mis-brand guard, CSV round-trip, UserSelector scoped mode, selector scoping, roster actions.
- Full suite: **33 suites, 556 tests passing**. Build compiles; changed non-allowlisted files lint at `--max-warnings=0`; allowlisted files carry identical warning counts to main.
