### PR TITLE
Add missing amber background utilities so buttons render

### DIFF
--- a/src/components/OrgProfileWizard.js
+++ b/src/components/OrgProfileWizard.js
@@ -250,7 +250,7 @@ const OrgProfileWizard = ({ onClose }) => {
               <button
                 type="button"
                 onClick={finish}
-                className="px-4 py-2 text-sm bg-amber-600 hover:bg-amber-700 text-white rounded-lg font-medium"
+                className="px-4 py-2 text-sm bg-amber-700 hover:bg-amber-800 text-white rounded-lg font-medium"
               >
                 Save profile
               </button>
@@ -258,7 +258,7 @@ const OrgProfileWizard = ({ onClose }) => {
               <button
                 type="button"
                 onClick={() => setStep(step + 1)}
-                className="px-4 py-2 text-sm bg-amber-600 hover:bg-amber-700 text-white rounded-lg font-medium flex items-center gap-1"
+                className="px-4 py-2 text-sm bg-amber-700 hover:bg-amber-800 text-white rounded-lg font-medium flex items-center gap-1"
               >
                 Next <ChevronRight size={14} />
               </button>

--- a/src/index.css
+++ b/src/index.css
@@ -257,6 +257,7 @@ code {
 .w-72 { width: 18rem; }
 .w-full { width: 100%; }
 
+.h-1\.5 { height: 0.375rem; }
 .h-3 { height: 0.75rem; }
 .h-4 { height: 1rem; }
 .h-5 { height: 1.25rem; }
@@ -448,6 +449,8 @@ code {
 .bg-yellow-600 { background-color: #ca8a04; }
 .bg-amber-50 { background-color: #fffbeb; }
 .bg-amber-100 { background-color: #fef3c7; }
+.bg-amber-500 { background-color: #f59e0b; }
+.bg-amber-600 { background-color: #d97706; }
 .bg-amber-700 { background-color: #b45309; }
 .bg-amber-800 { background-color: #92400e; }
 .bg-green-50 { background-color: #f0fdf4; }
@@ -621,6 +624,10 @@ code {
 .hover\:bg-indigo-700:hover { background-color: #11245a; }
 .hover\:bg-red-50:hover { background-color: #fef2f2; }
 .hover\:bg-amber-50:hover { background-color: #fffbeb; }
+.hover\:bg-amber-100:hover { background-color: #fef3c7; }
+.hover\:bg-amber-600:hover { background-color: #d97706; }
+.hover\:bg-amber-700:hover { background-color: #b45309; }
+.hover\:bg-amber-800:hover { background-color: #92400e; }
 .hover\:bg-green-700:hover { background-color: #15803d; }
 
 /* Hover — text */
@@ -906,8 +913,14 @@ nav a:active { text-decoration: none !important; }
 .dark .bg-yellow-600 { background-color: #ca8a04; }
 .dark .bg-orange-600 { background-color: #cc6600; }
 .dark .bg-amber-50 { background-color: #2a1a00; }
+.dark .bg-amber-500 { background-color: #c88a00; }
+.dark .bg-amber-600 { background-color: #a97000; }
 .dark .bg-amber-700 { background-color: #8a5a00; }
 .dark .bg-amber-800 { background-color: #6b4400; }
+.dark .hover\:bg-amber-100:hover { background-color: #3a2600; }
+.dark .hover\:bg-amber-600:hover { background-color: #a97000; }
+.dark .hover\:bg-amber-700:hover { background-color: #8a5a00; }
+.dark .hover\:bg-amber-800:hover { background-color: #6b4400; }
 .dark .bg-purple-50 { background-color: #111111; }
 .dark .bg-cyan-50 { background-color: #001a1a; }
 .dark .bg-indigo-50 { background-color: #001100; }


### PR DESCRIPTION
.bg-amber-500/.bg-amber-600, four hover:bg-amber-* variants and .h-1.5
were referenced across the app but never defined in index.css, so the
Organization profile wizard's Next button rendered white text on a
transparent background, the step progress bar had zero height, and the
Findings action buttons rendered unstyled.

Adds the missing utilities plus dark-theme overrides following the
existing gold cascade, and moves the wizard's Next/Save buttons to
amber-700/800 for a 4.6:1 contrast ratio with white text (AA).
