### PR TITLE
Demo users delete without a prompt; demo controls scope to the demo assessment (#299)

### DIFF
--- a/src/components/ControlSelector.js
+++ b/src/components/ControlSelector.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { X, Shield } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import useControlsStore from '../stores/controlsStore';
+import { belongsToAssessment, isUnassigned } from '../utils/assessmentScope';
 
 /**
  * In-app control linker for the evaluation panel (issue #294) — the Controls
@@ -9,22 +10,34 @@ import useControlsStore from '../stores/controlsStore';
  * Controls tab (/controls?selected=<controlId>, already honored by
  * UserControls); the dropdown selects from the controls register. Stores
  * plain controlId strings on the observation (linkedControls).
+ *
+ * When assessmentId is given, the pick list scopes to that assessment's
+ * controls plus unassigned ones (issue #299) — demo controls, stamped to the
+ * demo assessment, drop out of every other assessment's picker. Without the
+ * prop the selector fails OPEN and lists everything (existing chips always
+ * render regardless of scope).
  */
 const ControlSelector = ({
   label,
   selectedControls,
   onChange,
-  disabled = false
+  disabled = false,
+  assessmentId
 }) => {
   const navigate = useNavigate();
-  const controls = useControlsStore((state) => state.controls);
+  const allControls = useControlsStore((state) => state.controls);
+  const controls = assessmentId
+    ? allControls.filter(c => belongsToAssessment(c, assessmentId) || isUnassigned(c))
+    : allControls;
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef(null);
 
   // Tolerate missing/tampered persisted values — always work on an array.
   const selected = Array.isArray(selectedControls) ? selectedControls : [];
 
-  const getControlById = (controlId) => controls.find(c => c.controlId === controlId);
+  // Chip lookups use the UNSCOPED register: an existing link to an
+  // out-of-scope control must still render with its real tooltip.
+  const getControlById = (controlId) => allControls.find(c => c.controlId === controlId);
 
   const handleSelectControl = (control) => {
     if (selected.includes(control.controlId)) {

--- a/src/components/selectorScoping.test.js
+++ b/src/components/selectorScoping.test.js
@@ -3,14 +3,17 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import FindingSelector from './FindingSelector';
 import ArtifactSelector from './ArtifactSelector';
+import ControlSelector from './ControlSelector';
 import useFindingsStore from '../stores/findingsStore';
 import useArtifactStore from '../stores/artifactStore';
+import useControlsStore from '../stores/controlsStore';
 import { COMPREHENSIVE_ASSESSMENT_ID } from '../stores/comprehensiveAssessmentData';
 
 /**
- * Eval-panel pick lists scope to the assessment being evaluated (issue #297):
- * demo records (stamped to the demo assessment) drop out of every other
- * assessment; unassigned legacy records stay reachable everywhere.
+ * Eval-panel pick lists scope to the assessment being evaluated (issue #297;
+ * ControlSelector joined in #299): demo records (stamped to the demo
+ * assessment) drop out of every other assessment; unassigned legacy records
+ * stay reachable everywhere.
  */
 
 const MINE = 'ASM-user-2026';
@@ -94,5 +97,51 @@ describe('ArtifactSelector scoping (issue #297)', () => {
       <ArtifactSelector label="Artifacts" selectedArtifacts={['Demo artifact']} onChange={() => {}} assessmentId={MINE} />
     );
     expect(screen.getByText('Demo artifact')).toBeInTheDocument();
+  });
+});
+
+const CONTROLS = [
+  { controlId: 'CTL-demo', implementationDescription: 'Demo control', assessmentId: COMPREHENSIVE_ASSESSMENT_ID, seedSource: 'demo-alma' },
+  { controlId: 'CTL-mine', implementationDescription: 'My control', assessmentId: MINE },
+  { controlId: 'CTL-legacy', implementationDescription: 'Legacy control' }
+];
+
+describe('ControlSelector scoping (issue #299)', () => {
+  beforeEach(() => useControlsStore.setState({ controls: CONTROLS }));
+
+  it('scoped to my assessment: my + legacy controls listed, demo hidden', () => {
+    renderWithRouter(
+      <ControlSelector label="Controls" selectedControls={[]} onChange={() => {}} assessmentId={MINE} />
+    );
+    fireEvent.click(screen.getByText('Select controls'));
+    expect(screen.getByText('CTL-mine')).toBeInTheDocument();
+    expect(screen.getByText('CTL-legacy')).toBeInTheDocument();
+    expect(screen.queryByText('CTL-demo')).not.toBeInTheDocument();
+  });
+
+  it('scoped to the demo assessment: demo controls ARE listed', () => {
+    renderWithRouter(
+      <ControlSelector label="Controls" selectedControls={[]} onChange={() => {}} assessmentId={COMPREHENSIVE_ASSESSMENT_ID} />
+    );
+    fireEvent.click(screen.getByText('Select controls'));
+    expect(screen.getByText('CTL-demo')).toBeInTheDocument();
+  });
+
+  it('no assessmentId prop: fails OPEN — everything listed', () => {
+    renderWithRouter(
+      <ControlSelector label="Controls" selectedControls={[]} onChange={() => {}} />
+    );
+    fireEvent.click(screen.getByText('Select controls'));
+    expect(screen.getByText('CTL-demo')).toBeInTheDocument();
+    expect(screen.getByText('CTL-mine')).toBeInTheDocument();
+    expect(screen.getByText('CTL-legacy')).toBeInTheDocument();
+  });
+
+  it('an already-linked out-of-scope control still renders its chip with its real tooltip', () => {
+    renderWithRouter(
+      <ControlSelector label="Controls" selectedControls={['CTL-demo']} onChange={() => {}} disabled assessmentId={MINE} />
+    );
+    // The chip button's title comes from the UNSCOPED register lookup.
+    expect(screen.getByTitle('Demo control')).toHaveTextContent('CTL-demo');
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -328,6 +328,7 @@ code {
 .italic { font-style: italic; }
 .tracking-wider { letter-spacing: 0.05em; }
 .whitespace-pre-wrap { white-space: pre-wrap; }
+.whitespace-nowrap { white-space: nowrap; }
 .underline { text-decoration: underline; }
 .hover\:underline:hover { text-decoration: underline; }
 .break-all { word-break: break-all; }

--- a/src/pages/AIAssistant.js
+++ b/src/pages/AIAssistant.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import useAIStore from '../stores/aiStore';
 import useAssessmentsStore from '../stores/assessmentsStore';
 import useControlsStore from '../stores/controlsStore';
+import { filterByScope } from '../utils/assessmentScope';
 
 /**
  * AI Assistant Page
@@ -56,7 +57,11 @@ const AIAssistant = () => {
   const handleAnalyze = async () => {
     if (!selectedAssessment) return;
     try {
-      await analyzeAssessmentGaps(selectedAssessment, controls);
+      // Only the analyzed assessment's controls (plus unassigned ones) cross
+      // the AI boundary (issue #299) — other assessments' demo/stamped
+      // controls stay out of the analysis context.
+      const scopedControls = filterByScope(controls, selectedAssessment.id);
+      await analyzeAssessmentGaps(selectedAssessment, scopedControls);
     } catch (error) {
       console.error('Analysis failed:', error);
     }

--- a/src/pages/Artifacts.js
+++ b/src/pages/Artifacts.js
@@ -62,13 +62,19 @@ const Artifacts = () => {
   // Sorting (over the scoped list — issue #297)
   const { sort, sortedData, handleSort } = useSort(scopedArtifacts);
 
-  // Get linked controls for the selected artifact
+  // Get linked controls for the selected artifact, scoped to the ARTIFACT's
+  // own assessment (issue #299): derived chips follow the record's scope, not
+  // the page filter. An unassigned artifact fails open; demo controls only
+  // decorate demo-assessment artifacts.
   const linkedControls = useMemo(() => {
     if (!selectedArtifact?.linkedSubcategoryIds?.length) return [];
     const controlsSet = new Set();
     const controls = [];
     selectedArtifact.linkedSubcategoryIds.forEach(reqId => {
-      const reqControls = getControlsByRequirement(reqId);
+      const reqControls = filterByScope(
+        getControlsByRequirement(reqId),
+        selectedArtifact.assessmentId || SCOPE_ALL
+      );
       reqControls.forEach(ctrl => {
         if (!controlsSet.has(ctrl.controlId)) {
           controlsSet.add(ctrl.controlId);

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -31,6 +31,7 @@ import { bankCoverage, getBankProcedure, buildProcedureSource, bankSourceUrl } f
 import { canUseProfileWithProvider, buildTailorPrompt, tailoredProvenance, deriveStackTargets, describeStackPlan, bankAttachObservation, deterministicTailorUpdate } from '../utils/procedureTailor';
 import { getScoringScale, scoreBand, CMMI_LEVELS } from '../utils/scoringScale';
 import { SYSTEM_NAME_MAX_LENGTH } from '../utils/externalLinks';
+import { belongsToAssessment, isUnassigned } from '../utils/assessmentScope';
 import ExternalLinksEditor from '../components/ExternalLinksEditor';
 import useOrgProfileStore from '../stores/orgProfileStore';
 import OrgProfileWizard from '../components/OrgProfileWizard';
@@ -231,7 +232,13 @@ const Assessments = () => {
     let items = [];
 
     if (currentAssessment.scopeType === 'controls') {
-      items = controls.filter(c => !scopeIds.includes(c.controlId));
+      // Offer only this assessment's controls plus unassigned ones (issue
+      // #299) — controls stamped to another assessment (the demo set above
+      // all) are not scope candidates here.
+      items = controls.filter(c =>
+        (belongsToAssessment(c, currentAssessment.id) || isUnassigned(c)) &&
+        !scopeIds.includes(c.controlId)
+      );
       if (scopePickerSearch) {
         const search = scopePickerSearch.toLowerCase();
         items = items.filter(c =>
@@ -1526,6 +1533,7 @@ Format as a numbered list. Be specific and actionable.`;
                       selectedControls={currentObservation.linkedControls || []}
                       onChange={(controls) => handleObservationChange('linkedControls', controls)}
                       disabled={!editMode}
+                      assessmentId={currentAssessmentId}
                     />
                   </div>
 

--- a/src/pages/Findings.js
+++ b/src/pages/Findings.js
@@ -149,9 +149,16 @@ const Findings = () => {
       req.subcategoryId?.includes(csfRef)
     );
 
-    // Get controls linked to these requirements
+    // Get controls linked to these requirements, scoped to the FINDING's own
+    // assessment (issue #299): these chips are derived from requirement
+    // matching, and the record — not the page filter — owns the scope. An
+    // unassigned finding fails open (sees every control); demo controls only
+    // decorate demo-assessment findings.
     matchingReqs.forEach(req => {
-      const reqControls = getControlsByRequirement(req.id);
+      const reqControls = filterByScope(
+        getControlsByRequirement(req.id),
+        selectedFinding.assessmentId || SCOPE_ALL
+      );
       reqControls.forEach(ctrl => {
         if (!controlsSet.has(ctrl.controlId)) {
           controlsSet.add(ctrl.controlId);

--- a/src/pages/Requirements.js
+++ b/src/pages/Requirements.js
@@ -41,7 +41,6 @@ const Requirements = () => {
 
   // Controls, artifacts, and findings for the detail panel and table display
   const controls = useControlsStore((state) => state.controls);
-  const getControlsByRequirement = useControlsStore((state) => state.getControlsByRequirement);
   const allArtifactRecords = useArtifactStore((state) => state.artifacts);
   const allFindingRecords = useFindingsStore((state) => state.findings);
   const users = useUserStore((state) => state.users);
@@ -57,6 +56,13 @@ const Requirements = () => {
   const findings = useMemo(
     () => filterByScope(allFindingRecords, defaultScope(currentAssessmentId)),
     [allFindingRecords, currentAssessmentId]
+  );
+  // Controls join the same scoping in issue #299: the demo (Alma) controls
+  // belong to the demo assessment, so their implementation text / owners stop
+  // decorating requirements under every other assessment.
+  const scopedControls = useMemo(
+    () => filterByScope(controls, defaultScope(currentAssessmentId)),
+    [controls, currentAssessmentId]
   );
   const getArtifactsByControl = useCallback(
     (controlId) => artifacts.filter(a => a.controlId === controlId),
@@ -81,11 +87,14 @@ const Requirements = () => {
     return user?.name || '';
   }, [users]);
 
-  // Helper: Get control data for a requirement (pulls from linked Controls)
+  // Helper: Get control data for a requirement (pulls from linked Controls,
+  // scoped to the assessment being worked — issue #299)
   const getControlDataForRequirement = useCallback((requirementId) => {
-    const linkedControls = getControlsByRequirement(requirementId);
+    const linkedControls = scopedControls.filter(c =>
+      c.linkedRequirementIds && c.linkedRequirementIds.includes(requirementId)
+    );
     if (linkedControls.length === 0) {
-      const matchingControl = controls.find(c => c.controlId === requirementId);
+      const matchingControl = scopedControls.find(c => c.controlId === requirementId);
       if (matchingControl) {
         return {
           controlId: matchingControl.controlId,
@@ -119,7 +128,7 @@ const Requirements = () => {
       findings: allFindings,
       controlEvaluationBackLink: links[0] || ''
     };
-  }, [controls, getControlsByRequirement, getArtifactsByControl, getFindingsByControl, getUserName]);
+  }, [scopedControls, getArtifactsByControl, getFindingsByControl, getUserName]);
 
   // Local state
   const [selectedRequirement, setSelectedRequirement] = useState(null);
@@ -757,7 +766,7 @@ const Requirements = () => {
           requirement={selectedRequirement}
           onClose={() => setSelectedRequirement(null)}
           onSave={handleSaveRequirement}
-          controls={controls}
+          controls={scopedControls}
           artifacts={artifacts}
           findings={findings}
         />

--- a/src/pages/UserControls.js
+++ b/src/pages/UserControls.js
@@ -19,6 +19,18 @@ import useControlsStore from '../stores/controlsStore';
 import useRequirementsStore from '../stores/requirementsStore';
 import useFrameworksStore from '../stores/frameworksStore';
 import useUserStore from '../stores/userStore';
+import useAssessmentsStore from '../stores/assessmentsStore';
+
+// Assessment scoping (issue #299, same scheme as Findings/Artifacts got in
+// #297): demo controls are stamped to the demo assessment and drop out of
+// every other assessment's view; unassigned controls stay visible everywhere.
+import {
+  SCOPE_ALL,
+  SCOPE_UNASSIGNED,
+  filterByScope,
+  resolveScopeStamp,
+  defaultScope
+} from '../utils/assessmentScope';
 
 const UserControls = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -42,6 +54,9 @@ const UserControls = () => {
   const getEnabledFrameworks = useFrameworksStore((state) => state.getEnabledFrameworks);
 
   const users = useUserStore((state) => state.users);
+
+  const currentAssessmentId = useAssessmentsStore((state) => state.currentAssessmentId);
+  const assessments = useAssessmentsStore((state) => state.assessments);
 
   // Local state
   const [searchTerm, setSearchTerm] = useState('');
@@ -86,6 +101,20 @@ const UserControls = () => {
   const frameworkTriggerRef = useRef(null);
   const fileInputRef = useRef(null);
 
+  // Page-local assessment scope (issue #299): defaults to the assessment the
+  // user is working in; follows the app-wide selection when it changes. Only
+  // this page-local filter ever changes here — never the global selection.
+  const [scopeFilter, setScopeFilter] = useState(() => defaultScope(currentAssessmentId));
+  useEffect(() => {
+    setScopeFilter(defaultScope(currentAssessmentId));
+    setCurrentPage(1);
+  }, [currentAssessmentId]);
+
+  const scopedControls = useMemo(
+    () => filterByScope(controls, scopeFilter, { knownAssessmentIds: assessments.map(a => a.id) }),
+    [controls, scopeFilter, assessments]
+  );
+
   // Handle URL query parameter for deep linking to a specific control
   useEffect(() => {
     const selectedParam = searchParams.get('selected');
@@ -96,6 +125,14 @@ const UserControls = () => {
         setDetailPanelOpen(true);
         setEditMode(false);
         setIsCreating(false);
+        // Widen the PAGE-LOCAL scope if the linked control is outside it
+        // (issue #299) — an unassigned control maps to All, a stamped one to
+        // its own assessment. The global assessment selection is never touched.
+        setScopeFilter(prev => {
+          if (prev === SCOPE_ALL) return prev;
+          const visible = filterByScope([control], prev).length > 0;
+          return visible ? prev : (control.assessmentId || SCOPE_ALL);
+        });
         // Clear the URL parameter after selection
         setSearchParams({}, { replace: true });
       }
@@ -175,7 +212,7 @@ const UserControls = () => {
 
   // Filter and sort data
   const filteredData = useMemo(() => {
-    let result = [...controls];
+    let result = [...scopedControls];
 
     if (searchTerm) {
       const search = searchTerm.toLowerCase();
@@ -207,7 +244,7 @@ const UserControls = () => {
     });
 
     return result;
-  }, [controls, searchTerm, filterOwner, filterFramework, sort, getRequirement]);
+  }, [scopedControls, searchTerm, filterOwner, filterFramework, sort, getRequirement]);
 
   // Pagination
   const totalPages = Math.ceil(filteredData.length / itemsPerPage);
@@ -292,12 +329,18 @@ const UserControls = () => {
       return;
     }
 
-    const created = createControl(newControl);
+    // Stamp the active scope (issue #299): a concrete assessment scope wins,
+    // the Unassigned view stamps null so the new control stays visible where
+    // it was created, otherwise the app-wide current assessment.
+    const created = createControl({
+      ...newControl,
+      assessmentId: resolveScopeStamp(scopeFilter, currentAssessmentId)
+    });
     setSelectedControlId(created.controlId);
     setIsCreating(false);
     setEditMode(false);
     toast.success(`Control ${created.controlId} created`);
-  }, [newControl, createControl]);
+  }, [newControl, createControl, scopeFilter, currentAssessmentId]);
 
   const handleCancelCreate = useCallback(() => {
     setIsCreating(false);
@@ -420,6 +463,26 @@ const UserControls = () => {
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
+        </div>
+
+        {/* Assessment scope (issue #299) */}
+        <div className="flex items-center gap-2">
+          <select
+            value={scopeFilter}
+            onChange={(e) => { setScopeFilter(e.target.value); setCurrentPage(1); }}
+            className="text-sm border rounded-lg px-2 py-1.5 bg-white text-gray-700"
+            title="Show controls for one assessment"
+            aria-label="Assessment scope"
+          >
+            <option value={SCOPE_ALL}>All assessments</option>
+            {assessments.map(a => (
+              <option key={a.id} value={a.id}>{a.name}</option>
+            ))}
+            <option value={SCOPE_UNASSIGNED}>Unassigned only</option>
+          </select>
+          <span className="text-sm text-gray-500 whitespace-nowrap">
+            {scopedControls.length} items{scopeFilter !== SCOPE_ALL ? ` · ${controls.length} total` : ''}
+          </span>
         </div>
 
         {/* Owner filter */}

--- a/src/pages/UserManagement.js
+++ b/src/pages/UserManagement.js
@@ -4,6 +4,7 @@ import Papa from 'papaparse';
 import toast from 'react-hot-toast';
 import useUserStore from '../stores/userStore';
 import { escapeCSVValue } from '../utils/sanitize';
+import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
 
 const UserManagement = () => {
   const users = useUserStore((state) => state.users);
@@ -151,11 +152,17 @@ const UserManagement = () => {
     setEditMode(true);
   };
 
-  // Handle delete user
+  // Handle delete user. Shipped demo (Alma) users delete WITHOUT the
+  // confirmation prompt (issue #299) — they are fictional example data and
+  // clearing them is routine; a fresh install re-seeds them. The guard is a
+  // strict positive match on the seed brand so a real user can never lose
+  // the confirm.
   const handleDelete = (id) => {
-    if (window.confirm('Are you sure you want to delete this user?')) {
+    const user = users.find(u => u.id === id);
+    const isDemoUser = user?.seedSource === DEMO_SEED_SOURCE;
+    if (isDemoUser || window.confirm('Are you sure you want to delete this user?')) {
       deleteUser(id);
-      toast.success('User deleted');
+      toast.success(isDemoUser ? 'Demo user removed' : 'User deleted');
     }
   };
 
@@ -303,7 +310,7 @@ const UserManagement = () => {
                 <tr key={user.id} className="hover:bg-gray-50:bg-gray-700">
                   <td className="p-3 text-sm">
                     {user.name}
-                    {user.seedSource === 'demo-alma' && (
+                    {user.seedSource === DEMO_SEED_SOURCE && (
                       <span
                         className="badge badge-neutral ml-1"
                         title="Shipped example user — part of the Alma Security demo assessment"

--- a/src/pages/UserManagement.test.js
+++ b/src/pages/UserManagement.test.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import UserManagement from './UserManagement';
+import useUserStore from '../stores/userStore';
+import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
+
+jest.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: { success: jest.fn(), error: jest.fn() }
+}));
+
+/**
+ * Issue #299: shipped demo (Alma) users delete WITHOUT the confirmation
+ * prompt — they are fictional example data. Real users keep the confirm, and
+ * cancelling it still aborts the delete.
+ */
+
+const DEMO_USER = {
+  id: 101,
+  name: 'Gerry.Callahan',
+  title: 'CISO',
+  email: 'gerry.callahan@almasecurity.com',
+  seedSource: DEMO_SEED_SOURCE
+};
+const REAL_USER = {
+  id: 102,
+  name: 'Pat.Real',
+  title: 'Analyst',
+  email: 'pat.real@example.com'
+};
+
+describe('UserManagement delete confirmation (issue #299)', () => {
+  let confirmSpy;
+
+  beforeEach(() => {
+    useUserStore.setState({ users: [DEMO_USER, REAL_USER] });
+    confirmSpy = jest.spyOn(window, 'confirm');
+  });
+
+  afterEach(() => confirmSpy.mockRestore());
+
+  // Rows render in store order ([DEMO_USER, REAL_USER]), so the Delete
+  // buttons come back in that same order.
+  const deleteButtons = () => screen.getAllByTitle('Delete');
+
+  test('deleting a demo user skips the confirm prompt entirely', () => {
+    render(<UserManagement />);
+    fireEvent.click(deleteButtons()[0]);
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(useUserStore.getState().users.find(u => u.id === DEMO_USER.id)).toBeUndefined();
+    expect(useUserStore.getState().users.find(u => u.id === REAL_USER.id)).toBeDefined();
+  });
+
+  test('deleting a real user still asks for confirmation', () => {
+    confirmSpy.mockReturnValue(true);
+    render(<UserManagement />);
+    fireEvent.click(deleteButtons()[1]);
+    expect(confirmSpy).toHaveBeenCalledWith('Are you sure you want to delete this user?');
+    expect(useUserStore.getState().users.find(u => u.id === REAL_USER.id)).toBeUndefined();
+  });
+
+  test('cancelling the confirm keeps the real user', () => {
+    confirmSpy.mockReturnValue(false);
+    render(<UserManagement />);
+    fireEvent.click(deleteButtons()[1]);
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(useUserStore.getState().users.find(u => u.id === REAL_USER.id)).toBeDefined();
+  });
+
+  test('the demo badge marks demo users only', () => {
+    render(<UserManagement />);
+    // Exactly one Demo badge for the one seeded user in the table.
+    expect(screen.getAllByText('Demo')).toHaveLength(1);
+    expect(
+      screen.getByTitle('Shipped example user — part of the Alma Security demo assessment')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/stores/controlsStore.js
+++ b/src/stores/controlsStore.js
@@ -3,11 +3,24 @@ import { persist } from 'zustand/middleware';
 import Papa from 'papaparse';
 import { sanitizeInput, escapeCSVValue } from '../utils/sanitize';
 import { DEFAULT_CONTROLS } from './defaultControlsData';
+import { COMPREHENSIVE_ASSESSMENT_ID } from './comprehensiveAssessmentData';
+import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
+
+// The shipped Alma controls are demo evidence for the demo assessment
+// (issue #299, same segregation scheme as #297 gave users/findings/artifacts):
+// stamped with the demo assessment's id + seed provenance so they appear only
+// in the demo assessment's scope, while anything a user creates (which never
+// carries an assessmentId unless a scope stamps one) stays visible everywhere.
+export const SEEDED_CONTROLS = DEFAULT_CONTROLS.map((c) => ({
+  ...c,
+  assessmentId: COMPREHENSIVE_ASSESSMENT_ID,
+  seedSource: DEMO_SEED_SOURCE
+}));
 
 const useControlsStore = create(
   persist(
     (set, get) => ({
-      controls: DEFAULT_CONTROLS,
+      controls: SEEDED_CONTROLS,
       loading: false,
       error: null,
 
@@ -81,6 +94,11 @@ const useControlsStore = create(
           controlEvaluationBackLink: controlData.controlEvaluationBackLink || '',
           // Optional URL to this control in an external compliance/ticketing tool (issue #284)
           externalUrl: controlData.externalUrl || '',
+          // Assessment scoping (issue #299): null = visible in every
+          // assessment's view; a concrete id scopes the control to that
+          // assessment. seedSource is never set here — only shipped demo
+          // records carry it.
+          assessmentId: controlData.assessmentId || null,
           createdDate: new Date().toISOString(),
           lastModified: new Date().toISOString()
         };
@@ -282,6 +300,11 @@ const useControlsStore = create(
                   linkedRequirementIds: row['Linked Requirements']
                     ? row['Linked Requirements'].split(';').map(s => s.trim()).filter(Boolean)
                     : [],
+                  // Assessment scoping round-trip (issue #299): blank → null
+                  // (visible everywhere). Unknown ids are preserved, not
+                  // nulled — reachable under All, and they survive a later
+                  // restore of that assessment (same call as #297 artifacts).
+                  assessmentId: (row['Assessment ID'] || '').trim() || null,
                   createdDate: row.createdDate || new Date().toISOString(),
                   lastModified: new Date().toISOString()
                 };
@@ -313,6 +336,7 @@ const useControlsStore = create(
           'Stakeholder(s)': escapeCSVValue((c.stakeholderIds || []).map(id => getUserName(id)).join('; ')),
           'Stakeholder IDs': (c.stakeholderIds || []).join('; '),
           'Linked Requirements': (c.linkedRequirementIds || []).join('; '),
+          'Assessment ID': c.assessmentId || '',
           'Created Date': c.createdDate,
           'Last Modified': c.lastModified
         }));
@@ -350,6 +374,7 @@ const useControlsStore = create(
             stakeholderIds: c.stakeholderIds || [],
             stakeholderNames: (c.stakeholderIds || []).map(id => getUserName(id)),
             linkedRequirementIds: c.linkedRequirementIds || [],
+            assessmentId: c.assessmentId || null,
             createdDate: c.createdDate,
             lastModified: c.lastModified
           }))
@@ -474,25 +499,65 @@ const useControlsStore = create(
     }),
     {
       name: 'csf-controls-storage',
-      version: 5,
-      migrate: (persistedState, version) => {
-        // Version 5: Default controls from Alma Security example data
-        // Existing users with data keep their controls, new users get Alma Security examples
-        if (version < 5) {
-          if (persistedState?.controls?.length > 0) {
-            // Existing user with data - keep their controls
-            return persistedState;
-          }
-          // New user or empty state - use Alma Security example controls
-          return { controls: DEFAULT_CONTROLS };
-        }
-        return persistedState;
-      },
+      version: 6,
+      migrate: (persistedState, version) => migrateControlsState(persistedState, version),
       partialize: (state) => ({
         controls: state.controls
       })
     }
   )
 );
+
+/**
+ * Persist migration pipeline. Version history:
+ * - v5: empty/new installs get the Alma example controls; installs with their
+ *   own data keep it untouched.
+ * - v6 (issue #299): seeded demo controls gain assessmentId + seedSource so
+ *   they appear only in the demo assessment's scope.
+ */
+export function migrateControlsState(persistedState, version) {
+  let state = persistedState;
+  if (version < 5) {
+    state = state?.controls?.length > 0 ? state : { controls: SEEDED_CONTROLS };
+  }
+  return stampSeededDemoControls(state);
+}
+
+/**
+ * Stamp the persisted copies of the shipped Alma demo controls with the demo
+ * assessment's id + seed provenance (issue #299 — the same heal-in-place as
+ * #297's stampSeededDemoArtifacts / Users / Findings).
+ *
+ * Guard doctrine:
+ * - Absent-only: any existing assessmentId OR seedSource means this record
+ *   has already been classified (locally or by the install that exported it)
+ *   — never re-derive over an existing classification.
+ * - The match must be POSITIVE on both sides: the controlId must be a seeded
+ *   id AND the record's createdDate must equal that seed's createdDate.
+ *   createdDate is the stable identity field — updateControl never touches it
+ *   and createControl always stamps the current time — so a demo control
+ *   whose description the user edited is still recognized, while a
+ *   user-created control that reuses a seeded controlId can never match, and
+ *   a record with an unknown controlId and no createdDate cannot match via
+ *   undefined === undefined.
+ * - Idempotent: once stamped, the absent-only guard matches nothing.
+ */
+export function stampSeededDemoControls(state) {
+  const controls = state?.controls;
+  if (!Array.isArray(controls)) return state;
+
+  const seededCreatedById = new Map(DEFAULT_CONTROLS.map((c) => [c.controlId, c.createdDate]));
+
+  let changed = false;
+  const stamped = controls.map((control) => {
+    if (!control || control.assessmentId || control.seedSource) return control;
+    const seededCreated = seededCreatedById.get(control.controlId);
+    if (!seededCreated || seededCreated !== control.createdDate) return control;
+    changed = true;
+    return { ...control, assessmentId: COMPREHENSIVE_ASSESSMENT_ID, seedSource: DEMO_SEED_SOURCE };
+  });
+
+  return changed ? { ...state, controls: stamped } : state;
+}
 
 export default useControlsStore;

--- a/src/stores/controlsStore.migration.test.js
+++ b/src/stores/controlsStore.migration.test.js
@@ -1,0 +1,211 @@
+import useControlsStore, {
+  SEEDED_CONTROLS,
+  stampSeededDemoControls,
+  migrateControlsState
+} from './controlsStore';
+import { DEFAULT_CONTROLS } from './defaultControlsData';
+import { COMPREHENSIVE_ASSESSMENT_ID } from './comprehensiveAssessmentData';
+import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
+
+/**
+ * Issue #299: the shipped Alma demo controls are stamped to the demo
+ * assessment (same segregation scheme #297 gave users/findings/artifacts).
+ * The stamp's positive-match key is controlId + the seed's createdDate —
+ * createdDate is the stable identity field (updateControl never touches it,
+ * createControl always stamps the current time), so an edited demo control is
+ * still recognized while a user-created control can never false-match.
+ */
+
+const SEED = DEFAULT_CONTROLS[0];
+
+describe('SEEDED_CONTROLS (issue #299)', () => {
+  test('every seeded control is stamped to the demo assessment with seed provenance', () => {
+    expect(SEEDED_CONTROLS.length).toBe(DEFAULT_CONTROLS.length);
+    SEEDED_CONTROLS.forEach(c => {
+      expect(c.assessmentId).toBe(COMPREHENSIVE_ASSESSMENT_ID);
+      expect(c.seedSource).toBe(DEMO_SEED_SOURCE);
+    });
+  });
+
+  test('stamping adds ONLY the two classification fields', () => {
+    SEEDED_CONTROLS.forEach((c, i) => {
+      const { assessmentId, seedSource, ...rest } = c;
+      expect(rest).toEqual(DEFAULT_CONTROLS[i]);
+    });
+  });
+});
+
+describe('stampSeededDemoControls (controls store migration v6, issue #299)', () => {
+  test('stamps a pristine persisted copy of a seeded demo control', () => {
+    const persisted = { controls: [{ ...SEED }] };
+    const after = stampSeededDemoControls(persisted);
+    expect(after.controls[0].assessmentId).toBe(COMPREHENSIVE_ASSESSMENT_ID);
+    expect(after.controls[0].seedSource).toBe(DEMO_SEED_SOURCE);
+  });
+
+  test('stamps a demo control whose description the user edited (createdDate is the identity)', () => {
+    const edited = { ...SEED, implementationDescription: 'We do this our own way now.', lastModified: '2026-07-01T00:00:00.000Z' };
+    const after = stampSeededDemoControls({ controls: [edited] });
+    expect(after.controls[0].assessmentId).toBe(COMPREHENSIVE_ASSESSMENT_ID);
+    expect(after.controls[0].implementationDescription).toBe('We do this our own way now.');
+  });
+
+  test('does NOT stamp a user-created control that reuses a seeded controlId', () => {
+    const mine = { ...SEED, createdDate: '2026-05-05T10:00:00.000Z' };
+    const after = stampSeededDemoControls({ controls: [mine] });
+    expect(after.controls[0].assessmentId).toBeUndefined();
+    expect(after.controls[0].seedSource).toBeUndefined();
+  });
+
+  test('a record with an unknown controlId and no createdDate cannot match via undefined === undefined', () => {
+    const stranger = { controlId: 'CTL-777', implementationDescription: 'Mine' };
+    const after = stampSeededDemoControls({ controls: [stranger] });
+    expect(after.controls[0]).toEqual(stranger);
+  });
+
+  test('absent-only: an existing assessmentId is never overwritten', () => {
+    const claimed = { ...SEED, assessmentId: 'ASM-user-2026' };
+    const after = stampSeededDemoControls({ controls: [claimed] });
+    expect(after.controls[0].assessmentId).toBe('ASM-user-2026');
+    expect(after.controls[0].seedSource).toBeUndefined();
+  });
+
+  test('absent-only: an existing seedSource is never re-derived over', () => {
+    const branded = { ...SEED, seedSource: 'some-other-pack' };
+    const after = stampSeededDemoControls({ controls: [branded] });
+    expect(after.controls[0].seedSource).toBe('some-other-pack');
+    expect(after.controls[0].assessmentId).toBeUndefined();
+  });
+
+  test('is idempotent — a second pass returns the same state object', () => {
+    const once = stampSeededDemoControls({ controls: [{ ...SEED }] });
+    expect(stampSeededDemoControls(once)).toBe(once);
+  });
+
+  test('never deletes or reorders — record count and order are preserved', () => {
+    const mixed = [
+      { ...SEED },
+      { controlId: 'CTL-001', implementationDescription: 'Mine', createdDate: '2026-01-01T00:00:00.000Z' },
+      { ...DEFAULT_CONTROLS[1] }
+    ];
+    const after = stampSeededDemoControls({ controls: mixed });
+    expect(after.controls.length).toBe(3);
+    expect(after.controls.map(c => c.controlId)).toEqual(mixed.map(c => c.controlId));
+  });
+
+  test('preserves sibling keys on the persisted state', () => {
+    const after = stampSeededDemoControls({ controls: [{ ...SEED }], somethingElse: 42 });
+    expect(after.somethingElse).toBe(42);
+  });
+
+  test.each([
+    ['undefined state', undefined],
+    ['null state', null],
+    ['missing controls key', {}],
+    ['controls not an array', { controls: 'corrupt' }]
+  ])('survives %s without throwing', (_label, state) => {
+    expect(() => stampSeededDemoControls(state)).not.toThrow();
+  });
+});
+
+describe('migrateControlsState (v5 → v6 chain, issue #299)', () => {
+  test('a pre-v5 empty install seeds the stamped demo controls', () => {
+    const after = migrateControlsState({ controls: [] }, 0);
+    expect(after.controls).toEqual(SEEDED_CONTROLS);
+  });
+
+  test('a pre-v5 install with its own controls keeps them untouched', () => {
+    const mine = { controlId: 'CTL-001', implementationDescription: 'Mine', createdDate: '2026-01-01T00:00:00.000Z' };
+    const after = migrateControlsState({ controls: [mine] }, 0);
+    expect(after.controls).toEqual([mine]);
+  });
+
+  test('a v5 install with the pristine demo set converges to the fresh v6 seed state', () => {
+    const v5State = { controls: DEFAULT_CONTROLS.map(c => ({ ...c })) };
+    const after = migrateControlsState(v5State, 5);
+    expect(after.controls).toEqual(SEEDED_CONTROLS);
+  });
+
+  test('a v5 install mixing demo and user controls stamps only the demo ones', () => {
+    const mine = { controlId: 'CTL-001', implementationDescription: 'Mine', createdDate: '2026-01-01T00:00:00.000Z' };
+    const after = migrateControlsState({ controls: [{ ...SEED }, mine] }, 5);
+    expect(after.controls[0].assessmentId).toBe(COMPREHENSIVE_ASSESSMENT_ID);
+    expect(after.controls[1]).toEqual(mine);
+  });
+
+  test('migration never changes the record count', () => {
+    const v5State = { controls: DEFAULT_CONTROLS.map(c => ({ ...c })) };
+    expect(migrateControlsState(v5State, 5).controls.length).toBe(DEFAULT_CONTROLS.length);
+  });
+
+  test('deleted demo controls are NOT resurrected by the migration (stamp-only, never upsert)', () => {
+    // #299 makes demo controls one-click deletable; a heal migration that
+    // inserted missing seeds would bring every deleted one back on the next
+    // load, contradicting the feature.
+    const pruned = DEFAULT_CONTROLS.slice(6).map(c => ({ ...c }));
+    const after = migrateControlsState({ controls: pruned }, 5);
+    expect(after.controls.length).toBe(DEFAULT_CONTROLS.length - 6);
+    const deletedIds = DEFAULT_CONTROLS.slice(0, 6).map(c => c.controlId);
+    expect(after.controls.some(c => deletedIds.includes(c.controlId))).toBe(false);
+  });
+
+  test('a v5 install that deleted ALL controls stays empty (re-seed only ever applies pre-v5)', () => {
+    expect(migrateControlsState({ controls: [] }, 5).controls).toEqual([]);
+  });
+});
+
+describe('createControl assessment scoping (issue #299)', () => {
+  beforeEach(() => useControlsStore.setState({ controls: [], history: [], historyIndex: -1 }));
+
+  test('stamps the assessmentId it is given', () => {
+    const created = useControlsStore.getState().createControl({ assessmentId: 'ASM-user-2026' });
+    expect(created.assessmentId).toBe('ASM-user-2026');
+  });
+
+  test('defaults to null (visible everywhere) and never sets seedSource', () => {
+    const created = useControlsStore.getState().createControl({});
+    expect(created.assessmentId).toBeNull();
+    expect('seedSource' in created).toBe(false);
+  });
+
+  test('getNextControlId stays global across assessments — no duplicate CTL ids', () => {
+    const store = useControlsStore.getState();
+    const a = store.createControl({ controlId: store.getNextControlId(), assessmentId: 'ASM-a' });
+    const b = useControlsStore.getState().createControl({
+      controlId: useControlsStore.getState().getNextControlId(),
+      assessmentId: 'ASM-b'
+    });
+    expect(a.controlId).not.toBe(b.controlId);
+  });
+});
+
+describe('controls CSV assessment scope round-trip (issue #299)', () => {
+  beforeEach(() => useControlsStore.setState({ controls: [], history: [], historyIndex: -1 }));
+
+  test('importControlsCSV reads the Assessment ID column', async () => {
+    const csv = [
+      'Control ID,Control Implementation Description,Assessment ID',
+      'CTL-X1,Scoped control,ASM-user-2026',
+      'CTL-X2,Unscoped control,'
+    ].join('\n');
+    await useControlsStore.getState().importControlsCSV(csv);
+    const byId = Object.fromEntries(useControlsStore.getState().controls.map(c => [c.controlId, c]));
+    expect(byId['CTL-X1'].assessmentId).toBe('ASM-user-2026');
+    expect(byId['CTL-X2'].assessmentId).toBeNull();
+  });
+
+  test('an older CSV without the column imports as unassigned', async () => {
+    const csv = ['Control ID,Control Implementation Description', 'CTL-X3,Old-format control'].join('\n');
+    await useControlsStore.getState().importControlsCSV(csv);
+    expect(useControlsStore.getState().controls[0].assessmentId).toBeNull();
+  });
+
+  test('an id naming no current assessment is preserved, not silently nulled', async () => {
+    const csv = [
+      'Control ID,Control Implementation Description,Assessment ID',
+      'CTL-X4,Foreign control,ASM-not-here'
+    ].join('\n');
+    await useControlsStore.getState().importControlsCSV(csv);
+    expect(useControlsStore.getState().controls[0].assessmentId).toBe('ASM-not-here');
+  });
+});

--- a/src/utils/dataImport.js
+++ b/src/utils/dataImport.js
@@ -36,6 +36,7 @@ import {
 import { stampSeededDemoArtifacts } from '../stores/artifactStore';
 import { stampSeededDemoFindings } from '../stores/findingsStore';
 import { stampSeededDemoUsers } from '../stores/userStore';
+import { stampSeededDemoControls } from '../stores/controlsStore';
 
 // Sections a restore knows how to apply, with the store + bulk setter each uses.
 // Format-2 exports carry no metrics section — it is simply skipped (untouched),
@@ -211,12 +212,13 @@ export const importCompleteDatabase = (parsed, stores, { backupFirst = true } = 
   }
 
   // Demo-data segregation stamps are UNCONDITIONAL for the same reason
-  // (issue #297): a pre-#297 backup carries the seeded demo artifacts /
-  // findings / users without assessment scoping or provenance, and the bulk
-  // setters bypass each store's load-time migrate. All three passes are
-  // provenance-guarded (exact seeded id + name/email match, never overwrite
-  // an existing assessmentId/seedSource) and idempotent, so a current-format
-  // file passes through untouched.
+  // (issue #297; controls joined in #299): a pre-#297/#299 backup carries the
+  // seeded demo artifacts / findings / users / controls without assessment
+  // scoping or provenance, and the bulk setters bypass each store's
+  // load-time migrate. All four passes are provenance-guarded (exact seeded
+  // id + a positive second signal, never overwrite an existing
+  // assessmentId/seedSource) and idempotent, so a current-format file passes
+  // through untouched.
   if (Array.isArray(data.artifacts)) {
     data.artifacts = stampSeededDemoArtifacts({ artifacts: data.artifacts }).artifacts;
   }
@@ -225,6 +227,9 @@ export const importCompleteDatabase = (parsed, stores, { backupFirst = true } = 
   }
   if (Array.isArray(data.users)) {
     data.users = stampSeededDemoUsers({ users: data.users }).users;
+  }
+  if (Array.isArray(data.controls)) {
+    data.controls = stampSeededDemoControls({ controls: data.controls }).controls;
   }
 
   // Resolve every write BEFORE applying any, so a missing setter can never

--- a/src/utils/dataImport.test.js
+++ b/src/utils/dataImport.test.js
@@ -151,6 +151,41 @@ describe('export → restore round-trip', () => {
     expect(restored[1].seedSource).toBe('user');        // classification kept
     expect(restored[1].assessmentId).toBeUndefined();   // not demo-stamped
   });
+
+  test('a pre-#299 backup gets its demo controls stamped on restore, user controls untouched (issue #299)', () => {
+    const { SEEDED_CONTROLS } = require('../stores/controlsStore');
+    // What an old backup holds: a seeded demo control without the new fields,
+    // a user control that reuses a seeded controlId (different createdDate),
+    // and a plain user control.
+    const { assessmentId, seedSource, ...legacyDemoControl } = SEEDED_CONTROLS[0];
+    const collidingMine = {
+      ...legacyDemoControl,
+      createdDate: '2026-05-05T10:00:00.000Z'
+    };
+    const mineControl = { controlId: 'CTL-mine', implementationDescription: 'Mine', createdDate: '2026-01-01T00:00:00.000Z' };
+
+    const data = { ...SAMPLE, controls: [legacyDemoControl, collidingMine, mineControl] };
+    const { stores } = makeStores(data);
+    const parsed = JSON.parse(JSON.stringify(exportAllDataJSON(stores)));
+    const { stores: targetStores, setters } = makeStores();
+    importCompleteDatabase(parsed, targetStores, { backupFirst: false });
+
+    const restored = setters.setControls.mock.calls[0][0];
+    expect(restored[0].assessmentId).toBe(SEEDED_CONTROLS[0].assessmentId);
+    expect(restored[0].seedSource).toBe('demo-alma');
+    expect(restored[1]).toEqual(collidingMine);   // colliding id, different createdDate — untouched
+    expect(restored[2]).toEqual(mineControl);     // user record untouched
+  });
+
+  test('a current-format backup round-trips control assessmentIds verbatim (issue #299)', () => {
+    const scoped = { controlId: 'CTL-9', implementationDescription: 'Scoped', assessmentId: 'ASM-user-2026', createdDate: '2026-01-01T00:00:00.000Z' };
+    const data = { ...SAMPLE, controls: [scoped] };
+    const { stores } = makeStores(data);
+    const parsed = JSON.parse(JSON.stringify(exportAllDataJSON(stores)));
+    const { stores: targetStores, setters } = makeStores();
+    importCompleteDatabase(parsed, targetStores, { backupFirst: false });
+    expect(setters.setControls.mock.calls[0][0]).toEqual([scoped]);
+  });
 });
 
 describe('validateDatabaseExport', () => {


### PR DESCRIPTION
Closes #299.

Controls were the last first-class entity with zero assessment awareness after #297 segregated demo users, findings, and artifacts: the 24 shipped Alma controls rode as global records, decorating every assessment's Requirements columns, Controls register, eval-panel picker, scope picker, and AI analysis context. And clearing the fictional demo staff cost a confirm dialog per user.

## Ask 1 — demo users delete without the warning

`UserManagement.handleDelete` skips `window.confirm` only when the user carries the demo seed brand (strict `seedSource === DEMO_SEED_SOURCE` match). Real users keep the confirm; cancel still aborts. The toast says "Demo user removed" so the no-prompt path is still visibly acknowledged.

## Ask 2 — Alma controls scope to the demo assessment

Same scheme as #297, end-to-end:

- **Seeds + migration**: seeded controls are stamped `assessmentId` + `seedSource` at seed time; the store's v6 migration heals existing installs behind a positive-match guard keyed on **controlId + the seed's `createdDate`**. `createdDate` is the stable identity field (`updateControl` never touches it, `createControl` always stamps now), so a demo control whose *description the user edited* is still recognized, a user control reusing a seeded id can never false-match, and nothing matches via `undefined === undefined`. Absent-only on both classification fields; idempotent; never deletes or reorders.
- **Controls page**: #297-pattern scope filter (each assessment + Unassigned + All, defaulting to the current assessment), scoped count line, creation stamps the active scope, deep links widen only the page-local scope, CSV/JSON exports round-trip an `Assessment ID` column.
- **Scoped consumers**: Requirements control-data columns + detail panel; Findings/Artifacts derived linked-control chips; ControlSelector gains the same `assessmentId` prop as ArtifactSelector/FindingSelector (fails open without it) and is wired from the eval panel; the Assessments scope picker stops offering other assessments' controls; AI gap analysis passes only scoped controls across the boundary; the restore path runs the same idempotent stamp so pre-#299 backups heal (bulk setters bypass the store migrate).
- **Data safety**: unassigned (user-created/legacy) controls stay visible in **every** view — nothing a user made ever disappears behind the new filter.

Also adds the `whitespace-nowrap` utility that `index.css` never had (Findings.js already referenced it as a silent no-op).

## Ratification items (interpretation calls — flag before/at merge if any reads wrong)

1. **Confirm-skip reversibility**: deleting a demo user is not re-seeded on an existing install (a fresh install / cleared storage re-seeds the 8). The issue's ask is read literally — no prompt at all for demo users, not a lighter prompt.
2. **Derived chips scope by the record's own assessment**: the "Linked Controls" chips on Findings/Artifacts derive from requirement matching, so they now follow the *selected record's* assessment (fail-open when the record is unassigned) rather than the page filter — a non-demo finding no longer shows Alma control chips for the same requirement.
3. **Share export still includes demo controls**, consistent with #297 shipping the whole (fictional, fiction-labeled) demo assessment + demo findings/artifacts in share exports. The rows now carry `seedSource`, so recipients can tell. A "exclude demo data from share export" toggle is a candidate follow-up issue if wanted.
4. **CSV round-trip** preserves `Assessment ID` but drops `seedSource` (same accepted trade-off as #297's artifacts CSV) — scoping survives; only the brand is laundered. Any future "purge demo data" action must not assume the brand is durable.
5. **Assessments scope picker** for controls-type assessments now offers only that assessment's own + unassigned controls — another assessment's stamped controls are no longer scope candidates.

## Testing

- 41 new tests (controlsStore migration/stamp/CSV, UserManagement confirm behavior, ControlSelector scoping, dataImport controls stamp + round-trip); full suite 594 passing.
- Migration tests drive the production `migrateControlsState`/`stampSeededDemoControls` functions with negative cases (colliding id, unknown id + missing createdDate, pre-classified records) — including a resurrection guard proving the heal is stamp-only: demo controls the user deletes stay deleted across the migration (the delete feature and the heal migration cannot contradict each other).
- eslint max-warnings=0 on all non-allowlisted changed files; allowlisted files at exact warning parity with main; `CI=false` build compiles.
