### PR TITLE
Fix shortcut-chip contrast in both themes; add a Windows/Mac modifier toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "zustand": "^5.0.9"
       },
       "devDependencies": {
-        "@tauri-apps/cli": "^2.9.6"
+        "@tauri-apps/cli": "^2.9.6",
+        "postcss": "^8.4.31"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     ]
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2.9.6"
+    "@tauri-apps/cli": "^2.9.6",
+    "postcss": "^8.4.31"
   }
 }

--- a/src/components/KeyboardShortcutsOverlay.js
+++ b/src/components/KeyboardShortcutsOverlay.js
@@ -1,4 +1,10 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  PLATFORM_MAC,
+  PLATFORM_WINDOWS,
+  resolvePlatform,
+  storePlatform,
+} from '../utils/platform';
 
 /**
  * KeyboardShortcutsOverlay
@@ -15,10 +21,18 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 // A key token renders as a <kbd> chip.
 const K = (label) => ({ kbd: label });
+// The primary chord modifier, rendered per the selected platform. The hook
+// accepts ctrlKey || metaKey everywhere, so either label is truthful.
+const MOD = { mod: true };
 // A separator between alternative key options ("or").
 const OR = { or: true };
 // A "+" combiner rendered between chord keys.
 const PLUS = { plus: true };
+
+const MODIFIER_LABEL = {
+  [PLATFORM_WINDOWS]: 'Ctrl',
+  [PLATFORM_MAC]: '⌘',
+};
 
 const SHORTCUT_GROUPS = [
   {
@@ -35,7 +49,7 @@ const SHORTCUT_GROUPS = [
     shortcuts: [
       { desc: 'Toggle selection of current item', keys: [K('Space')] },
       { desc: 'Extend selection while moving', keys: [K('Shift'), PLUS, K('↑'), OR, K('Shift'), PLUS, K('↓')] },
-      { desc: 'Select all items', keys: [K('Ctrl'), OR, K('⌘'), PLUS, K('A')] },
+      { desc: 'Select all items', keys: [MOD, PLUS, K('A')] },
       { desc: 'Exit edit / clear selection / deselect', keys: [K('Esc')] },
     ],
   },
@@ -44,8 +58,8 @@ const SHORTCUT_GROUPS = [
     shortcuts: [
       { desc: 'Edit current item', keys: [K('Enter')] },
       { desc: 'Create new item', keys: [K('N')] },
-      { desc: 'Undo', keys: [K('Ctrl'), OR, K('⌘'), PLUS, K('Z')] },
-      { desc: 'Redo', keys: [K('Ctrl'), OR, K('⌘'), PLUS, K('Shift'), PLUS, K('Z'), OR, K('Ctrl'), OR, K('⌘'), PLUS, K('Y')] },
+      { desc: 'Undo', keys: [MOD, PLUS, K('Z')] },
+      { desc: 'Redo', keys: [MOD, PLUS, K('Shift'), PLUS, K('Z'), OR, MOD, PLUS, K('Y')] },
     ],
   },
   {
@@ -57,16 +71,28 @@ const SHORTCUT_GROUPS = [
   },
 ];
 
-const KeyToken = ({ token }) => {
+const KeyToken = ({ token, platform }) => {
   if (token.or) return <span className="kbd-overlay-or">or</span>;
   if (token.plus) return <span className="kbd-overlay-plus">+</span>;
+  if (token.mod) return <kbd className="terminal-kbd">{MODIFIER_LABEL[platform]}</kbd>;
   return <kbd className="terminal-kbd">{token.kbd}</kbd>;
 };
 
+const PLATFORM_OPTIONS = [
+  { id: PLATFORM_WINDOWS, label: 'Windows' },
+  { id: PLATFORM_MAC, label: 'Mac' },
+];
+
 const KeyboardShortcutsOverlay = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const [platform, setPlatform] = useState(resolvePlatform);
   const closeButtonRef = useRef(null);
   const previouslyFocused = useRef(null);
+
+  const choosePlatform = useCallback((next) => {
+    setPlatform(next);
+    storePlatform(next);
+  }, []);
 
   const close = useCallback(() => {
     setIsOpen(false);
@@ -124,6 +150,19 @@ const KeyboardShortcutsOverlay = () => {
       >
         <div className="kbd-overlay-header">
           <span className="kbd-overlay-title">Keyboard Shortcuts</span>
+          <div className="kbd-overlay-platform" role="group" aria-label="Modifier key style">
+            {PLATFORM_OPTIONS.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                className={`kbd-overlay-platform-btn${platform === option.id ? ' is-active' : ''}`}
+                aria-pressed={platform === option.id}
+                onClick={() => choosePlatform(option.id)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
           <button
             type="button"
             ref={closeButtonRef}
@@ -142,10 +181,10 @@ const KeyboardShortcutsOverlay = () => {
               {group.shortcuts.map((shortcut) => (
                 <div key={shortcut.desc} className="kbd-overlay-row">
                   <span className="kbd-overlay-row-desc">{shortcut.desc}</span>
-                  <span className="kbd-overlay-row-keys">
+                  <span className="kbd-overlay-row-keys" role="group" aria-label={shortcut.desc}>
                     {shortcut.keys.map((token, i) => (
                       // eslint-disable-next-line react/no-array-index-key
-                      <KeyToken key={i} token={token} />
+                      <KeyToken key={i} token={token} platform={platform} />
                     ))}
                   </span>
                 </div>
@@ -155,6 +194,7 @@ const KeyboardShortcutsOverlay = () => {
 
           <div className="kbd-overlay-footer">
             Shortcuts are disabled while typing in an input, textarea, or select.
+            {' '}Ctrl and {'⌘'} both work regardless of the setting above.
           </div>
         </div>
       </div>

--- a/src/components/KeyboardShortcutsOverlay.js
+++ b/src/components/KeyboardShortcutsOverlay.js
@@ -181,7 +181,7 @@ const KeyboardShortcutsOverlay = () => {
               {group.shortcuts.map((shortcut) => (
                 <div key={shortcut.desc} className="kbd-overlay-row">
                   <span className="kbd-overlay-row-desc">{shortcut.desc}</span>
-                  <span className="kbd-overlay-row-keys" role="group" aria-label={shortcut.desc}>
+                  <span className="kbd-overlay-row-keys">
                     {shortcut.keys.map((token, i) => (
                       // eslint-disable-next-line react/no-array-index-key
                       <KeyToken key={i} token={token} platform={platform} />

--- a/src/components/KeyboardShortcutsOverlay.test.js
+++ b/src/components/KeyboardShortcutsOverlay.test.js
@@ -1,0 +1,143 @@
+import React from 'react';
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
+import KeyboardShortcutsOverlay from './KeyboardShortcutsOverlay';
+import { PLATFORM_STORAGE_KEY } from '../utils/platform';
+
+const openOverlay = () => {
+  act(() => {
+    window.dispatchEvent(new CustomEvent('keyboard-show-help'));
+  });
+};
+
+const setUserAgent = (ua) => {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: ua,
+    configurable: true,
+  });
+};
+
+const ORIGINAL_UA = window.navigator.userAgent;
+
+const modifierChips = () =>
+  screen
+    .getAllByText((_content, node) => node.tagName === 'KBD')
+    .map((node) => node.textContent);
+
+beforeEach(() => {
+  window.localStorage.clear();
+  setUserAgent(ORIGINAL_UA);
+});
+
+afterAll(() => setUserAgent(ORIGINAL_UA));
+
+describe('KeyboardShortcutsOverlay — platform toggle', () => {
+  it('renders a Windows/Mac toggle in the header when open', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+    render(<KeyboardShortcutsOverlay />);
+    openOverlay();
+
+    expect(screen.getByRole('group', { name: /modifier key style/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Windows' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Mac' })).toBeInTheDocument();
+  });
+
+  it('exposes the active side via aria-pressed', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+    render(<KeyboardShortcutsOverlay />);
+    openOverlay();
+
+    expect(screen.getByRole('button', { name: 'Windows' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Mac' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('auto-detects Mac from the user agent', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)');
+    render(<KeyboardShortcutsOverlay />);
+    openOverlay();
+
+    expect(screen.getByRole('button', { name: 'Mac' })).toHaveAttribute('aria-pressed', 'true');
+    expect(modifierChips()).toContain('⌘');
+    expect(modifierChips()).not.toContain('Ctrl');
+  });
+
+  it('defaults to Windows when the platform is unrecognised', () => {
+    setUserAgent('Mozilla/5.0 (X11; Linux x86_64)');
+    render(<KeyboardShortcutsOverlay />);
+    openOverlay();
+
+    expect(screen.getByRole('button', { name: 'Windows' })).toHaveAttribute('aria-pressed', 'true');
+    expect(modifierChips()).toContain('Ctrl');
+    expect(modifierChips()).not.toContain('⌘');
+  });
+
+  it('swaps every modifier chip when the other side is clicked', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+    render(<KeyboardShortcutsOverlay />);
+    openOverlay();
+
+    const ctrlCount = modifierChips().filter((label) => label === 'Ctrl').length;
+    expect(ctrlCount).toBe(4); // select-all, undo, redo x2
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mac' }));
+
+    expect(modifierChips().filter((label) => label === '⌘')).toHaveLength(ctrlCount);
+    expect(modifierChips()).not.toContain('Ctrl');
+  });
+
+  it('renders both redo alternatives for the selected platform', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)');
+    render(<KeyboardShortcutsOverlay />);
+    openOverlay();
+
+    const redoKeys = screen.getByRole('group', { name: 'Redo' });
+    const labels = within(redoKeys)
+      .getAllByText((_content, node) => node.tagName === 'KBD')
+      .map((node) => node.textContent);
+    expect(labels).toEqual(['⌘', 'Shift', 'Z', '⌘', 'Y']);
+    expect(within(redoKeys).getByText('or')).toBeInTheDocument();
+  });
+
+  it('persists the choice and prefers it over detection on remount', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+    const view = render(<KeyboardShortcutsOverlay />);
+    openOverlay();
+    fireEvent.click(screen.getByRole('button', { name: 'Mac' }));
+    expect(window.localStorage.getItem(PLATFORM_STORAGE_KEY)).toBe('mac');
+    view.unmount();
+
+    render(<KeyboardShortcutsOverlay />);
+    openOverlay();
+    expect(screen.getByRole('button', { name: 'Mac' })).toHaveAttribute('aria-pressed', 'true');
+    expect(modifierChips()).toContain('⌘');
+  });
+});
+
+describe('KeyboardShortcutsOverlay — existing behavior is unchanged', () => {
+  it('stays closed until the help event fires, then closes on Escape', () => {
+    render(<KeyboardShortcutsOverlay />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    openOverlay();
+    expect(screen.getByRole('dialog', { name: /keyboard shortcuts/i })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('closes on a backdrop click but not on a panel click', () => {
+    render(<KeyboardShortcutsOverlay />);
+    openOverlay();
+
+    fireEvent.click(screen.getByRole('dialog'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('presentation'));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('says both modifiers work, so the toggle cannot read as a rebind', () => {
+    render(<KeyboardShortcutsOverlay />);
+    openOverlay();
+    expect(screen.getByText(/both work regardless of the setting/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/KeyboardShortcutsOverlay.test.js
+++ b/src/components/KeyboardShortcutsOverlay.test.js
@@ -89,12 +89,16 @@ describe('KeyboardShortcutsOverlay — platform toggle', () => {
     render(<KeyboardShortcutsOverlay />);
     openOverlay();
 
-    const redoKeys = screen.getByRole('group', { name: 'Redo' });
-    const labels = within(redoKeys)
+    // Scoping to the row needs one DOM step up from its description. The
+    // alternative — giving every keys span a role and a name purely so a query
+    // can reach it — makes screen readers announce each shortcut twice.
+    // eslint-disable-next-line testing-library/no-node-access
+    const redoRow = screen.getByText('Redo').closest('.kbd-overlay-row');
+    const labels = within(redoRow)
       .getAllByText((_content, node) => node.tagName === 'KBD')
       .map((node) => node.textContent);
     expect(labels).toEqual(['⌘', 'Shift', 'Z', '⌘', 'Y']);
-    expect(within(redoKeys).getByText('or')).toBeInTheDocument();
+    expect(within(redoRow).getByText('or')).toBeInTheDocument();
   });
 
   it('persists the choice and prefers it over detection on remount', () => {

--- a/src/hooks/useKeyboardNavigation.js
+++ b/src/hooks/useKeyboardNavigation.js
@@ -65,8 +65,13 @@ export function useKeyboardNavigation() {
       return;
     }
 
+    // event.key carries the SHIFTED character, so Shift+Z arrives as 'Z' (and
+    // Caps Lock alone flips plain Z the same way). Compare case-insensitively
+    // or the Shift+Z redo chord the shortcuts overlay advertises never fires.
+    const letter = typeof event.key === 'string' ? event.key.toLowerCase() : '';
+
     // Undo: Ctrl/Cmd + Z
-    if ((event.ctrlKey || event.metaKey) && event.key === 'z' && !event.shiftKey) {
+    if ((event.ctrlKey || event.metaKey) && letter === 'z' && !event.shiftKey) {
       event.preventDefault();
       if (canUndo()) {
         undo();
@@ -76,8 +81,8 @@ export function useKeyboardNavigation() {
 
     // Redo: Ctrl/Cmd + Shift + Z or Ctrl/Cmd + Y
     if ((event.ctrlKey || event.metaKey) && (
-      (event.key === 'z' && event.shiftKey) ||
-      event.key === 'y'
+      (letter === 'z' && event.shiftKey) ||
+      letter === 'y'
     )) {
       event.preventDefault();
       if (canRedo()) {

--- a/src/hooks/useKeyboardNavigation.test.js
+++ b/src/hooks/useKeyboardNavigation.test.js
@@ -1,0 +1,92 @@
+import { renderHook } from '@testing-library/react';
+import useKeyboardNavigation from './useKeyboardNavigation';
+
+/**
+ * Regression guard for the chords the shortcuts overlay advertises.
+ *
+ * The overlay renders "Ctrl/⌘ + Shift + Z". Browsers report the SHIFTED
+ * character in event.key, so that chord arrives as 'Z' — the hook used to
+ * compare against a lowercase literal and never fired, meaning the overlay
+ * documented a key combination that did nothing.
+ */
+
+const mockUndo = jest.fn();
+const mockRedo = jest.fn();
+
+jest.mock('../stores/uiStore', () => {
+  const state = {
+    currentItemId: null,
+    setCurrentItemId: jest.fn(),
+    editMode: false,
+    setEditMode: jest.fn(),
+    selectedItemIds: [],
+    toggleItemSelection: jest.fn(),
+    clearSelection: jest.fn(),
+  };
+  const store = () => state;
+  store.getState = () => ({ ...state, selectAllItems: jest.fn() });
+  return { __esModule: true, default: store };
+});
+
+jest.mock('../stores/csfStore', () => ({
+  __esModule: true,
+  default: () => ({
+    undo: mockUndo,
+    redo: mockRedo,
+    canUndo: () => true,
+    canRedo: () => true,
+  }),
+}));
+
+jest.mock('./useFilters', () => ({
+  useFilters: () => ({
+    filteredData: [],
+    getNextItem: () => null,
+    getPrevItem: () => null,
+    goToNextPage: jest.fn(),
+    goToPrevPage: jest.fn(),
+  }),
+}));
+
+const press = (init) => {
+  window.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, ...init }));
+};
+
+beforeEach(() => {
+  mockUndo.mockClear();
+  mockRedo.mockClear();
+});
+
+describe('undo/redo chords survive the shifted-key report', () => {
+  it('fires redo for Ctrl + Shift + Z, which arrives as key "Z"', () => {
+    renderHook(() => useKeyboardNavigation());
+    press({ key: 'Z', shiftKey: true, ctrlKey: true });
+    expect(mockRedo).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires redo for Cmd + Shift + Z on a Mac', () => {
+    renderHook(() => useKeyboardNavigation());
+    press({ key: 'Z', shiftKey: true, metaKey: true });
+    expect(mockRedo).toHaveBeenCalledTimes(1);
+  });
+
+  it('still fires redo for the Ctrl + Y alternative', () => {
+    renderHook(() => useKeyboardNavigation());
+    press({ key: 'y', ctrlKey: true });
+    expect(mockRedo).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires undo for Ctrl + Z even when Caps Lock reports "Z"', () => {
+    renderHook(() => useKeyboardNavigation());
+    press({ key: 'Z', ctrlKey: true });
+    expect(mockUndo).toHaveBeenCalledTimes(1);
+    expect(mockRedo).not.toHaveBeenCalled();
+  });
+
+  it('does not treat a bare Z as undo', () => {
+    renderHook(() => useKeyboardNavigation());
+    press({ key: 'z' });
+    expect(mockUndo).not.toHaveBeenCalled();
+    expect(mockRedo).not.toHaveBeenCalled();
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -65,13 +65,20 @@
   --text-primary: #0e1626;     /* near-black with blue undertone */
   --text-secondary: #1f2a44;
   --text-muted: #4a5570;
-  --text-faint: #8a93a6;
+  --text-faint: #5f6b85;       /* lowest INFORMATIONAL tier — must clear 4.5:1 */
+  --text-decorative: #8a93a6;  /* ornament only (bracket glyphs); never carries meaning */
   --border-color: #0e1626;
   --border-dark: #1f2a44;
   --ring-color: #1e3a8a;
   --accent: #1e3a8a;           /* Simply Cyber royal blue */
   --accent-bright: #2b4fae;    /* hover / CTA tint */
   --accent-soft: #eaf0fb;      /* accent surface */
+
+  /* On-header tokens — for the chrome that stays DARK in both themes
+     (--bg-header). Page-level --accent is a dark navy here and would be
+     invisible, so anything rendered on that surface uses these instead. */
+  --on-header-accent: #3ea6ff;
+  --on-header-muted: #8a8a8a;
 
   /* Terminal status colors (light) */
   --terminal-amber: #1e3a8a;   /* repurposed: status-bar primary */
@@ -97,12 +104,18 @@
   --bg-nav-active: #001100;
   --text-primary: #33ff66;
   --text-secondary: #22cc55;
-  --text-muted: #189944;
-  --text-faint: #0e6633;
+  --text-muted: #1fb551;
+  --text-faint: #12a04a;       /* lowest INFORMATIONAL tier — must clear 4.5:1 */
+  --text-decorative: #0e6633;  /* ornament only (bracket glyphs); never carries meaning */
   --border-color: #1f5533;
   --border-dark: #2a8044;
   --ring-color: #33ff66;
   --accent: #33ff66;
+
+  /* On-header tokens — the dark chrome is already dark here, so the page
+     accent works; kept as tokens so the surface has one vocabulary. */
+  --on-header-accent: #33ff66;
+  --on-header-muted: #12a04a;
 
   /* Terminal status colors (dark) */
   --terminal-amber: #3ea6ff;
@@ -764,12 +777,12 @@ tr:hover .row-hover-actions { opacity: 1; }
 .filter-chip::before {
   content: '[';
   margin-right: 4px;
-  color: var(--text-faint);
+  color: var(--text-decorative);
 }
 .filter-chip::after {
   content: ']';
   margin-left: 4px;
-  color: var(--text-faint);
+  color: var(--text-decorative);
 }
 .filter-chip:hover {
   color: var(--accent);
@@ -990,7 +1003,7 @@ nav a:active { text-decoration: none !important; }
   background-color: transparent;
 }
 .dark .filter-chip::before,
-.dark .filter-chip::after { color: var(--text-faint); }
+.dark .filter-chip::after { color: var(--text-decorative); }
 .dark .filter-chip:hover {
   color: var(--accent);
   border-color: var(--accent);
@@ -1036,7 +1049,7 @@ nav a:active { text-decoration: none !important; }
   font-variant-numeric: tabular-nums;
 }
 .badge-success { background-color: rgba(42, 106, 42, 0.10); border-color: #2a6a2a; color: #2a6a2a; }
-.badge-warning { background-color: rgba(201, 123, 0, 0.10); border-color: #c97b00; color: #c97b00; }
+.badge-warning { background-color: rgba(163, 95, 0, 0.10); border-color: #a35f00; color: #a35f00; }
 .badge-danger  { background-color: rgba(160, 0, 0, 0.10); border-color: #a00000; color: #a00000; }
 .badge-info    { background-color: rgba(0, 106, 142, 0.10); border-color: #006a8e; color: #006a8e; }
 .badge-neutral { background-color: rgba(90, 90, 90, 0.08); border-color: #5a5a5a; color: #5a5a5a; }
@@ -1236,7 +1249,7 @@ nav a:active { text-decoration: none !important; }
 .terminal-statusbar-segment:first-child::before { content: none; margin-right: 0; }
 .terminal-statusbar-segment.terminal-statusbar-flex { flex: 1; }
 .terminal-statusbar-label {
-  color: #8a8a8a;
+  color: var(--on-header-muted);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-weight: 600;
@@ -1245,7 +1258,7 @@ nav a:active { text-decoration: none !important; }
 .terminal-statusbar-value { color: #3ea6ff; }
 
 .dark .terminal-statusbar { color: var(--accent); }
-.dark .terminal-statusbar-label { color: var(--text-faint); }
+.dark .terminal-statusbar-label { color: var(--on-header-muted); }
 .dark .terminal-statusbar-value { color: var(--accent); }
 
 /* --- Interactive selector inside status bar (assessment) --- */
@@ -1431,12 +1444,12 @@ nav a:active { text-decoration: none !important; }
 .terminal-bracket-link::before {
   content: '[';
   margin-right: 2px;
-  color: var(--text-faint);
+  color: var(--text-decorative);
 }
 .terminal-bracket-link::after {
   content: ']';
   margin-left: 2px;
-  color: var(--text-faint);
+  color: var(--text-decorative);
 }
 .terminal-bracket-link:hover,
 .terminal-bracket-link.is-active {
@@ -1622,14 +1635,15 @@ nav a:active { text-decoration: none !important; }
 .terminal-statusbar-kbdhints .terminal-kbd {
   height: 14px;
   line-height: 12px;
+  color: var(--on-header-accent);
+  border-color: var(--on-header-accent);
 }
 .terminal-statusbar-kbdhints .terminal-statusbar-kbdlabel {
-  color: #8a8a8a;
+  color: var(--on-header-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-.dark .terminal-statusbar-kbdhints .terminal-statusbar-kbdlabel { color: var(--text-faint); }
-.terminal-statusbar-kbdhints:hover .terminal-statusbar-kbdlabel { color: var(--accent); }
+.terminal-statusbar-kbdhints:hover .terminal-statusbar-kbdlabel { color: var(--on-header-accent); }
 
 /* --- Keyboard-shortcuts overlay modal --- */
 .kbd-overlay-backdrop {
@@ -1674,13 +1688,13 @@ nav a:active { text-decoration: none !important; }
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--accent);
+  color: var(--on-header-accent);
 }
 .kbd-overlay-title::before { content: '█ '; }
 .kbd-overlay-close {
   background: transparent;
-  border: 1px solid var(--accent);
-  color: var(--accent);
+  border: 1px solid var(--on-header-accent);
+  color: var(--on-header-accent);
   font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 600;
@@ -1691,7 +1705,37 @@ nav a:active { text-decoration: none !important; }
   border-radius: 0;
   line-height: 16px;
 }
-.kbd-overlay-close:hover { background: var(--accent); color: var(--bg-primary); }
+.kbd-overlay-close:hover { background: var(--on-header-accent); color: var(--bg-header); }
+
+/* Windows / Mac modifier-style toggle — lives on the dark header surface. */
+.kbd-overlay-platform {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  margin-left: auto;
+  margin-right: 12px;
+}
+.kbd-overlay-platform-btn {
+  background: transparent;
+  border: 1px solid var(--on-header-muted);
+  color: var(--on-header-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 1px 8px;
+  line-height: 16px;
+  cursor: pointer;
+  border-radius: 0;
+}
+.kbd-overlay-platform-btn + .kbd-overlay-platform-btn { border-left: none; }
+.kbd-overlay-platform-btn:hover { color: var(--on-header-accent); border-color: var(--on-header-accent); }
+.kbd-overlay-platform-btn.is-active {
+  background: var(--on-header-accent);
+  border-color: var(--on-header-accent);
+  color: var(--bg-header);
+}
 
 .kbd-overlay-body { padding: 8px 16px 16px; }
 .kbd-overlay-group { margin-top: 14px; }

--- a/src/theme/contrast.test.js
+++ b/src/theme/contrast.test.js
@@ -1,0 +1,206 @@
+/**
+ * Theme contrast guard.
+ *
+ * CSS-only defects are invisible to the rest of the suite: nothing here renders
+ * a stylesheet, and jsdom does not resolve custom properties. So this test
+ * parses src/index.css with postcss and reads the actual declared values — the
+ * colors under test come from the stylesheet, not from constants typed here.
+ * Editing a hex in index.css changes this test's input; it cannot drift green.
+ *
+ * The hand-maintained part is which foreground pairs with which background.
+ * The coverage assertion at the bottom is what keeps that honest: every
+ * --text-* / --on-* token must appear in at least one pair, so adding a token
+ * fails the suite until someone classifies it.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const postcss = require('postcss');
+
+const CSS_PATH = path.join(__dirname, '..', 'index.css');
+const root = postcss.parse(fs.readFileSync(CSS_PATH, 'utf8'));
+
+// --- palette extraction ------------------------------------------------------
+
+const collectCustomProps = (selector) => {
+  const out = {};
+  root.walkRules(selector, (rule) => {
+    rule.walkDecls((decl) => {
+      if (decl.prop.startsWith('--')) out[decl.prop] = decl.value.trim();
+    });
+  });
+  return out;
+};
+
+const LIGHT_VARS = collectCustomProps(':root');
+const DARK_VARS = collectCustomProps('.dark');
+
+/** Resolve a token (or literal hex) to a hex, following one level of var(). */
+const resolve = (value, vars) => {
+  const varMatch = /^var\((--[a-z0-9-]+)\)$/i.exec(value.trim());
+  const raw = varMatch ? vars[varMatch[1]] : value.trim();
+  if (!raw) throw new Error(`unresolved color: ${value}`);
+  const inner = /^var\((--[a-z0-9-]+)\)$/i.exec(raw);
+  const hex = inner ? vars[inner[1]] : raw;
+  if (!/^#[0-9a-f]{6}$/i.test(hex)) throw new Error(`not a 6-digit hex: ${value} -> ${hex}`);
+  return hex.toLowerCase();
+};
+
+/** Read one declared value straight out of the stylesheet, e.g. the literals. */
+const declValue = (selector, prop) => {
+  let found = null;
+  root.walkRules((rule) => {
+    if (rule.selector.split(',').map((s) => s.trim()).includes(selector)) {
+      rule.walkDecls(prop, (decl) => {
+        found = decl.value.trim();
+      });
+    }
+  });
+  if (found === null) throw new Error(`no "${prop}" declared on ${selector}`);
+  return found;
+};
+
+// --- WCAG relative luminance / contrast --------------------------------------
+
+const channel = (c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+
+const luminance = (hex) => {
+  const h = hex.replace('#', '');
+  const [r, g, b] = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16) / 255);
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+};
+
+const contrast = (a, b) => {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+/** Composite a translucent overlay (hover tints) onto an opaque background. */
+const over = (fg, bg, alpha) => {
+  const parse = (h) => [0, 2, 4].map((i) => parseInt(h.replace('#', '').slice(i, i + 2), 16));
+  const [f, b] = [parse(fg), parse(bg)];
+  return `#${f
+    .map((v, i) => Math.round(v * alpha + b[i] * (1 - alpha)).toString(16).padStart(2, '0'))
+    .join('')}`;
+};
+
+// --- the pair matrix ---------------------------------------------------------
+
+const AA = 4.5;
+
+/**
+ * Surfaces text actually lands on. --bg-header is the chrome that stays dark in
+ * BOTH themes, which is the trap the on-header tokens exist to avoid.
+ */
+const surfaces = (vars) => ({
+  base: resolve('var(--bg-primary)', vars),
+  secondary: resolve('var(--bg-secondary)', vars),
+  header: resolve('var(--bg-header)', vars),
+});
+
+const lightSurfaces = surfaces(LIGHT_VARS);
+const darkSurfaces = surfaces(DARK_VARS);
+
+// Row hover tints are declared as rgba() literals; keep them in sync by hand
+// with index.css `tr:hover td` — asserted below so a change is caught.
+const LIGHT_HOVER = over(resolve('var(--accent)', LIGHT_VARS), lightSurfaces.base, 0.06);
+const DARK_HOVER = over(resolve('var(--accent)', DARK_VARS), darkSurfaces.base, 0.08);
+
+const pairs = [
+  // Informational text tiers on the page surface.
+  ['light', '--text-primary on page', 'var(--text-primary)', lightSurfaces.base],
+  ['light', '--text-secondary on page', 'var(--text-secondary)', lightSurfaces.base],
+  ['light', '--text-muted on page', 'var(--text-muted)', lightSurfaces.base],
+  ['light', '--text-faint on page', 'var(--text-faint)', lightSurfaces.base],
+  ['light', '--text-faint on panel', 'var(--text-faint)', lightSurfaces.secondary],
+  ['light', '--text-faint on hovered row', 'var(--text-faint)', LIGHT_HOVER],
+  ['dark', '--text-primary on page', 'var(--text-primary)', darkSurfaces.base],
+  ['dark', '--text-secondary on page', 'var(--text-secondary)', darkSurfaces.base],
+  ['dark', '--text-muted on page', 'var(--text-muted)', darkSurfaces.base],
+  ['dark', '--text-faint on page', 'var(--text-faint)', darkSurfaces.base],
+  ['dark', '--text-faint on panel', 'var(--text-faint)', darkSurfaces.secondary],
+  ['dark', '--text-faint on hovered row', 'var(--text-faint)', DARK_HOVER],
+
+  // The always-dark chrome: status bar + shortcuts-overlay header.
+  ['light', '--on-header-accent on chrome', 'var(--on-header-accent)', lightSurfaces.header],
+  ['light', '--on-header-muted on chrome', 'var(--on-header-muted)', lightSurfaces.header],
+  ['dark', '--on-header-accent on chrome', 'var(--on-header-accent)', darkSurfaces.header],
+  ['dark', '--on-header-muted on chrome', 'var(--on-header-muted)', darkSurfaces.header],
+
+  // Shortcut chips render --accent on the overlay body, which is the page surface.
+  ['light', 'kbd chip in overlay body', 'var(--accent)', lightSurfaces.base],
+  ['dark', 'kbd chip in overlay body', 'var(--accent)', darkSurfaces.base],
+
+  // Active/hover inversions: dark chrome color becomes the text on an accent fill.
+  ['light', 'active chip label on accent fill', 'var(--bg-header)', resolve('var(--on-header-accent)', LIGHT_VARS)],
+  ['dark', 'active chip label on accent fill', 'var(--bg-header)', resolve('var(--on-header-accent)', DARK_VARS)],
+
+  // Status-bar literals (read from the stylesheet, not retyped).
+  ['light', 'status-bar value literal', declValue('.terminal-statusbar-value', 'color'), lightSurfaces.header],
+  ['light', 'status-bar bar text', declValue('.terminal-statusbar', 'color'), lightSurfaces.header],
+
+  // Warning badge on the page surface.
+  ['light', 'badge-warning', declValue('.badge-warning', 'color'), lightSurfaces.base],
+  ['dark', 'badge-warning', declValue('.dark .badge-warning', 'color'), darkSurfaces.base],
+];
+
+describe('luminance arithmetic', () => {
+  it('matches known WCAG reference ratios', () => {
+    expect(contrast('#000000', '#ffffff')).toBeCloseTo(21, 5);
+    expect(contrast('#777777', '#ffffff')).toBeCloseTo(4.48, 2);
+    expect(contrast('#123456', '#123456')).toBeCloseTo(1, 5);
+  });
+});
+
+describe('palette parsing', () => {
+  it('reads both theme blocks out of index.css', () => {
+    expect(Object.keys(LIGHT_VARS).length).toBeGreaterThan(20);
+    expect(Object.keys(DARK_VARS).length).toBeGreaterThan(10);
+    // Sanity: the two themes really do define different accents.
+    expect(resolve('var(--accent)', LIGHT_VARS)).not.toEqual(resolve('var(--accent)', DARK_VARS));
+  });
+
+  it('still composites the row-hover tints index.css declares', () => {
+    expect(declValue('tr:hover td', 'background-color')).toContain('0.06');
+    expect(declValue('.dark tr:hover td', 'background-color')).toContain('0.08');
+  });
+});
+
+describe('WCAG AA contrast (4.5:1) in both themes', () => {
+  it.each(pairs)('%s — %s', (mode, _label, fg, bg) => {
+    const vars = mode === 'dark' ? DARK_VARS : LIGHT_VARS;
+    const ratio = contrast(resolve(fg, vars), bg);
+    expect(ratio).toBeGreaterThanOrEqual(AA);
+  });
+});
+
+describe('token coverage', () => {
+  it('every informational text token is exercised by at least one pair', () => {
+    const covered = new Set(pairs.map(([, , fg]) => fg));
+    const merged = { ...LIGHT_VARS, ...DARK_VARS };
+    const tokens = Object.keys(merged).filter(
+      (name) =>
+        /^--(text|on)-/.test(name) &&
+        // --text-xs .. --text-3xl are font sizes sharing the prefix.
+        /^#[0-9a-f]{6}$/i.test(merged[name]) &&
+        name !== '--text-decorative',
+    );
+    const missing = tokens.filter((name) => !covered.has(`var(${name})`));
+    expect(missing).toEqual([]);
+  });
+
+  it('--text-decorative is exempt and used only for ornamental glyphs', () => {
+    // Exempt by WCAG 1.4.3 (decorative), so it is deliberately excluded above.
+    // Guard the exemption: it may only appear on ::before/::after content rules.
+    const offenders = [];
+    root.walkRules((rule) => {
+      rule.walkDecls((decl) => {
+        if (!decl.value.includes('--text-decorative')) return;
+        if (decl.prop.startsWith('--')) return;
+        const isPseudoElement = /::(before|after)/.test(rule.selector);
+        if (!isPseudoElement) offenders.push(rule.selector);
+      });
+    });
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/theme/contrast.test.js
+++ b/src/theme/contrast.test.js
@@ -75,13 +75,30 @@ const contrast = (a, b) => {
   return (hi + 0.05) / (lo + 0.05);
 };
 
-/** Composite a translucent overlay (hover tints) onto an opaque background. */
-const over = (fg, bg, alpha) => {
-  const parse = (h) => [0, 2, 4].map((i) => parseInt(h.replace('#', '').slice(i, i + 2), 16));
-  const [f, b] = [parse(fg), parse(bg)];
-  return `#${f
-    .map((v, i) => Math.round(v * alpha + b[i] * (1 - alpha)).toString(16).padStart(2, '0'))
+const parseHex = (h) => [0, 2, 4].map((i) => parseInt(h.replace('#', '').slice(i, i + 2), 16));
+
+/** Composite a translucent overlay onto an opaque background. */
+const over = ([r, g, b], bg, alpha) => {
+  const base = parseHex(bg);
+  return `#${[r, g, b]
+    .map((v, i) => Math.round(v * alpha + base[i] * (1 - alpha)).toString(16).padStart(2, '0'))
     .join('')}`;
+};
+
+/**
+ * Read an `rgba(r, g, b, a)` declaration out of the stylesheet. Taking the
+ * channels as well as the alpha matters: an earlier version asserted only that
+ * the alpha was still 0.06 and composited a hardcoded accent, so restyling the
+ * hover tint to a different color left the test grading the old surface.
+ */
+const rgbaDecl = (selector, prop) => {
+  const raw = declValue(selector, prop);
+  const m = /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)/.exec(raw);
+  if (!m) throw new Error(`not an rgb(a) value on ${selector}: ${raw}`);
+  return {
+    rgb: [Number(m[1]), Number(m[2]), Number(m[3])],
+    alpha: m[4] === undefined ? 1 : Number(m[4]),
+  };
 };
 
 // --- the pair matrix ---------------------------------------------------------
@@ -101,10 +118,12 @@ const surfaces = (vars) => ({
 const lightSurfaces = surfaces(LIGHT_VARS);
 const darkSurfaces = surfaces(DARK_VARS);
 
-// Row hover tints are declared as rgba() literals; keep them in sync by hand
-// with index.css `tr:hover td` — asserted below so a change is caught.
-const LIGHT_HOVER = over(resolve('var(--accent)', LIGHT_VARS), lightSurfaces.base, 0.06);
-const DARK_HOVER = over(resolve('var(--accent)', DARK_VARS), darkSurfaces.base, 0.08);
+// Row hover tints: both the color and the alpha come from the stylesheet, so
+// restyling `tr:hover td` re-grades every hovered-row pair automatically.
+const lightHoverTint = rgbaDecl('tr:hover td', 'background-color');
+const darkHoverTint = rgbaDecl('.dark tr:hover td', 'background-color');
+const LIGHT_HOVER = over(lightHoverTint.rgb, lightSurfaces.base, lightHoverTint.alpha);
+const DARK_HOVER = over(darkHoverTint.rgb, darkSurfaces.base, darkHoverTint.alpha);
 
 const pairs = [
   // Informational text tiers on the page surface.
@@ -160,9 +179,13 @@ describe('palette parsing', () => {
     expect(resolve('var(--accent)', LIGHT_VARS)).not.toEqual(resolve('var(--accent)', DARK_VARS));
   });
 
-  it('still composites the row-hover tints index.css declares', () => {
-    expect(declValue('tr:hover td', 'background-color')).toContain('0.06');
-    expect(declValue('.dark tr:hover td', 'background-color')).toContain('0.08');
+  it('composites the row-hover tints from their declared color and alpha', () => {
+    expect(lightHoverTint.alpha).toBeLessThan(1);
+    expect(darkHoverTint.alpha).toBeLessThan(1);
+    // The composited surfaces must actually differ from the untinted base,
+    // otherwise the hovered-row pairs are silently duplicating the base pairs.
+    expect(LIGHT_HOVER).not.toEqual(lightSurfaces.base);
+    expect(DARK_HOVER).not.toEqual(darkSurfaces.base);
   });
 });
 
@@ -178,11 +201,15 @@ describe('token coverage', () => {
   it('every informational text token is exercised by at least one pair', () => {
     const covered = new Set(pairs.map(([, , fg]) => fg));
     const merged = { ...LIGHT_VARS, ...DARK_VARS };
+    // Exclude by what a value IS, not by what it looks like: --text-xs..3xl are
+    // font sizes sharing the prefix. Anything that is not a length is treated
+    // as a color and must be classified, so a token declared as rgb()/hsl()/
+    // an 8-digit hex cannot slip past this the way a hex-only filter allowed.
+    const isLength = (value) => /^[\d.]+(rem|em|px|%)$/.test(value.trim());
     const tokens = Object.keys(merged).filter(
       (name) =>
         /^--(text|on)-/.test(name) &&
-        // --text-xs .. --text-3xl are font sizes sharing the prefix.
-        /^#[0-9a-f]{6}$/i.test(merged[name]) &&
+        !isLength(merged[name]) &&
         name !== '--text-decorative',
     );
     const missing = tokens.filter((name) => !covered.has(`var(${name})`));

--- a/src/utils/platform.js
+++ b/src/utils/platform.js
@@ -1,0 +1,58 @@
+/**
+ * Platform detection for keyboard-shortcut display.
+ *
+ * This is DISPLAY ONLY. The navigation hook accepts ctrlKey || metaKey on every
+ * chorded action, so both renderings describe keys that genuinely work. The
+ * toggle exists so the overlay shows the modifier a reader expects to press,
+ * not to rebind anything.
+ *
+ * Detection biases toward Windows: telling a Windows user to press ⌘ names a
+ * key their keyboard does not have, while telling a Mac user to press Ctrl is
+ * merely the less idiomatic of two working options.
+ */
+
+export const PLATFORM_STORAGE_KEY = 'csf-shortcut-platform';
+
+export const PLATFORM_WINDOWS = 'windows';
+export const PLATFORM_MAC = 'mac';
+
+const isValid = (value) => value === PLATFORM_WINDOWS || value === PLATFORM_MAC;
+
+/** Read the user's explicit choice, or null when they have not made one. */
+export const readStoredPlatform = () => {
+  try {
+    const stored = window.localStorage.getItem(PLATFORM_STORAGE_KEY);
+    return isValid(stored) ? stored : null;
+  } catch (err) {
+    // Private-mode / disabled storage: fall through to detection.
+    return null;
+  }
+};
+
+export const storePlatform = (platform) => {
+  if (!isValid(platform)) return;
+  try {
+    window.localStorage.setItem(PLATFORM_STORAGE_KEY, platform);
+  } catch (err) {
+    // Persistence is a convenience; the session still works without it.
+  }
+};
+
+/** Best-effort platform sniff. Unknown or unavailable → Windows. */
+export const detectPlatform = () => {
+  const nav = typeof navigator === 'undefined' ? undefined : navigator;
+  if (!nav) return PLATFORM_WINDOWS;
+
+  // userAgentData.platform is the non-deprecated source where it exists.
+  const hinted = nav.userAgentData && nav.userAgentData.platform;
+  if (typeof hinted === 'string' && hinted) {
+    return /mac/i.test(hinted) ? PLATFORM_MAC : PLATFORM_WINDOWS;
+  }
+
+  const ua = typeof nav.userAgent === 'string' ? nav.userAgent : '';
+  // iPadOS reports as Macintosh; both want ⌘, so no special case is needed.
+  return /Mac|iPhone|iPad|iPod/i.test(ua) ? PLATFORM_MAC : PLATFORM_WINDOWS;
+};
+
+/** Stored choice wins over detection. */
+export const resolvePlatform = () => readStoredPlatform() || detectPlatform();


### PR DESCRIPTION
## What this fixes

The keyboard-shortcut key chips were unreadable in light mode: dark navy text on the dark navy status bar, about 1.7:1. Tracing it turned up a general defect rather than a one-off.

**Root cause.** The status bar and the shortcuts-overlay header use `--bg-header`, a surface that stays dark in *both* themes. The text on it used `--accent`, which flips per theme — bright green in dark mode (fine), dark navy in light mode (invisible). Any shared component dropped onto that bar inherits the page-level accent and silently fails in one theme.

**Fix.** Two new tokens, `--on-header-accent` and `--on-header-muted`, defined once per theme, give that always-dark chrome its own vocabulary. `--accent` itself is unchanged, so nothing outside the chrome shifts.

While auditing, a second class showed up: `--text-faint` failed 4.5:1 against the page background in **both** themes (2.9:1 light, 2.8:1 dark), affecting roughly ten more places — table row numbers, empty-value placeholders, dark-mode input placeholders, the overlay footer, nav menu group titles, dark status-bar labels. Fixed at the token, not per selector.

## Changes

- **New `--on-header-accent` / `--on-header-muted`** applied to status-bar chips and labels, and to the overlay header's title, close button, and new toggle.
- **`--text-faint` re-spaced**: light `#8a93a6` → `#5f6b85` (4.98:1), dark `#0e6633` → `#12a04a` (5.80:1).
- **Dark `--text-muted` lifted** `#189944` → `#1fb551`. ⚠️ **Ratify:** without this the dark ramp collapses — a passing "faint" lands within 1.1:1 of "muted", leaving three tokens and two visual weights. This does change the look of secondary text throughout the dark theme.
- **New `--text-decorative`** keeps the old low-contrast values for the `[` `]` bracket glyphs on filter chips and bracket links. ⚠️ **Ratify:** these are ornamental and WCAG 1.4.3-exempt, so they are deliberately *not* raised. A test enforces that the token can only ever be used on `::before` / `::after` rules, so it cannot quietly become a way to ship unreadable body text.
- **`.badge-warning`** light color `#c97b00` → `#a35f00` (3.1:1 → 4.7:1).
- **Windows/Mac toggle** in the overlay header. Auto-detected from `userAgentData.platform` with a `userAgent` fallback, persisted to `localStorage`, and biased to Windows when detection fails — telling a Windows user to press `⌘` names a key they do not have, while `Ctrl` is merely the less idiomatic of two working options.

The toggle is **display only**. `useKeyboardNavigation` already accepts `ctrlKey || metaKey` on every chorded action, so both renderings describe keys that genuinely work; the overlay footer now says so, in case the toggle reads as a rebind.

## The new guard

`src/theme/contrast.test.js` parses `src/index.css` with postcss and asserts WCAG AA over a fg/bg pair matrix, including the always-dark chrome, panel surfaces, and hovered-row tints. The colors come from the stylesheet, so editing a hex changes the test's input rather than leaving a hand-typed copy to drift green. A coverage assertion requires every `--text-*` / `--on-*` color token to appear in at least one pair, so adding a token fails the suite until someone classifies it.

Proven in both polarities: reverting `--text-faint` fails 3 pairs; pointing `--on-header-accent` back at the page accent fails 5.

## Verification

- 633/633 jest (37 suites), up from 594 — 29 contrast assertions, 10 overlay behavior tests.
- eslint `--max-warnings=0` on all changed files.
- `npm run build` compiles.
- Both themes rendered in headless Chrome against the real stylesheet and eyeballed.

## Second commit: review round

An independent review pass on the first commit turned up five findings, all real and all fixed in `06b09b5`.

**The one that matters.** The overlay documents `Ctrl/⌘ + Shift + Z` for redo — and that chord never worked. Browsers report the *shifted* character in `event.key`, so it arrives as `'Z'`, and `useKeyboardNavigation` compared against a lowercase `'z'`. Only the `Ctrl + Y` alternative fired. Caps Lock broke plain `Ctrl + Z` the same way. This is a pre-existing bug, but adding a platform toggle would have shipped a prettier version of a false claim, so it is fixed here: comparison is now case-insensitive, with a new hook test that fails on the old code (3 of its 5 cases go red when reverted).

**Guard hardening**, both mutation-proven:

- The token-coverage assertion filtered on a 6-digit hex, so a token declared `rgb(...)` slipped past the check that exists to catch unclassified colors. Adding `--text-whisper: rgb(204,204,204)` used to leave the suite green; it now fails. The filter excludes by what a value *is* (a length), not what it looks like.
- Hovered-row surfaces composited a hardcoded accent and asserted only that the alpha hadn't changed, so recoloring the tint left the test grading the old surface. Both channels and alpha now come from the stylesheet; recoloring the tint to something close to the text color now fails the pair.

**`postcss` was an undeclared dependency**, resolving only through react-scripts' hoisted copy. Now a devDependency.

**Reverted my own `role="group"` on each row's key list.** It existed only so a test query could reach the row, and it made screen readers announce every shortcut twice. Production markup is now identical to `main`; the test scopes to the row with one narrow, commented lint exemption.

Review items deliberately **not** changed, with reasons: three literals now differ from the tokens they used to match (`.terminal-statusbar-backup-neutral`, `.dark .badge-neutral`, `--prose-blockquote-text`) but all clear AA at 5.35–6.80, so this is consistency drift rather than a defect; two `AlertCircle` icons in Settings keep `#c97b00` at 3.10:1, which is the correct threshold for a graphical object; and `aria-modal` without a focus trap is pre-existing and out of scope here.

Final: **638/638 jest across 38 suites**, eslint clean on every changed file, build compiles.
