### PR TITLE
Add control/artifact fields (#306) and CSF scope filters (#305)

### DIFF
--- a/src/pages/Artifacts.js
+++ b/src/pages/Artifacts.js
@@ -214,7 +214,14 @@ const Artifacts = () => {
 
     if (editMode) {
       updateArtifact(formData.id, formData);
-      setSelectedArtifact({ ...formData });
+      // Re-read from the store rather than reusing formData: updateArtifact
+      // stamps lastModified INSIDE the store, so formData still carries the
+      // pre-save value. Before issue #306 nothing rendered lastModified and
+      // the stale copy was invisible; now the panel would show yesterday's
+      // date next to a list row showing today's.
+      const saved = useArtifactStore.getState().getArtifactById(formData.id);
+      setSelectedArtifact(saved || { ...formData });
+      if (saved) setFormData({ ...saved, linkedSubcategoryIds: saved.linkedSubcategoryIds || [] });
       toast.success('Artifact updated');
     } else {
       const newArtifact = {
@@ -423,7 +430,12 @@ const Artifacts = () => {
         {/* Left - Table */}
         <div className={`${selectedArtifact || editMode ? 'w-1/2' : 'w-full'} overflow-auto border-r dark:border-gray-700`}>
           {/* Column headers */}
-          <div className="sticky top-0 z-10 bg-gray-50 dark:bg-gray-800 border-b dark:border-gray-700">
+          {/* min-w-max belongs on the STICKY wrapper, not only on the inner
+              row: a block child of an overflow-auto container is sized to the
+              container's client width, so the grey background and border would
+              stop at the first viewport-width while ~1300px of columns scroll
+              past — rows would slide under a transparent header. */}
+          <div className="sticky top-0 z-10 bg-gray-50 dark:bg-gray-800 border-b dark:border-gray-700 min-w-max">
             <div className="flex items-center gap-3 px-4 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider min-w-max">
               <div className="w-8 flex-shrink-0"></div>
               <div className="w-56 flex-shrink-0">ID</div>

--- a/src/pages/Artifacts.js
+++ b/src/pages/Artifacts.js
@@ -3,7 +3,7 @@ import { Edit, Trash2, Save, X, Plus, Link as LinkIcon, Upload, Download, Chevro
 import { useNavigate, useLocation } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import useCSFStore from '../stores/csfStore';
-import useArtifactStore from '../stores/artifactStore';
+import useArtifactStore, { ARTIFACT_HEALTH_VALUES } from '../stores/artifactStore';
 import useUserStore from '../stores/userStore';
 import useControlsStore from '../stores/controlsStore';
 import useAssessmentsStore from '../stores/assessmentsStore';
@@ -48,6 +48,8 @@ const Artifacts = () => {
     description: '',
     link: '',
     status: 'ACTIVE',
+    health: '',
+    controlId: '',
     assigneeId: null,
     reporterId: null,
     priority: 'Medium',
@@ -146,10 +148,14 @@ const Artifacts = () => {
     event.target.value = '';
   }, []);
 
-  // Handle CSV export - uses store's exportForJiraCSV (same as Settings Jira export)
+  // Handle CSV export — the STANDARD artifact CSV (issue #306). This page used
+  // to emit the Jira AR import shape, which has no Artifact ID column at all
+  // and so could not carry the fields this issue added. The Jira shape is still
+  // available under Settings → Artifacts (Jira AR Project). The standard CSV is
+  // also what this page's own Import reads, so export → import now round-trips.
   const handleExportCSV = useCallback(() => {
     try {
-      useArtifactStore.getState().exportForJiraCSV();
+      useArtifactStore.getState().exportArtifactsCSV();
       toast.success('Artifacts exported to CSV');
     } catch (err) {
       console.error('Artifact CSV export error:', err);
@@ -261,6 +267,8 @@ const Artifacts = () => {
       description: '',
       link: '',
       status: 'ACTIVE',
+      health: '',
+      controlId: '',
       assigneeId: null,
       reporterId: null,
       priority: 'Medium',
@@ -316,6 +324,29 @@ const Artifacts = () => {
       default:
         return 'bg-green-100 text-green-700 dark:bg-green-600 dark:text-white';
     }
+  };
+
+  // Evidence-health badge style (issue #306). Health is a judgement about the
+  // evidence; status above is the record's lifecycle. They are independent.
+  const getHealthStyle = (health) => {
+    switch (health) {
+      case 'Healthy':
+        return 'bg-green-100 text-green-700 dark:bg-green-600 dark:text-white';
+      case 'Needs Remediation':
+        return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-600 dark:text-white';
+      default:
+        return 'bg-gray-100 text-gray-600 dark:bg-gray-600 dark:text-gray-200';
+    }
+  };
+
+  // Render an ISO timestamp as a plain date. Anything unparseable renders as
+  // an em-dash rather than "Invalid Date" — imported CSVs carry whatever the
+  // source tool wrote in the Last Updated column.
+  const formatUpdatedDate = (value) => {
+    if (!value) return '—';
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return '—';
+    return parsed.toISOString().split('T')[0];
   };
 
   // Get user by ID
@@ -393,13 +424,15 @@ const Artifacts = () => {
         <div className={`${selectedArtifact || editMode ? 'w-1/2' : 'w-full'} overflow-auto border-r dark:border-gray-700`}>
           {/* Column headers */}
           <div className="sticky top-0 z-10 bg-gray-50 dark:bg-gray-800 border-b dark:border-gray-700">
-            <div className="flex items-center gap-3 px-4 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            <div className="flex items-center gap-3 px-4 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider min-w-max">
               <div className="w-8 flex-shrink-0"></div>
               <div className="w-56 flex-shrink-0">ID</div>
-              <div className="flex-1 min-w-0">Summary</div>
+              <div className="w-64 flex-shrink-0">Artifact Name</div>
               <div className="w-28 flex-shrink-0">Assignee</div>
               <div className="w-28 flex-shrink-0">Reporter</div>
               <div className="w-24 flex-shrink-0">Status</div>
+              <div className="w-36 flex-shrink-0">Health</div>
+              <div className="w-28 flex-shrink-0">Updated</div>
               <div className="w-20 flex-shrink-0">Priority</div>
             </div>
           </div>
@@ -414,7 +447,7 @@ const Artifacts = () => {
                 return (
                   <div
                     key={artifact.id}
-                    className={`flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors ${selectedArtifact?.id === artifact.id ? 'bg-blue-50 dark:bg-blue-900/30' : ''
+                    className={`flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors min-w-max ${selectedArtifact?.id === artifact.id ? 'bg-blue-50 dark:bg-blue-900/30' : ''
                       }`}
                     onClick={() => handleViewDetails(artifact)}
                   >
@@ -434,8 +467,8 @@ const Artifacts = () => {
                       </span>
                     </div>
 
-                    {/* Summary/Name */}
-                    <div className="flex-1 min-w-0">
+                    {/* Artifact Name (renamed from Summary — issue #306) */}
+                    <div className="w-64 flex-shrink-0">
                       <p className="text-sm text-gray-900 dark:text-white truncate">{artifact.name}</p>
                     </div>
 
@@ -475,6 +508,24 @@ const Artifacts = () => {
                       <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getStatusStyle(artifact.status || 'ACTIVE')}`}>
                         {artifact.status || 'ACTIVE'}
                         <ChevronRight size={12} className="ml-1 rotate-90" />
+                      </span>
+                    </div>
+
+                    {/* Health (issue #306) */}
+                    <div className="w-36 flex-shrink-0">
+                      {artifact.health ? (
+                        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getHealthStyle(artifact.health)}`}>
+                          {artifact.health}
+                        </span>
+                      ) : (
+                        <span className="text-sm text-gray-400 dark:text-gray-500">Not set</span>
+                      )}
+                    </div>
+
+                    {/* Last Updated (issue #306) */}
+                    <div className="w-28 flex-shrink-0">
+                      <span className="text-sm text-gray-600 dark:text-gray-400">
+                        {formatUpdatedDate(artifact.lastModified)}
                       </span>
                     </div>
 
@@ -582,6 +633,27 @@ const Artifacts = () => {
                     <ChevronRight size={14} className="ml-1 rotate-90" />
                   </span>
                 )}
+
+                {/* Evidence health (issue #306) — independent of the lifecycle
+                    status to its left */}
+                {editMode ? (
+                  <select
+                    name="health"
+                    value={formData.health || ''}
+                    onChange={handleChange}
+                    className={`px-3 py-1.5 rounded text-sm font-medium ${getHealthStyle(formData.health)} border-none cursor-pointer`}
+                    aria-label="Health"
+                  >
+                    <option value="">Health: not set</option>
+                    {ARTIFACT_HEALTH_VALUES.map((value) => (
+                      <option key={value} value={value}>{value}</option>
+                    ))}
+                  </select>
+                ) : (
+                  <span className={`inline-flex items-center px-3 py-1.5 rounded text-sm font-medium ${getHealthStyle(selectedArtifact?.health)}`}>
+                    {selectedArtifact?.health || 'Health: not set'}
+                  </span>
+                )}
               </div>
 
               {/* Key details section */}
@@ -590,6 +662,57 @@ const Artifacts = () => {
                   <ChevronRight size={16} className="rotate-90" />
                   Key details
                 </h3>
+
+                {/* Artifact ID (issue #306): editable while creating, shown
+                    read-only afterwards — the ID is the record's identity and
+                    the CSV import key, so it is not something to retype later */}
+                <div className="mb-4">
+                  <label className="text-sm text-gray-500 dark:text-gray-400 block mb-1">Artifact ID</label>
+                  {editMode && !selectedArtifact ? (
+                    <input
+                      type="text"
+                      name="artifactId"
+                      value={formData.artifactId || ''}
+                      onChange={handleChange}
+                      className="w-full p-2 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white"
+                      placeholder={`AR-${artifacts.length + 1}`}
+                    />
+                  ) : (
+                    <span className="text-sm font-mono text-gray-700 dark:text-gray-300">
+                      {selectedArtifact?.artifactId || formData.artifactId || '—'}
+                    </span>
+                  )}
+                </div>
+
+                {/* Control ID (issue #306): the control this evidence supports.
+                    Already a first-class field in the store and the CSV; it had
+                    no panel until now. */}
+                <div className="mb-4">
+                  <label className="text-sm text-gray-500 dark:text-gray-400 block mb-1">Control ID</label>
+                  {editMode ? (
+                    <input
+                      type="text"
+                      name="controlId"
+                      value={formData.controlId || ''}
+                      onChange={handleChange}
+                      className="w-full p-2 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white"
+                      placeholder="e.g. CTL-001 or PR.AA-01 Ex1"
+                    />
+                  ) : (
+                    <span className="text-sm font-mono text-gray-700 dark:text-gray-300">
+                      {selectedArtifact?.controlId || 'None'}
+                    </span>
+                  )}
+                </div>
+
+                {/* Last Updated (issue #306): derived from the record, never
+                    hand-edited — the store stamps it on every write */}
+                <div className="mb-4">
+                  <label className="text-sm text-gray-500 dark:text-gray-400 block mb-1">Last Updated</label>
+                  <span className="text-sm text-gray-700 dark:text-gray-300">
+                    {formatUpdatedDate(selectedArtifact?.lastModified)}
+                  </span>
+                </div>
 
                 {/* Assessment scope (issue #297): visible + reassignable, so an
                     imported or mis-scoped artifact is never stranded */}
@@ -831,20 +954,8 @@ const Artifacts = () => {
                     )}
                   </div>
 
-                  {/* Artifact ID (for new artifacts) */}
-                  {editMode && !selectedArtifact && (
-                    <div className="flex items-center justify-between">
-                      <span className="text-sm text-gray-500 dark:text-gray-400">Artifact ID</span>
-                      <input
-                        type="text"
-                        name="artifactId"
-                        value={formData.artifactId || ''}
-                        onChange={handleChange}
-                        className="p-1 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white w-32"
-                        placeholder={`AR-${artifacts.length + 1}`}
-                      />
-                    </div>
-                  )}
+                  {/* Artifact ID moved into Key details above (issue #306) —
+                      it is shown for every artifact now, not just new ones. */}
                 </div>
               </div>
 

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   Plus, Edit, Save, Trash2, X, CheckCircle, XCircle,
   Download, Upload, ClipboardList, FileSearch, ChevronRight, Copy,
@@ -222,6 +222,147 @@ const Assessments = () => {
       }
     }).filter(Boolean);
   }, [currentAssessment, getControl, getRequirement, requirements]);
+
+  // ---- Scoped-item CSF filters (issue #305) ----------------------------
+  //
+  // A real assessment scopes hundreds of subcategories; working through them
+  // means working one function (or one category) at a time. These two filters
+  // narrow the scoped list in BOTH the scope view and the evaluations table.
+  // They are page-local view state: nothing here ever writes scopeIds.
+
+  // The CSF function/category a scoped item belongs to. A requirement carries
+  // them directly. A control carries neither, so they are derived from the
+  // requirements it links to — a control can legitimately span more than one
+  // function, hence sets rather than single values.
+  const scopedItemFacets = useCallback((item) => {
+    if (item.type === 'requirement') {
+      return {
+        functions: item.function ? [item.function] : [],
+        categories: item.category ? [item.category] : []
+      };
+    }
+    const functions = new Set();
+    const categories = new Set();
+    (item.linkedRequirementIds || []).forEach((reqId) => {
+      const req = getRequirement(reqId);
+      if (req?.function) functions.add(req.function);
+      if (req?.category) categories.add(req.category);
+    });
+    return { functions: [...functions], categories: [...categories] };
+  }, [getRequirement]);
+
+  const [scopedFunctionFilter, setScopedFunctionFilter] = useState('');
+  const [scopedCategoryFilter, setScopedCategoryFilter] = useState('');
+
+  // Switching assessments clears the filters — a function that existed in the
+  // old assessment's scope may not exist in the new one, and a filter matching
+  // nothing reads as an empty assessment.
+  useEffect(() => {
+    setScopedFunctionFilter('');
+    setScopedCategoryFilter('');
+  }, [currentAssessmentId]);
+
+  // Options come from the items actually in scope, not from the whole CSF
+  // catalog, so the dropdowns never offer a choice that yields nothing.
+  const scopedFunctionOptions = useMemo(() => {
+    const found = new Set();
+    scopedItems.forEach((item) => scopedItemFacets(item).functions.forEach((f) => found.add(f)));
+    return [...found].sort();
+  }, [scopedItems, scopedItemFacets]);
+
+  // Categories narrow to the selected function, so the second dropdown only
+  // ever offers categories that can actually be reached from the first.
+  const scopedCategoryOptions = useMemo(() => {
+    const found = new Set();
+    scopedItems.forEach((item) => {
+      const facets = scopedItemFacets(item);
+      if (scopedFunctionFilter && !facets.functions.includes(scopedFunctionFilter)) return;
+      facets.categories.forEach((c) => found.add(c));
+    });
+    return [...found].sort();
+  }, [scopedItems, scopedItemFacets, scopedFunctionFilter]);
+
+  const scopedFiltersActive = Boolean(scopedFunctionFilter || scopedCategoryFilter);
+
+  const filteredScopedItems = useMemo(() => {
+    if (!scopedFiltersActive) return scopedItems;
+    return scopedItems.filter((item) => {
+      const facets = scopedItemFacets(item);
+      if (scopedFunctionFilter && !facets.functions.includes(scopedFunctionFilter)) return false;
+      if (scopedCategoryFilter && !facets.categories.includes(scopedCategoryFilter)) return false;
+      return true;
+    });
+  }, [scopedItems, scopedItemFacets, scopedFunctionFilter, scopedCategoryFilter, scopedFiltersActive]);
+
+  // EVAL-nn is derived from the UNFILTERED position, so an item keeps its
+  // number when a filter is applied. Numbering off the rendered index would
+  // make the table and the detail header disagree the moment you filter.
+  const evalNumberByItemId = useMemo(() => {
+    const numbers = new Map();
+    scopedItems.forEach((item, index) => numbers.set(item.itemId, index + 1));
+    return numbers;
+  }, [scopedItems]);
+
+  const evalNumber = useCallback(
+    (itemId) => String(evalNumberByItemId.get(itemId) || 0).padStart(2, '0'),
+    [evalNumberByItemId]
+  );
+
+  // Prev/next walks the list the user is looking at. When the selected item is
+  // outside the active filter (deep link, or the filter changed underneath it)
+  // fall back to the full list so navigation is never dead.
+  const navigationItems = useMemo(() => (
+    filteredScopedItems.some((i) => i.itemId === selectedItemId) ? filteredScopedItems : scopedItems
+  ), [filteredScopedItems, scopedItems, selectedItemId]);
+
+  // A reusable pair of dropdowns — the scope view and the evaluations table
+  // both drive the same filter state, so a filter set in one holds in the other.
+  const renderScopedCsfFilters = (idPrefix) => (
+    <div className="flex items-center gap-2">
+      <select
+        id={`${idPrefix}-function-filter`}
+        value={scopedFunctionFilter}
+        onChange={(e) => {
+          setScopedFunctionFilter(e.target.value);
+          // The chosen category may not exist under the new function.
+          setScopedCategoryFilter('');
+        }}
+        className="text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+        aria-label="Filter scoped items by CSF function"
+        disabled={scopedFunctionOptions.length === 0}
+      >
+        <option value="">All functions</option>
+        {scopedFunctionOptions.map((f) => (
+          <option key={f} value={f}>{f}</option>
+        ))}
+      </select>
+      <select
+        id={`${idPrefix}-category-filter`}
+        value={scopedCategoryFilter}
+        onChange={(e) => setScopedCategoryFilter(e.target.value)}
+        className="text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+        aria-label="Filter scoped items by CSF category"
+        disabled={scopedCategoryOptions.length === 0}
+      >
+        <option value="">All categories</option>
+        {scopedCategoryOptions.map((c) => (
+          <option key={c} value={c}>{c}</option>
+        ))}
+      </select>
+      {scopedFiltersActive && (
+        <button
+          type="button"
+          className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+          onClick={() => {
+            setScopedFunctionFilter('');
+            setScopedCategoryFilter('');
+          }}
+        >
+          Clear
+        </button>
+      )}
+    </div>
+  );
 
   // Get available items for scope selection
   const availableItems = useMemo(() => {
@@ -1128,17 +1269,32 @@ Format as a numbered list. Be specific and actionable.`;
       <div className="grid grid-cols-2 flex-1 min-h-0 overflow-hidden">
         {/* Scoped items */}
         <div className="border-r overflow-auto">
-          <div className="p-3 bg-gray-50 border-b sticky top-0">
-            <h3 className="font-medium">Scoped Items ({scopedItems.length})</h3>
+          <div className="p-3 bg-gray-50 border-b sticky top-0 z-10">
+            <div className="flex items-center justify-between gap-2 mb-2">
+              <h3 className="font-medium">
+                Scoped Items ({scopedFiltersActive
+                  ? `${filteredScopedItems.length} of ${scopedItems.length}`
+                  : scopedItems.length})
+              </h3>
+            </div>
+            {/* CSF function/category filters (issue #305) */}
+            {renderScopedCsfFilters('scope')}
           </div>
           {scopedItems.length === 0 ? (
             <div className="p-4 text-center text-gray-500">
               <p>No items in scope</p>
               <p className="text-sm mt-1">Add items from the right panel</p>
             </div>
+          ) : filteredScopedItems.length === 0 ? (
+            <div className="p-4 text-center text-gray-500">
+              <p>No scoped items match this filter</p>
+              <p className="text-sm mt-1">
+                {scopedItems.length} item{scopedItems.length === 1 ? '' : 's'} in scope — clear the filter to see them
+              </p>
+            </div>
           ) : (
             <div className="divide-y">
-              {scopedItems.map(item => {
+              {filteredScopedItems.map(item => {
                 const obs = currentAssessment ? currentAssessment.observations?.[item.itemId] : null;
                 return (
                   <div
@@ -1298,8 +1454,11 @@ Format as a numbered list. Be specific and actionable.`;
 
   // Render assessment view - Jira-style: full table, then two-column detail on click
   const renderAssessView = () => {
+    // Lookup is against the FULL list — a selected item must stay reachable
+    // even when the active filter would hide it (issue #305).
     const currentItem = scopedItems.find(i => i.itemId === selectedItemId);
-    const currentIndex = scopedItems.findIndex(i => i.itemId === selectedItemId);
+    // Prev/next index is against whichever list navigation is walking.
+    const currentIndex = navigationItems.findIndex(i => i.itemId === selectedItemId);
 
     // If an item is selected, show the two-column detail view
     if (selectedItemId && currentObservation && currentItem) {
@@ -1316,14 +1475,14 @@ Format as a numbered list. Be specific and actionable.`;
                 Back
               </button>
               <span>/</span>
-              <span className="text-blue-600 dark:text-blue-400 font-medium">EVAL-{String(currentIndex + 1).padStart(2, '0')}</span>
+              <span className="text-blue-600 dark:text-blue-400 font-medium">EVAL-{evalNumber(selectedItemId)}</span>
               <span className="flex items-center gap-1">
                 <button
                   onClick={() => {
                     const prevIndex = currentIndex - 1;
-                    if (prevIndex >= 0) setSelectedItemId(scopedItems[prevIndex].itemId);
+                    if (prevIndex >= 0) setSelectedItemId(navigationItems[prevIndex].itemId);
                   }}
-                  disabled={currentIndex === 0}
+                  disabled={currentIndex <= 0}
                   className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded disabled:opacity-30"
                 >
                   <ChevronRight size={14} className="rotate-180" />
@@ -1331,9 +1490,9 @@ Format as a numbered list. Be specific and actionable.`;
                 <button
                   onClick={() => {
                     const nextIndex = currentIndex + 1;
-                    if (nextIndex < scopedItems.length) setSelectedItemId(scopedItems[nextIndex].itemId);
+                    if (nextIndex < navigationItems.length) setSelectedItemId(navigationItems[nextIndex].itemId);
                   }}
-                  disabled={currentIndex === scopedItems.length - 1}
+                  disabled={currentIndex === -1 || currentIndex === navigationItems.length - 1}
                   className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded disabled:opacity-30"
                 >
                   <ChevronRight size={14} />
@@ -1764,10 +1923,17 @@ Format as a numbered list. Be specific and actionable.`;
               </button>
               <div>
                 <h1 className="text-lg font-semibold text-gray-900 dark:text-white">{currentAssessment?.name}</h1>
-                <p className="text-xs text-gray-500 dark:text-gray-400">{scopedItems.length} evaluations</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  {scopedFiltersActive
+                    ? `${filteredScopedItems.length} of ${scopedItems.length} evaluations`
+                    : `${scopedItems.length} evaluations`}
+                </p>
               </div>
             </div>
             <div className="flex items-center gap-3">
+              {/* CSF function/category filters (issue #305) — same state the
+                  scope view drives, so a filter carries across the two views */}
+              {renderScopedCsfFilters('assess')}
               {/* Quarter selector */}
               <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-700 rounded-lg p-0.5">
                 {['Q1', 'Q2', 'Q3', 'Q4'].map((q) => (
@@ -1814,7 +1980,7 @@ Format as a numbered list. Be specific and actionable.`;
 
           {/* Table rows */}
           <div className="divide-y divide-gray-100 dark:divide-gray-700">
-            {scopedItems.map((item, index) => {
+            {filteredScopedItems.map((item) => {
               const obs = currentAssessment?.observations?.[item.itemId];
               const quarterData = obs?.quarters?.[selectedQuarter] || {};
               const auditor = obs?.auditorId ? useUserStore.getState().getUserById(obs.auditorId) : null;
@@ -1840,7 +2006,7 @@ Format as a numbered list. Be specific and actionable.`;
                     </div>
                     <div className="min-w-0">
                       <span className="text-xs font-medium text-blue-600 dark:text-blue-400 hover:underline">
-                        EVAL-{String(index + 1).padStart(2, '0')}
+                        EVAL-{evalNumber(item.itemId)}
                       </span>
                       <p className="text-sm text-gray-900 dark:text-white truncate">
                         {item.type === 'control' ? item.controlId : item.subcategoryId || item.id}
@@ -1932,7 +2098,7 @@ Format as a numbered list. Be specific and actionable.`;
           <div className="sticky bottom-0 bg-white dark:bg-gray-800 border-t dark:border-gray-700 px-4 py-2">
             <div className="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400">
               <span>+ Create</span>
-              <span>{scopedItems.length} of {scopedItems.length}</span>
+              <span>{filteredScopedItems.length} of {scopedItems.length}</span>
             </div>
           </div>
         </div>

--- a/src/pages/UserControls.js
+++ b/src/pages/UserControls.js
@@ -15,7 +15,7 @@ import DropdownPortal from '../components/DropdownPortal';
 import SortableHeader from '../components/SortableHeader';
 
 // Stores
-import useControlsStore from '../stores/controlsStore';
+import useControlsStore, { CONTROL_STATUSES } from '../stores/controlsStore';
 import useRequirementsStore from '../stores/requirementsStore';
 import useFrameworksStore from '../stores/frameworksStore';
 import useUserStore from '../stores/userStore';
@@ -74,6 +74,10 @@ const UserControls = () => {
   // New control form state
   const [newControl, setNewControl] = useState({
     controlId: '',
+    name: '',
+    status: CONTROL_STATUSES[0],
+    tests: '',
+    frameworks: '',
     implementationDescription: '',
     ownerId: null,
     stakeholderIds: [],
@@ -210,6 +214,17 @@ const UserControls = () => {
     return user ? user.name : 'Unknown';
   }, [users]);
 
+  // Implementation-status badge variant (issue #306). Uses the same semantic
+  // badge classes the rest of the app does, so it inherits both themes.
+  const getControlStatusColor = useCallback((status) => {
+    switch (status) {
+      case 'Implemented': return 'badge-success';
+      case 'Partially Implemented': return 'badge-warning';
+      case 'Not Applicable': return 'badge-info';
+      default: return 'badge-neutral';
+    }
+  }, []);
+
   // Filter and sort data
   const filteredData = useMemo(() => {
     let result = [...scopedControls];
@@ -218,6 +233,8 @@ const UserControls = () => {
       const search = searchTerm.toLowerCase();
       result = result.filter(c =>
         c.controlId?.toLowerCase().includes(search) ||
+        // issue #306 — the control name is the field most people will search by
+        c.name?.toLowerCase().includes(search) ||
         c.implementationDescription?.toLowerCase().includes(search)
       );
     }
@@ -313,6 +330,10 @@ const UserControls = () => {
     setIsCreating(true);
     setNewControl({
       controlId: getNextControlId(),
+      name: '',
+      status: CONTROL_STATUSES[0],
+      tests: '',
+      frameworks: '',
       implementationDescription: '',
       ownerId: null,
       stakeholderIds: [],
@@ -421,9 +442,16 @@ const UserControls = () => {
   }, [importControlsCSV]);
 
   const handleDownloadTemplate = useCallback(() => {
+    // Headers match exactly what importControlsCSV reads, so the template can
+    // be filled in and imported without translation (issue #306 added Control
+    // Name / Status / Tests / Frameworks).
     const templateData = [
       {
         'Control ID': 'CTL-001',
+        'Control Name': 'Quarterly Access Review',
+        'Status': CONTROL_STATUSES[0],
+        'Tests': 'Sample 25 accounts per quarter; confirm reviewer sign-off in the ticket.',
+        'Frameworks': 'NIST CSF 2.0; SOC 2',
         'Control Implementation Description': 'Example control description',
         'Control Owner ID': 'Owner Name <owner@example.com>',
         'Stakeholder IDs': 'Person One <person1@example.com>; Person Two <person2@example.com>',
@@ -431,7 +459,17 @@ const UserControls = () => {
       }
     ];
 
-    const headers = ['Control ID', 'Control Implementation Description', 'Control Owner ID', 'Stakeholder IDs', 'Linked Requirements'];
+    const headers = [
+      'Control ID',
+      'Control Name',
+      'Status',
+      'Tests',
+      'Frameworks',
+      'Control Implementation Description',
+      'Control Owner ID',
+      'Stakeholder IDs',
+      'Linked Requirements'
+    ];
     const csv = [
       headers.join(','),
       templateData.map(row => headers.map(h => `"${row[h] || ''}"`).join(',')).join('\n')
@@ -664,6 +702,11 @@ const UserControls = () => {
               <thead className="sticky top-0 z-10">
                 <tr>
                   <SortableHeader label="Control ID" sortKey="controlId" currentSort={sort} onSort={handleSort} />
+                  <SortableHeader label="Control Name" sortKey="name" currentSort={sort} onSort={handleSort} />
+                  <SortableHeader label="Status" sortKey="status" currentSort={sort} onSort={handleSort} />
+                  <th className="p-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Frameworks
+                  </th>
                   <th className="p-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Implementation Description
                   </th>
@@ -685,6 +728,21 @@ const UserControls = () => {
                     onClick={() => handleSelectControl(control)}
                   >
                     <td className="p-3 text-sm font-medium font-mono">{control.controlId}</td>
+                    <td className="p-3 text-sm">
+                      {control.name
+                        ? <span className="font-medium">{control.name}</span>
+                        : <span className="text-gray-400">Unnamed</span>}
+                    </td>
+                    <td className="p-3 text-sm">
+                      <span className={`badge ${getControlStatusColor(control.status)}`}>
+                        {control.status || CONTROL_STATUSES[0]}
+                      </span>
+                    </td>
+                    <td className="p-3 text-sm">
+                      {control.frameworks
+                        ? <span className="text-gray-600">{control.frameworks}</span>
+                        : <span className="text-gray-400">None</span>}
+                    </td>
                     <td className="p-3 text-sm">
                       <div className="max-w-md line-clamp-2 text-gray-600">
                         {control.implementationDescription || 'No description'}
@@ -883,6 +941,61 @@ const UserControls = () => {
                       )}
                     </div>
 
+                    {/* Control Name (issue #306) */}
+                    <div>
+                      <label className="text-sm font-medium text-gray-500">Control Name</label>
+                      {editMode || isCreating ? (
+                        <input
+                          type="text"
+                          value={currentControl.name || ''}
+                          onChange={(e) => handleFieldChange('name', e.target.value)}
+                          className="mt-1 w-full p-2 border rounded"
+                          placeholder="e.g. Quarterly Access Review"
+                        />
+                      ) : (
+                        <p className="mt-1">{currentControl.name || 'Unnamed'}</p>
+                      )}
+                    </div>
+
+                    {/* Implementation status (issue #306) */}
+                    <div>
+                      <label className="text-sm font-medium text-gray-500">Status</label>
+                      {editMode || isCreating ? (
+                        <select
+                          value={currentControl.status || CONTROL_STATUSES[0]}
+                          onChange={(e) => handleFieldChange('status', e.target.value)}
+                          className="mt-1 w-full p-2 border rounded"
+                        >
+                          {CONTROL_STATUSES.map((value) => (
+                            <option key={value} value={value}>{value}</option>
+                          ))}
+                        </select>
+                      ) : (
+                        <p className="mt-1">
+                          <span className={`badge ${getControlStatusColor(currentControl.status)}`}>
+                            {currentControl.status || CONTROL_STATUSES[0]}
+                          </span>
+                        </p>
+                      )}
+                    </div>
+
+                    {/* Frameworks (issue #306) — stored free text, not derived
+                        from the linked requirements below */}
+                    <div>
+                      <label className="text-sm font-medium text-gray-500">Frameworks</label>
+                      {editMode || isCreating ? (
+                        <input
+                          type="text"
+                          value={currentControl.frameworks || ''}
+                          onChange={(e) => handleFieldChange('frameworks', e.target.value)}
+                          className="mt-1 w-full p-2 border rounded"
+                          placeholder="e.g. NIST CSF 2.0; SOC 2"
+                        />
+                      ) : (
+                        <p className="mt-1">{currentControl.frameworks || 'None recorded'}</p>
+                      )}
+                    </div>
+
                     {/* Implementation Description */}
                     <div>
                       <label className="text-sm font-medium text-gray-500">Control Implementation Description</label>
@@ -897,6 +1010,27 @@ const UserControls = () => {
                         <div className="mt-1 prose prose-sm max-w-none">
                           <Markdown>
                             {currentControl.implementationDescription || 'No description'}
+                          </Markdown>
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Tests (issue #306) — how this control is tested. The
+                        control's own test plan, distinct from an assessment
+                        observation's point-in-time test procedures. */}
+                    <div>
+                      <label className="text-sm font-medium text-gray-500">Tests</label>
+                      {editMode || isCreating ? (
+                        <textarea
+                          value={currentControl.tests || ''}
+                          onChange={(e) => handleFieldChange('tests', e.target.value)}
+                          className="mt-1 w-full p-2 border rounded h-24"
+                          placeholder="How is this control tested? Steps, sample size, evidence to collect..."
+                        />
+                      ) : (
+                        <div className="mt-1 prose prose-sm max-w-none">
+                          <Markdown>
+                            {currentControl.tests || 'No tests documented'}
                           </Markdown>
                         </div>
                       )}

--- a/src/pages/scopedItemFilters.test.js
+++ b/src/pages/scopedItemFilters.test.js
@@ -1,0 +1,239 @@
+/**
+ * Issue #305 — CSF function/category filters over an assessment's scoped items.
+ *
+ * The Assessments page is 2,900 lines and mounts the whole store graph, so
+ * these tests exercise the page's rendered OUTPUT through a focused harness
+ * that mirrors the page's own logic literally: the same facet derivation, the
+ * same option narrowing, the same unfiltered EVAL numbering. If the page and
+ * this harness ever diverge the divergence is the defect — the properties
+ * asserted here (numbering stability, option narrowing, no scope mutation) are
+ * the ones a filter can quietly break.
+ */
+
+const REQUIREMENTS = {
+  'GV.OC-01-01': { id: 'GV.OC-01-01', function: 'GOVERN (GV)', category: 'Organizational Context (GV.OC)' },
+  'GV.RM-01-01': { id: 'GV.RM-01-01', function: 'GOVERN (GV)', category: 'Risk Management Strategy (GV.RM)' },
+  'PR.AA-01-01': { id: 'PR.AA-01-01', function: 'PROTECT (PR)', category: 'Identity Management (PR.AA)' },
+  'DE.CM-01-01': { id: 'DE.CM-01-01', function: 'DETECT (DE)', category: 'Continuous Monitoring (DE.CM)' }
+};
+
+const getRequirement = (id) => REQUIREMENTS[id];
+
+// --- the page's logic, mirrored -----------------------------------------
+
+const scopedItemFacets = (item) => {
+  if (item.type === 'requirement') {
+    return {
+      functions: item.function ? [item.function] : [],
+      categories: item.category ? [item.category] : []
+    };
+  }
+  const functions = new Set();
+  const categories = new Set();
+  (item.linkedRequirementIds || []).forEach((reqId) => {
+    const req = getRequirement(reqId);
+    if (req?.function) functions.add(req.function);
+    if (req?.category) categories.add(req.category);
+  });
+  return { functions: [...functions], categories: [...categories] };
+};
+
+const functionOptions = (scopedItems) => {
+  const found = new Set();
+  scopedItems.forEach((item) => scopedItemFacets(item).functions.forEach((f) => found.add(f)));
+  return [...found].sort();
+};
+
+const categoryOptions = (scopedItems, fn) => {
+  const found = new Set();
+  scopedItems.forEach((item) => {
+    const facets = scopedItemFacets(item);
+    if (fn && !facets.functions.includes(fn)) return;
+    facets.categories.forEach((c) => found.add(c));
+  });
+  return [...found].sort();
+};
+
+const applyFilters = (scopedItems, fn, cat) => {
+  if (!fn && !cat) return scopedItems;
+  return scopedItems.filter((item) => {
+    const facets = scopedItemFacets(item);
+    if (fn && !facets.functions.includes(fn)) return false;
+    if (cat && !facets.categories.includes(cat)) return false;
+    return true;
+  });
+};
+
+const evalNumbers = (scopedItems) => {
+  const numbers = new Map();
+  scopedItems.forEach((item, index) => numbers.set(item.itemId, index + 1));
+  return numbers;
+};
+
+// --- fixtures -------------------------------------------------------------
+
+const requirementItem = (id) => ({ ...REQUIREMENTS[id], type: 'requirement', itemId: id });
+
+const REQUIREMENT_SCOPE = [
+  requirementItem('GV.OC-01-01'),
+  requirementItem('GV.RM-01-01'),
+  requirementItem('PR.AA-01-01'),
+  requirementItem('DE.CM-01-01')
+];
+
+describe('function options', () => {
+  it('come from the scoped items, not the whole catalog', () => {
+    const scope = [requirementItem('GV.OC-01-01'), requirementItem('PR.AA-01-01')];
+    expect(functionOptions(scope)).toEqual(['GOVERN (GV)', 'PROTECT (PR)']);
+    // DETECT is in the catalog but not in scope, so it is not offered.
+    expect(functionOptions(scope)).not.toContain('DETECT (DE)');
+  });
+
+  it('de-duplicate when several items share a function', () => {
+    expect(functionOptions(REQUIREMENT_SCOPE).filter(f => f === 'GOVERN (GV)')).toHaveLength(1);
+  });
+
+  it('are empty for an empty scope', () => {
+    expect(functionOptions([])).toEqual([]);
+  });
+});
+
+describe('category options narrow to the selected function', () => {
+  it('offers only the selected function\'s categories', () => {
+    expect(categoryOptions(REQUIREMENT_SCOPE, 'GOVERN (GV)')).toEqual([
+      'Organizational Context (GV.OC)',
+      'Risk Management Strategy (GV.RM)'
+    ]);
+  });
+
+  it('offers every category when no function is selected', () => {
+    expect(categoryOptions(REQUIREMENT_SCOPE, '')).toHaveLength(4);
+  });
+});
+
+describe('filtering', () => {
+  it('returns the untouched list when no filter is set', () => {
+    expect(applyFilters(REQUIREMENT_SCOPE, '', '')).toBe(REQUIREMENT_SCOPE);
+  });
+
+  it('filters by function', () => {
+    const filtered = applyFilters(REQUIREMENT_SCOPE, 'GOVERN (GV)', '');
+    expect(filtered.map(i => i.itemId)).toEqual(['GV.OC-01-01', 'GV.RM-01-01']);
+  });
+
+  it('filters by category', () => {
+    const filtered = applyFilters(REQUIREMENT_SCOPE, '', 'Identity Management (PR.AA)');
+    expect(filtered.map(i => i.itemId)).toEqual(['PR.AA-01-01']);
+  });
+
+  it('applies function and category together', () => {
+    const filtered = applyFilters(REQUIREMENT_SCOPE, 'GOVERN (GV)', 'Risk Management Strategy (GV.RM)');
+    expect(filtered.map(i => i.itemId)).toEqual(['GV.RM-01-01']);
+  });
+
+  it('never mutates the scoped list it filters', () => {
+    const before = REQUIREMENT_SCOPE.map(i => i.itemId);
+    applyFilters(REQUIREMENT_SCOPE, 'GOVERN (GV)', '');
+    expect(REQUIREMENT_SCOPE.map(i => i.itemId)).toEqual(before);
+  });
+});
+
+describe('control-scoped assessments derive facets from linked requirements', () => {
+  const CONTROL_SCOPE = [
+    {
+      type: 'control',
+      itemId: 'CTL-001',
+      controlId: 'CTL-001',
+      linkedRequirementIds: ['GV.OC-01-01', 'PR.AA-01-01']
+    },
+    { type: 'control', itemId: 'CTL-002', controlId: 'CTL-002', linkedRequirementIds: ['DE.CM-01-01'] },
+    { type: 'control', itemId: 'CTL-003', controlId: 'CTL-003', linkedRequirementIds: [] }
+  ];
+
+  it('offers the union of the linked requirements\' functions', () => {
+    expect(functionOptions(CONTROL_SCOPE)).toEqual(['DETECT (DE)', 'GOVERN (GV)', 'PROTECT (PR)']);
+  });
+
+  it('matches a control that spans more than one function under either', () => {
+    expect(applyFilters(CONTROL_SCOPE, 'GOVERN (GV)', '').map(i => i.itemId)).toEqual(['CTL-001']);
+    expect(applyFilters(CONTROL_SCOPE, 'PROTECT (PR)', '').map(i => i.itemId)).toEqual(['CTL-001']);
+  });
+
+  it('drops a control with nothing to derive from once a filter is active, and keeps it otherwise', () => {
+    expect(applyFilters(CONTROL_SCOPE, 'GOVERN (GV)', '').map(i => i.itemId)).not.toContain('CTL-003');
+    expect(applyFilters(CONTROL_SCOPE, '', '').map(i => i.itemId)).toContain('CTL-003');
+  });
+});
+
+describe('EVAL numbering is stable under a filter', () => {
+  it('numbers from the UNFILTERED position so list and detail agree', () => {
+    const numbers = evalNumbers(REQUIREMENT_SCOPE);
+    const filtered = applyFilters(REQUIREMENT_SCOPE, 'PROTECT (PR)', '');
+
+    // PR.AA-01-01 is third in the full scope, and stays EVAL-03 when it is
+    // the only row on screen. Numbering off the rendered index would call it
+    // EVAL-01 while the detail header still said EVAL-03.
+    expect(numbers.get('PR.AA-01-01')).toBe(3);
+    expect(filtered).toHaveLength(1);
+    expect(numbers.get(filtered[0].itemId)).toBe(3);
+  });
+
+  it('keeps every number distinct across the full scope', () => {
+    const values = [...evalNumbers(REQUIREMENT_SCOPE).values()];
+    expect(new Set(values).size).toBe(values.length);
+  });
+});
+
+describe('the page is actually wired to the filtered list', () => {
+  // The harness above proves the LOGIC. This proves the page USES it — the
+  // failure mode a mirrored harness cannot otherwise catch is a page that
+  // still renders the unfiltered list while every logic test passes.
+  const fs = require('fs');
+  const path = require('path');
+  const source = fs.readFileSync(path.join(__dirname, 'Assessments.js'), 'utf8');
+
+  it('renders both scoped-item lists from filteredScopedItems', () => {
+    expect(source).toContain('filteredScopedItems.map(item =>');
+    expect(source).toContain('filteredScopedItems.map((item) =>');
+  });
+
+  it('no longer maps the unfiltered scopedItems into a rendered list', () => {
+    expect(source).not.toContain('scopedItems.map((item, index) =>');
+    expect(source).not.toMatch(/\{scopedItems\.map\(item =>/);
+  });
+
+  it('derives EVAL numbers from the unfiltered index in both places', () => {
+    expect(source).toContain('EVAL-{evalNumber(item.itemId)}');
+    expect(source).toContain('EVAL-{evalNumber(selectedItemId)}');
+    // The old rendered-index numbering must be gone from both call sites.
+    expect(source).not.toContain("String(index + 1).padStart(2, '0')");
+    expect(source).not.toContain("String(currentIndex + 1).padStart(2, '0')");
+  });
+
+  it('renders the two filter dropdowns in both views', () => {
+    expect(source).toContain("renderScopedCsfFilters('scope')");
+    expect(source).toContain("renderScopedCsfFilters('assess')");
+    expect(source).toContain('Filter scoped items by CSF function');
+    expect(source).toContain('Filter scoped items by CSF category');
+  });
+
+  it('clears the filters when the current assessment changes', () => {
+    expect(source).toMatch(/setScopedFunctionFilter\(''\);[\s\S]{0,80}setScopedCategoryFilter\(''\);[\s\S]{0,60}\}, \[currentAssessmentId\]\)/);
+  });
+});
+
+describe('navigation list selection', () => {
+  const navigationItems = (filtered, all, selectedItemId) =>
+    filtered.some(i => i.itemId === selectedItemId) ? filtered : all;
+
+  it('walks the filtered list when the selection is inside it', () => {
+    const filtered = applyFilters(REQUIREMENT_SCOPE, 'GOVERN (GV)', '');
+    expect(navigationItems(filtered, REQUIREMENT_SCOPE, 'GV.RM-01-01')).toBe(filtered);
+  });
+
+  it('falls back to the full list when the selection is outside the filter', () => {
+    const filtered = applyFilters(REQUIREMENT_SCOPE, 'GOVERN (GV)', '');
+    // Without the fallback, prev/next would be dead on a deep-linked item.
+    expect(navigationItems(filtered, REQUIREMENT_SCOPE, 'DE.CM-01-01')).toBe(REQUIREMENT_SCOPE);
+  });
+});

--- a/src/stores/artifactFields.test.js
+++ b/src/stores/artifactFields.test.js
@@ -1,0 +1,192 @@
+/**
+ * Issue #306 — Artifact Name rename, Health, Last Updated, Artifact ID,
+ * Control ID.
+ *
+ * The Jira AR export is asserted UNCHANGED: 'Summary' is a foreign contract
+ * (Jira's own import column), not this app's column to rename.
+ */
+
+import useArtifactStore, {
+  ARTIFACT_HEALTH_VALUES,
+  migrateArtifactsState,
+  normalizeArtifactFields
+} from './artifactStore';
+
+const resetStore = () => useArtifactStore.setState({ artifacts: [] });
+
+const captureCSV = (run) => {
+  const captured = [];
+  const originalBlob = global.Blob;
+  global.Blob = function MockBlob(parts) { captured.push(parts.join('')); return { parts }; };
+  global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+  global.URL.revokeObjectURL = jest.fn();
+  try {
+    run();
+  } finally {
+    global.Blob = originalBlob;
+  }
+  return captured.join('');
+};
+
+describe('addArtifact stamps health', () => {
+  beforeEach(resetStore);
+
+  it('defaults health to "not set" rather than claiming Healthy', () => {
+    const id = useArtifactStore.getState().addArtifact({ name: 'New evidence' });
+    expect(useArtifactStore.getState().getArtifactById(id).health).toBe('');
+  });
+
+  it('keeps a supplied health value', () => {
+    const id = useArtifactStore.getState().addArtifact({ name: 'Reviewed', health: 'Needs Remediation' });
+    expect(useArtifactStore.getState().getArtifactById(id).health).toBe('Needs Remediation');
+  });
+
+  it('exposes exactly the two documented health values', () => {
+    expect(ARTIFACT_HEALTH_VALUES).toEqual(['Healthy', 'Needs Remediation']);
+  });
+});
+
+describe('normalizeArtifactFields', () => {
+  it('adds health to a pre-#306 record', () => {
+    const state = normalizeArtifactFields({
+      artifacts: [{ artifactId: 'AR-1', name: 'Old', lastModified: '2025-01-01T00:00:00.000Z' }]
+    });
+    expect(state.artifacts[0].health).toBe('');
+  });
+
+  it('falls lastModified back to createdDate, not to now', () => {
+    const state = normalizeArtifactFields({
+      artifacts: [{ artifactId: 'AR-2', name: 'Old', createdDate: '2024-06-01T00:00:00.000Z' }]
+    });
+    expect(state.artifacts[0].lastModified).toBe('2024-06-01T00:00:00.000Z');
+  });
+
+  it('never overwrites an existing health value', () => {
+    const state = normalizeArtifactFields({
+      artifacts: [{ artifactId: 'AR-3', health: 'Healthy', lastModified: '2025-01-01T00:00:00.000Z' }]
+    });
+    expect(state.artifacts[0].health).toBe('Healthy');
+  });
+
+  it('is idempotent — a second pass returns the same state object', () => {
+    const once = normalizeArtifactFields({ artifacts: [{ artifactId: 'AR-4' }] });
+    const twice = normalizeArtifactFields(once);
+    expect(twice).toBe(once);
+  });
+
+  it('is idempotent for a record that has a createdDate to fall back to', () => {
+    const once = normalizeArtifactFields({
+      artifacts: [{ artifactId: 'AR-5', createdDate: '2024-01-01T00:00:00.000Z' }]
+    });
+    expect(once.artifacts[0].lastModified).toBe('2024-01-01T00:00:00.000Z');
+    expect(normalizeArtifactFields(once)).toBe(once);
+  });
+
+  it('heals a record whose lastModified was blanked but has a createdDate', () => {
+    const state = normalizeArtifactFields({
+      artifacts: [{ artifactId: 'AR-6', lastModified: '', createdDate: '2024-02-02T00:00:00.000Z' }]
+    });
+    expect(state.artifacts[0].lastModified).toBe('2024-02-02T00:00:00.000Z');
+  });
+
+  it('leaves a non-array state untouched', () => {
+    expect(normalizeArtifactFields({ artifacts: null })).toEqual({ artifacts: null });
+  });
+});
+
+describe('migrateArtifactsState runs the #306 pass', () => {
+  it('normalizes a v8 state that skips every version branch', () => {
+    const migrated = migrateArtifactsState(
+      { artifacts: [{ artifactId: 'AR-V8', name: 'Kept', createdDate: '2025-02-02T00:00:00.000Z' }] },
+      8
+    );
+    expect(migrated.artifacts[0].health).toBe('');
+    expect(migrated.artifacts[0].lastModified).toBe('2025-02-02T00:00:00.000Z');
+  });
+});
+
+describe('standard artifact CSV', () => {
+  beforeEach(resetStore);
+
+  it('exports Artifact Name, Status, Health and Last Updated', () => {
+    useArtifactStore.getState().addArtifact({
+      artifactId: 'AR-10',
+      name: 'Access Review Q1',
+      health: 'Healthy',
+      status: 'ACTIVE',
+      controlId: 'CTL-001'
+    });
+
+    const csv = captureCSV(() => useArtifactStore.getState().exportArtifactsCSV());
+
+    expect(csv).toContain('Artifact Name');
+    expect(csv).not.toMatch(/(^|,)"?Name"?,/);
+    expect(csv).toContain('Health');
+    expect(csv).toContain('Last Updated');
+    expect(csv).toContain('Access Review Q1');
+    expect(csv).toContain('Healthy');
+    expect(csv).toContain('CTL-001');
+  });
+
+  it('imports the new header and still accepts the legacy ones', async () => {
+    const store = useArtifactStore.getState();
+    await store.importArtifactsCSV(
+      'Artifact ID,Artifact Name,Health,Last Updated\nAR-20,Named By New Header,Needs Remediation,2025-03-03T00:00:00.000Z'
+    );
+    await store.importArtifactsCSV('Artifact ID,Name\nAR-21,Named By Legacy Header');
+    await store.importArtifactsCSV('Artifact ID,Summary\nAR-22,Named By Jira Header');
+
+    const byId = (id) => useArtifactStore.getState().getArtifactByArtifactId(id);
+    expect(byId('AR-20').name).toBe('Named By New Header');
+    expect(byId('AR-20').health).toBe('Needs Remediation');
+    expect(byId('AR-20').lastModified).toBe('2025-03-03T00:00:00.000Z');
+    expect(byId('AR-21').name).toBe('Named By Legacy Header');
+    expect(byId('AR-22').name).toBe('Named By Jira Header');
+  });
+
+  it('stamps now when the Last Updated column is absent', async () => {
+    await useArtifactStore.getState().importArtifactsCSV('Artifact ID,Artifact Name\nAR-30,No Date');
+    const imported = useArtifactStore.getState().getArtifactByArtifactId('AR-30');
+    expect(Number.isNaN(new Date(imported.lastModified).getTime())).toBe(false);
+  });
+
+  it('leaves health blank when the column is absent', async () => {
+    await useArtifactStore.getState().importArtifactsCSV('Artifact ID,Artifact Name\nAR-31,No Health');
+    expect(useArtifactStore.getState().getArtifactByArtifactId('AR-31').health).toBe('');
+  });
+});
+
+describe('CSV injection through the round-tripped columns', () => {
+  beforeEach(resetStore);
+
+  // Issue #306 made 'Last Updated' round-trip, which turned a store-stamped
+  // timestamp into a user-controlled value: a crafted CSV puts a formula in
+  // the cell, import stores it verbatim, and export writes it back out. Every
+  // importable column must go through escapeCSVValue.
+  it('neutralizes a formula smuggled in through an imported column', async () => {
+    await useArtifactStore.getState().importArtifactsCSV(
+      'Artifact ID,Artifact Name,Last Updated,Created Date\nAR-50,Evil,=cmd|calc,@SUM(1)'
+    );
+
+    const csv = captureCSV(() => useArtifactStore.getState().exportArtifactsCSV());
+
+    // Escaped form is a leading apostrophe, so no cell starts with = or @.
+    expect(csv).not.toMatch(/(^|,)=cmd/);
+    expect(csv).not.toMatch(/(^|,)@SUM/);
+    expect(csv).toContain("'=cmd|calc");
+    expect(csv).toContain("'@SUM(1)");
+  });
+});
+
+describe('Jira AR export is a foreign contract', () => {
+  beforeEach(resetStore);
+
+  it('still emits Summary, not Artifact Name', () => {
+    useArtifactStore.getState().addArtifact({ artifactId: 'AR-40', name: 'Jira shaped' });
+    const csv = captureCSV(() => useArtifactStore.getState().exportForJiraCSV());
+
+    expect(csv).toContain('Summary');
+    expect(csv).toContain('Project key');
+    expect(csv).not.toContain('Artifact Name');
+  });
+});

--- a/src/stores/artifactFields.test.js
+++ b/src/stores/artifactFields.test.js
@@ -178,6 +178,39 @@ describe('CSV injection through the round-tripped columns', () => {
   });
 });
 
+describe('artifact CSV round-trip is lossless', () => {
+  beforeEach(resetStore);
+
+  it('preserves commas, apostrophes and quotes through export → import', async () => {
+    useArtifactStore.getState().addArtifact({
+      artifactId: 'AR-60',
+      name: "Vendor, Third-Party Reviews (Sam's copy)",
+      description: 'Quoted "evidence" bundle',
+      health: 'Healthy'
+    });
+
+    const csv = captureCSV(() => useArtifactStore.getState().exportArtifactsCSV());
+    resetStore();
+    await useArtifactStore.getState().importArtifactsCSV(csv);
+
+    const back = useArtifactStore.getState().getArtifactByArtifactId('AR-60');
+    expect(back.name).toBe("Vendor, Third-Party Reviews (Sam's copy)");
+    expect(back.description).toBe('Quoted "evidence" bundle');
+    expect(back.health).toBe('Healthy');
+  });
+
+  it('keeps an apostrophe-bearing Artifact ID stable so re-import dedupes', async () => {
+    // A mangled ID would miss `existingKeys.has(artifactId)` on re-import and
+    // silently duplicate the record instead of skipping it.
+    useArtifactStore.getState().addArtifact({ artifactId: "AR-Q1'26", name: 'Quarterly' });
+    const csv = captureCSV(() => useArtifactStore.getState().exportArtifactsCSV());
+
+    const added = await useArtifactStore.getState().importArtifactsCSV(csv);
+    expect(added).toBe(0); // recognized as already present
+    expect(useArtifactStore.getState().artifacts).toHaveLength(1);
+  });
+});
+
 describe('Jira AR export is a foreign contract', () => {
   beforeEach(resetStore);
 

--- a/src/stores/artifactStore.js
+++ b/src/stores/artifactStore.js
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import Papa from 'papaparse';
 import { v4 as uuidv4 } from 'uuid';
-import { escapeCSVValue } from '../utils/sanitize';
+import { escapeCSVValue, csvFormulaGuard } from '../utils/sanitize';
 import { DEFAULT_ARTIFACTS, RELOCATED_ARTIFACT_LINKS } from './defaultArtifactsData';
 import { COMPREHENSIVE_ARTIFACTS, COMPREHENSIVE_ASSESSMENT_ID } from './comprehensiveAssessmentData';
 import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
@@ -289,28 +289,28 @@ const useArtifactStore = create(
         const artifacts = get().artifacts;
 
         const csvData = artifacts.map(a => ({
-          'Artifact ID': escapeCSVValue(a.artifactId),
+          'Artifact ID': csvFormulaGuard(a.artifactId),
           // 'Name' → 'Artifact Name' (issue #306). Import still accepts the
           // old header, so files exported by earlier versions keep working.
-          'Artifact Name': escapeCSVValue(a.name),
-          'Description': escapeCSVValue(a.description),
-          'Link': escapeCSVValue(a.link || ''),
-          'Type': escapeCSVValue(a.type || 'Document'),
-          'Status': escapeCSVValue(a.status || 'ACTIVE'),
-          'Health': escapeCSVValue(a.health || ''),
-          'Priority': escapeCSVValue(a.priority || 'Medium'),
-          'Control ID': escapeCSVValue(a.controlId || ''),
-          'Assessment ID': escapeCSVValue(a.assessmentId || ''),
+          'Artifact Name': csvFormulaGuard(a.name),
+          'Description': csvFormulaGuard(a.description),
+          'Link': csvFormulaGuard(a.link || ''),
+          'Type': csvFormulaGuard(a.type || 'Document'),
+          'Status': csvFormulaGuard(a.status || 'ACTIVE'),
+          'Health': csvFormulaGuard(a.health || ''),
+          'Priority': csvFormulaGuard(a.priority || 'Medium'),
+          'Control ID': csvFormulaGuard(a.controlId || ''),
+          'Assessment ID': csvFormulaGuard(a.assessmentId || ''),
           'Linked Evaluation IDs': (a.linkedEvaluationIds || []).join('; '),
-          'Compliance Requirement': escapeCSVValue(a.complianceRequirement || ''), // Deprecated
+          'Compliance Requirement': csvFormulaGuard(a.complianceRequirement || ''), // Deprecated
           'Linked Subcategories': (a.linkedSubcategoryIds || []).join('; '), // Deprecated
           // Every one of these round-trips through importArtifactsCSV, so
           // every one is user-controlled and must be escaped. 'Last Updated'
           // is new in issue #306; the rest were already importable and
           // already exported raw — same defect class, fixed together.
-          'Created Date': escapeCSVValue(a.createdDate),
-          'Last Updated': escapeCSVValue(a.lastModified || ''),
-          'Jira Key': escapeCSVValue(a.jiraKey || '')
+          'Created Date': csvFormulaGuard(a.createdDate),
+          'Last Updated': csvFormulaGuard(a.lastModified || ''),
+          'Jira Key': csvFormulaGuard(a.jiraKey || '')
         }));
 
         const csv = Papa.unparse(csvData);

--- a/src/stores/artifactStore.js
+++ b/src/stores/artifactStore.js
@@ -10,6 +10,8 @@ import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
 // Merge defaults + catalog artifacts. De-dupe by artifactId; catalog wins ties.
 // Every shipped artifact is Alma demo evidence, so all of them are scoped to
 // the demo assessment (issue #297) and carry seed provenance.
+// The issue #306 `health` key is normalized into the seed itself, so a FRESH
+// install and an UPGRADED install hold byte-identical demo records.
 export const SEEDED_ARTIFACTS = (() => {
   const seen = new Set();
   const merged = [];
@@ -18,8 +20,20 @@ export const SEEDED_ARTIFACTS = (() => {
     seen.add(a.artifactId);
     merged.push({ ...a, assessmentId: COMPREHENSIVE_ASSESSMENT_ID, seedSource: DEMO_SEED_SOURCE });
   }
-  return merged;
+  return normalizeArtifactFields({ artifacts: merged }).artifacts;
 })();
+
+/**
+ * Health of the evidence itself (issue #306) — is this artifact current and
+ * sufficient, or does it need work? Deliberately SEPARATE from `status`
+ * (ACTIVE / PENDING / ARCHIVED), which tracks the record's lifecycle: Steve's
+ * 2026-07-19 ratification chose two independent fields over overloading one.
+ *
+ * The default is '' (not set) rather than 'Healthy' — a brand new artifact
+ * nobody has reviewed has not been judged healthy, and asserting otherwise
+ * would put a green claim on evidence in an audit register.
+ */
+export const ARTIFACT_HEALTH_VALUES = ['Healthy', 'Needs Remediation'];
 
 /**
  * Artifact Store
@@ -59,6 +73,10 @@ const useArtifactStore = create(
           linkedSubcategoryIds: artifact.linkedSubcategoryIds || [],
 
           type: artifact.type || 'Document', // Document, Screenshot, Log, Policy, etc.
+
+          // Evidence health (issue #306) — '' means nobody has judged it yet
+          health: artifact.health || '',
+
           createdDate: artifact.createdDate || new Date().toISOString(),
           lastModified: new Date().toISOString(),
           jiraKey: artifact.jiraKey || null // Jira issue key if synced
@@ -272,17 +290,27 @@ const useArtifactStore = create(
 
         const csvData = artifacts.map(a => ({
           'Artifact ID': escapeCSVValue(a.artifactId),
-          'Name': escapeCSVValue(a.name),
+          // 'Name' → 'Artifact Name' (issue #306). Import still accepts the
+          // old header, so files exported by earlier versions keep working.
+          'Artifact Name': escapeCSVValue(a.name),
           'Description': escapeCSVValue(a.description),
           'Link': escapeCSVValue(a.link || ''),
           'Type': escapeCSVValue(a.type || 'Document'),
+          'Status': escapeCSVValue(a.status || 'ACTIVE'),
+          'Health': escapeCSVValue(a.health || ''),
+          'Priority': escapeCSVValue(a.priority || 'Medium'),
           'Control ID': escapeCSVValue(a.controlId || ''),
-          'Assessment ID': a.assessmentId || '',
+          'Assessment ID': escapeCSVValue(a.assessmentId || ''),
           'Linked Evaluation IDs': (a.linkedEvaluationIds || []).join('; '),
           'Compliance Requirement': escapeCSVValue(a.complianceRequirement || ''), // Deprecated
           'Linked Subcategories': (a.linkedSubcategoryIds || []).join('; '), // Deprecated
-          'Created Date': a.createdDate,
-          'Jira Key': a.jiraKey || ''
+          // Every one of these round-trips through importArtifactsCSV, so
+          // every one is user-controlled and must be escaped. 'Last Updated'
+          // is new in issue #306; the rest were already importable and
+          // already exported raw — same defect class, fixed together.
+          'Created Date': escapeCSVValue(a.createdDate),
+          'Last Updated': escapeCSVValue(a.lastModified || ''),
+          'Jira Key': escapeCSVValue(a.jiraKey || '')
         }));
 
         const csv = Papa.unparse(csvData);
@@ -354,7 +382,10 @@ const useArtifactStore = create(
                   return {
                     id: uuidv4(),
                     artifactId: artifactId,
-                    name: row['Name'] || row['Summary'] || '',
+                    // 'Artifact Name' is the current header (issue #306);
+                    // 'Name' is what this app used to export and 'Summary' is
+                    // the Jira AR column. All three still land here.
+                    name: row['Artifact Name'] || row['Name'] || row['Summary'] || '',
                     description: row['Description'] || '',
                     link: row['Link'] || row['Custom field (Link)'] || '',
                     type: row['Type'] || row['Custom field (Artifact Type)'] || 'Document',
@@ -380,9 +411,16 @@ const useArtifactStore = create(
                       .split(';').map(s => s.trim()).filter(Boolean),
 
                     createdDate: row['Created Date'] || row['Created'] || new Date().toISOString(),
-                    lastModified: new Date().toISOString(),
+                    // Honor an exported 'Last Updated' so an export → import
+                    // round-trip preserves when the evidence actually changed.
+                    // Without the column this is a brand new local record, so
+                    // "now" is the honest answer.
+                    lastModified: (row['Last Updated'] || '').trim() || new Date().toISOString(),
                     jiraKey: row['Issue key'] || row['Jira Key'] || null,
                     status: row['Status'] || 'ACTIVE',
+                    // issue #306 — blank stays blank ("not set"), never
+                    // defaulted to Healthy
+                    health: (row['Health'] || '').trim(),
                     priority: row['Priority'] || 'Medium'
                   };
                 });
@@ -407,7 +445,7 @@ const useArtifactStore = create(
     }),
     {
       name: 'csf-artifacts-storage',
-      version: 8,
+      version: 9,
       migrate: (persistedState, version) => migrateArtifactsState(persistedState, version),
       partialize: (state) => ({
         artifacts: state.artifacts
@@ -430,14 +468,52 @@ const useArtifactStore = create(
  */
 /**
  * Full persisted-state migration for csf-artifacts-storage. Exported so tests
- * exercise the EXACT production path. Version 7 (#287) and version 8 (#297)
- * run after the version chain rather than as more branches in it — the
- * branches return early, so a user coming from v5 would never reach a branch
- * placed at the end. Repairing afterwards covers every upgrade path, and both
- * passes are no-ops on states that already carry the new data.
+ * exercise the EXACT production path. Version 7 (#287), version 8 (#297) and
+ * version 9 (#306) run after the version chain rather than as more branches in
+ * it — the branches return early, so a user coming from v5 would never reach a
+ * branch placed at the end. Repairing afterwards covers every upgrade path,
+ * and all three passes are no-ops on states that already carry the new data.
  */
 export function migrateArtifactsState(persistedState, version) {
-  return stampSeededDemoArtifacts(repairRelocatedLinks(applyVersionMigrations(persistedState, version)));
+  return normalizeArtifactFields(
+    stampSeededDemoArtifacts(repairRelocatedLinks(applyVersionMigrations(persistedState, version)))
+  );
+}
+
+/**
+ * Version 9 (issue #306): give every artifact the `health` key and a
+ * `lastModified` the panel can render.
+ *
+ * Absent-only: an existing string is never rewritten, so '' (deliberately
+ * "not set") survives untouched. `lastModified` falls back to `createdDate`
+ * rather than to now — stamping now would claim the evidence was updated
+ * today, which is exactly the fact the field exists to report.
+ *
+ * Exported because the restore path (dataImport) uses zustand's bulk setters,
+ * which bypass this store's load-time migrate entirely.
+ */
+export function normalizeArtifactFields(state) {
+  const artifacts = state?.artifacts;
+  if (!Array.isArray(artifacts)) return state;
+
+  let changed = false;
+  const normalized = artifacts.map((artifact) => {
+    if (!artifact || typeof artifact !== 'object') return artifact;
+    const patch = {};
+    if (typeof artifact.health !== 'string') patch.health = '';
+    // Only write lastModified when there is a real value to write. Patching a
+    // blank back to a blank would make this pass non-idempotent, which is the
+    // one property a migration that runs on every load cannot afford.
+    const hasLastModified = typeof artifact.lastModified === 'string' && artifact.lastModified !== '';
+    const createdDate = typeof artifact.createdDate === 'string' ? artifact.createdDate : '';
+    if (!hasLastModified && createdDate) patch.lastModified = createdDate;
+    else if (typeof artifact.lastModified !== 'string') patch.lastModified = '';
+    if (Object.keys(patch).length === 0) return artifact;
+    changed = true;
+    return { ...artifact, ...patch };
+  });
+
+  return changed ? { ...state, artifacts: normalized } : state;
 }
 
 /**

--- a/src/stores/artifactStore.js
+++ b/src/stores/artifactStore.js
@@ -301,9 +301,9 @@ const useArtifactStore = create(
           'Priority': csvFormulaGuard(a.priority || 'Medium'),
           'Control ID': csvFormulaGuard(a.controlId || ''),
           'Assessment ID': csvFormulaGuard(a.assessmentId || ''),
-          'Linked Evaluation IDs': (a.linkedEvaluationIds || []).join('; '),
+          'Linked Evaluation IDs': csvFormulaGuard((a.linkedEvaluationIds || []).join('; ')),
           'Compliance Requirement': csvFormulaGuard(a.complianceRequirement || ''), // Deprecated
-          'Linked Subcategories': (a.linkedSubcategoryIds || []).join('; '), // Deprecated
+          'Linked Subcategories': csvFormulaGuard((a.linkedSubcategoryIds || []).join('; ')), // Deprecated
           // Every one of these round-trips through importArtifactsCSV, so
           // every one is user-controlled and must be escaped. 'Last Updated'
           // is new in issue #306; the rest were already importable and

--- a/src/stores/artifactStore.migration.test.js
+++ b/src/stores/artifactStore.migration.test.js
@@ -204,10 +204,16 @@ describe('migrateArtifactsState — the production migrate path (issue #297)', (
       .toBe(COMPREHENSIVE_ASSESSMENT_ID);
   });
 
-  test('a user-created artifact rides the full chain untouched', () => {
+  test('a user-created artifact rides the full chain unclassified', () => {
     const mine = { artifactId: 'AR-9001', name: 'My evidence', link: 'https://intranet.example.com/x' };
     const after = migrateArtifactsState({ artifacts: [mine] }, 7);
-    expect(after.artifacts[0]).toEqual(mine);
+    // The issue #306 pass adds the health/lastModified keys to every record.
+    // What must not happen is a demo classification landing on a user record,
+    // or the user's own content being rewritten.
+    expect(after.artifacts[0]).toMatchObject(mine);
+    expect(after.artifacts[0].assessmentId).toBeUndefined();
+    expect(after.artifacts[0].seedSource).toBeUndefined();
+    expect(after.artifacts[0].health).toBe('');
   });
 });
 

--- a/src/stores/controlFields.test.js
+++ b/src/stores/controlFields.test.js
@@ -1,0 +1,184 @@
+/**
+ * Issue #306 — Control Name / Status / Tests / Frameworks.
+ *
+ * Covers the store surface: the create default, the persist migration, and the
+ * CSV/JSON round-trip. The migration is exercised through the EXACT production
+ * entry point (migrateControlsState), not a hand-rolled copy of it.
+ */
+
+import useControlsStore, {
+  CONTROL_STATUSES,
+  migrateControlsState,
+  normalizeControlFields
+} from './controlsStore';
+
+const resetStore = () => {
+  useControlsStore.setState({ controls: [], history: [], historyIndex: -1 });
+};
+
+describe('createControl stamps the issue #306 fields', () => {
+  beforeEach(resetStore);
+
+  it('defaults name, tests and frameworks to empty strings', () => {
+    const created = useControlsStore.getState().createControl({ controlId: 'CTL-900' });
+    expect(created.name).toBe('');
+    expect(created.tests).toBe('');
+    expect(created.frameworks).toBe('');
+  });
+
+  it('defaults status to the first documented status', () => {
+    const created = useControlsStore.getState().createControl({ controlId: 'CTL-901' });
+    expect(created.status).toBe(CONTROL_STATUSES[0]);
+    expect(CONTROL_STATUSES[0]).toBe('Not Implemented');
+  });
+
+  it('keeps the values the caller supplied', () => {
+    const created = useControlsStore.getState().createControl({
+      controlId: 'CTL-902',
+      name: 'Quarterly Access Review',
+      status: 'Implemented',
+      tests: 'Sample 25 accounts',
+      frameworks: 'NIST CSF 2.0; SOC 2'
+    });
+    expect(created.name).toBe('Quarterly Access Review');
+    expect(created.status).toBe('Implemented');
+    expect(created.tests).toBe('Sample 25 accounts');
+    expect(created.frameworks).toBe('NIST CSF 2.0; SOC 2');
+  });
+});
+
+describe('updateControl sanitizes every free-text field', () => {
+  beforeEach(resetStore);
+
+  it('writes name/tests/frameworks and leaves untouched fields alone', () => {
+    useControlsStore.getState().createControl({ controlId: 'CTL-903', name: 'Original' });
+    useControlsStore.getState().updateControl('CTL-903', { tests: 'Walk the log' });
+
+    const control = useControlsStore.getState().getControl('CTL-903');
+    expect(control.tests).toBe('Walk the log');
+    // A partial update must not blank the field it did not mention.
+    expect(control.name).toBe('Original');
+  });
+});
+
+describe('normalizeControlFields', () => {
+  it('fills the missing fields on a pre-#306 record', () => {
+    const state = normalizeControlFields({
+      controls: [{ controlId: 'CTL-OLD', implementationDescription: 'legacy' }]
+    });
+    expect(state.controls[0]).toMatchObject({
+      name: '',
+      tests: '',
+      frameworks: '',
+      status: CONTROL_STATUSES[0]
+    });
+  });
+
+  it('never overwrites a value the record already carries', () => {
+    const state = normalizeControlFields({
+      controls: [{
+        controlId: 'CTL-SET',
+        name: 'Kept',
+        tests: 'Kept tests',
+        frameworks: 'Kept frameworks',
+        status: 'Implemented'
+      }]
+    });
+    expect(state.controls[0]).toMatchObject({
+      name: 'Kept',
+      tests: 'Kept tests',
+      frameworks: 'Kept frameworks',
+      status: 'Implemented'
+    });
+  });
+
+  it('treats a deliberately empty string as a value, not as absent', () => {
+    const state = normalizeControlFields({
+      controls: [{ controlId: 'CTL-BLANK', name: '', tests: '', frameworks: '', status: 'Implemented' }]
+    });
+    // Nothing changed → the SAME object comes back.
+    expect(state.controls[0].status).toBe('Implemented');
+  });
+
+  it('is idempotent — a second pass returns the same state object', () => {
+    const once = normalizeControlFields({ controls: [{ controlId: 'CTL-OLD' }] });
+    const twice = normalizeControlFields(once);
+    expect(twice).toBe(once);
+  });
+
+  it('leaves a non-array state untouched', () => {
+    expect(normalizeControlFields(undefined)).toBeUndefined();
+    expect(normalizeControlFields({ controls: null })).toEqual({ controls: null });
+  });
+});
+
+describe('migrateControlsState runs the #306 pass on every upgrade path', () => {
+  it('normalizes a v4 state that takes the early seeding branch', () => {
+    const migrated = migrateControlsState({ controls: [{ controlId: 'CTL-V4' }] }, 4);
+    expect(migrated.controls[0]).toMatchObject({ name: '', tests: '', frameworks: '' });
+  });
+
+  it('normalizes a v6 state that skips every version branch', () => {
+    const migrated = migrateControlsState({ controls: [{ controlId: 'CTL-V6' }] }, 6);
+    expect(migrated.controls[0]).toMatchObject({
+      name: '',
+      tests: '',
+      frameworks: '',
+      status: CONTROL_STATUSES[0]
+    });
+  });
+});
+
+describe('CSV round-trip carries the issue #306 fields', () => {
+  beforeEach(resetStore);
+
+  const CSV = [
+    'Control ID,Control Name,Status,Tests,Frameworks,Control Implementation Description,Linked Requirements',
+    'CTL-100,Access Review,Implemented,Sample 25 accounts,NIST CSF 2.0; SOC 2,Reviewed quarterly,GV.OC-01-01'
+  ].join('\n');
+
+  it('imports all four columns', async () => {
+    await useControlsStore.getState().importControlsCSV(CSV, null);
+    const control = useControlsStore.getState().getControl('CTL-100');
+    expect(control.name).toBe('Access Review');
+    expect(control.status).toBe('Implemented');
+    expect(control.tests).toBe('Sample 25 accounts');
+    expect(control.frameworks).toBe('NIST CSF 2.0; SOC 2');
+  });
+
+  it('falls back to the default status when the column is blank', async () => {
+    const blank = [
+      'Control ID,Control Name,Status',
+      'CTL-101,No Status,'
+    ].join('\n');
+    await useControlsStore.getState().importControlsCSV(blank, null);
+    expect(useControlsStore.getState().getControl('CTL-101').status).toBe(CONTROL_STATUSES[0]);
+  });
+
+  it('exports the four columns (regression: status used to be dropped on import)', () => {
+    const captured = [];
+    const originalBlob = global.Blob;
+    global.Blob = function MockBlob(parts) { captured.push(parts.join('')); return { parts }; };
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+    global.URL.revokeObjectURL = jest.fn();
+
+    useControlsStore.getState().createControl({
+      controlId: 'CTL-200',
+      name: 'Exported Control',
+      status: 'Partially Implemented',
+      tests: 'Inspect the ticket',
+      frameworks: 'ISO 27001'
+    });
+    useControlsStore.getState().exportControlsCSV(null);
+
+    global.Blob = originalBlob;
+
+    const csv = captured.join('');
+    expect(csv).toContain('Control Name');
+    expect(csv).toContain('Tests');
+    expect(csv).toContain('Frameworks');
+    expect(csv).toContain('Exported Control');
+    expect(csv).toContain('Partially Implemented');
+    expect(csv).toContain('ISO 27001');
+  });
+});

--- a/src/stores/controlFields.test.js
+++ b/src/stores/controlFields.test.js
@@ -244,6 +244,27 @@ describe('CSV round-trip carries the issue #306 fields', () => {
     expect(csv).toContain("'=cmd|calc");
   });
 
+  it('guards EVERY importable column, including the joined id lists', async () => {
+    // A crafted CSV can seed a formula into any column the importer reads
+    // back, not just the obvious prose ones.
+    await useControlsStore.getState().importControlsCSV(
+      'Control ID,Linked Requirements,Stakeholder IDs\nCTL-302,=cmd|calc,@SUM(1)',
+      null
+    );
+
+    const captured = [];
+    const originalBlob = global.Blob;
+    global.Blob = function MockBlob(parts) { captured.push(parts.join('')); return { parts }; };
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+    global.URL.revokeObjectURL = jest.fn();
+    useControlsStore.getState().exportControlsCSV(null);
+    global.Blob = originalBlob;
+
+    const csv = captured.join('');
+    expect(csv).not.toMatch(/(^|,)=cmd/);
+    expect(csv).not.toMatch(/(^|,)@SUM/);
+  });
+
   it('exports the four columns (regression: status used to be dropped on import)', () => {
     const captured = [];
     const originalBlob = global.Blob;

--- a/src/stores/controlFields.test.js
+++ b/src/stores/controlFields.test.js
@@ -61,6 +61,49 @@ describe('updateControl sanitizes every free-text field', () => {
   });
 });
 
+describe('the new free-text fields survive angle brackets', () => {
+  beforeEach(resetStore);
+
+  // Regression: these fields used to run through sanitizeInput (DOMPurify with
+  // ALLOWED_TAGS: []), which DELETES angle-bracket content. The panel writes on
+  // every keystroke against a controlled input, so an escalation address
+  // vanished as the user typed it — and `Name <email>` is this app's own owner
+  // convention, so it is exactly what a Tests plan will contain.
+  const WITH_EMAIL = 'Escalate exceptions to <soc@example.com> weekly';
+
+  it('keeps an <email> written through createControl', () => {
+    const created = useControlsStore.getState().createControl({
+      controlId: 'CTL-400',
+      name: 'Review <owner@example.com>',
+      tests: WITH_EMAIL,
+      frameworks: 'CSF 2.0 <internal>'
+    });
+    expect(created.tests).toBe(WITH_EMAIL);
+    expect(created.name).toBe('Review <owner@example.com>');
+    expect(created.frameworks).toBe('CSF 2.0 <internal>');
+  });
+
+  it('keeps an <email> written through updateControl', () => {
+    useControlsStore.getState().createControl({ controlId: 'CTL-401' });
+    useControlsStore.getState().updateControl('CTL-401', { tests: WITH_EMAIL });
+    expect(useControlsStore.getState().getControl('CTL-401').tests).toBe(WITH_EMAIL);
+  });
+
+  it('keeps a less-than sign intact rather than entity-encoding it', () => {
+    useControlsStore.getState().createControl({ controlId: 'CTL-402' });
+    useControlsStore.getState().updateControl('CTL-402', { tests: 'sample size < 25 accounts' });
+    expect(useControlsStore.getState().getControl('CTL-402').tests).toBe('sample size < 25 accounts');
+  });
+
+  it('keeps an <email> through a CSV import', async () => {
+    await useControlsStore.getState().importControlsCSV(
+      `Control ID,Tests\nCTL-403,"${WITH_EMAIL}"`,
+      null
+    );
+    expect(useControlsStore.getState().getControl('CTL-403').tests).toBe(WITH_EMAIL);
+  });
+});
+
 describe('normalizeControlFields', () => {
   it('fills the missing fields on a pre-#306 record', () => {
     const state = normalizeControlFields({
@@ -153,6 +196,52 @@ describe('CSV round-trip carries the issue #306 fields', () => {
     ].join('\n');
     await useControlsStore.getState().importControlsCSV(blank, null);
     expect(useControlsStore.getState().getControl('CTL-101').status).toBe(CONTROL_STATUSES[0]);
+  });
+
+  it('is LOSSLESS for values containing commas, apostrophes and quotes', async () => {
+    // Regression: escapeCSVValue wraps-and-quotes, and Papa.unparse quotes
+    // again, so a re-imported value came back carrying literal " characters
+    // that grew by two on every cycle. An apostrophe alone was enough.
+    const tricky = {
+      controlId: 'CTL-300',
+      name: 'Vendor, Third-Party Reviews',
+      tests: "Sam's quarterly review",
+      frameworks: 'ISO 27001, "Annex A"',
+      status: 'Implemented'
+    };
+
+    const captured = [];
+    const originalBlob = global.Blob;
+    global.Blob = function MockBlob(parts) { captured.push(parts.join('')); return { parts }; };
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+    global.URL.revokeObjectURL = jest.fn();
+    useControlsStore.getState().createControl(tricky);
+    useControlsStore.getState().exportControlsCSV(null);
+    global.Blob = originalBlob;
+
+    // Feed the exported file straight back into the importer.
+    await useControlsStore.getState().importControlsCSV(captured.join(''), null);
+    const back = useControlsStore.getState().getControl('CTL-300');
+
+    expect(back.name).toBe(tricky.name);
+    expect(back.tests).toBe(tricky.tests);
+    expect(back.frameworks).toBe(tricky.frameworks);
+    expect(back.status).toBe('Implemented');
+  });
+
+  it('still neutralizes a formula while staying lossless', async () => {
+    const captured = [];
+    const originalBlob = global.Blob;
+    global.Blob = function MockBlob(parts) { captured.push(parts.join('')); return { parts }; };
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+    global.URL.revokeObjectURL = jest.fn();
+    useControlsStore.getState().createControl({ controlId: 'CTL-301', name: '=cmd|calc' });
+    useControlsStore.getState().exportControlsCSV(null);
+    global.Blob = originalBlob;
+
+    const csv = captured.join('');
+    expect(csv).not.toMatch(/(^|,)=cmd/);
+    expect(csv).toContain("'=cmd|calc");
   });
 
   it('exports the four columns (regression: status used to be dropped on import)', () => {

--- a/src/stores/controlsStore.js
+++ b/src/stores/controlsStore.js
@@ -400,8 +400,10 @@ const useControlsStore = create(
           'Control Owner': csvFormulaGuard(getUserName(c.ownerId)),
           'Control Owner ID': csvFormulaGuard(c.ownerId || ''),
           'Stakeholder(s)': csvFormulaGuard((c.stakeholderIds || []).map(id => getUserName(id)).join('; ')),
-          'Stakeholder IDs': (c.stakeholderIds || []).join('; '),
-          'Linked Requirements': (c.linkedRequirementIds || []).join('; '),
+          // Guarded like every other importable column: these are read back
+          // by importControlsCSV, so a crafted file can seed a formula here.
+          'Stakeholder IDs': csvFormulaGuard((c.stakeholderIds || []).join('; ')),
+          'Linked Requirements': csvFormulaGuard((c.linkedRequirementIds || []).join('; ')),
           // Importable columns are user-controlled; escape them all.
           'Assessment ID': csvFormulaGuard(c.assessmentId || ''),
           'Created Date': csvFormulaGuard(c.createdDate),

--- a/src/stores/controlsStore.js
+++ b/src/stores/controlsStore.js
@@ -1,10 +1,31 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import Papa from 'papaparse';
-import { sanitizeInput, escapeCSVValue } from '../utils/sanitize';
+import { sanitizeInput, csvFormulaGuard } from '../utils/sanitize';
 import { DEFAULT_CONTROLS } from './defaultControlsData';
 import { COMPREHENSIVE_ASSESSMENT_ID } from './comprehensiveAssessmentData';
 import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
+
+/**
+ * Implementation status a control can carry (issue #306). The first value is
+ * the default for a control that has never been given one; the shipped Alma
+ * demo set already uses 'Implemented' and 'Partially Implemented'.
+ */
+export const CONTROL_STATUSES = [
+  'Not Implemented',
+  'Partially Implemented',
+  'Implemented',
+  'Not Applicable'
+];
+
+// NOTE ON ORDER: CONTROL_STATUSES is declared ABOVE the seed below, and must
+// stay there. The seed is built by calling normalizeControlFields, which reads
+// CONTROL_STATUSES[0] — and a `const` is in its temporal dead zone until its
+// own line runs, so declaring it after the seed throws
+// "Cannot access 'CONTROL_STATUSES' before initialization" at module load and
+// white-screens the app. It does not throw today only because every shipped
+// demo control already has a status, so that branch is never reached; one
+// status-less demo record would be enough to trip it.
 
 // The shipped Alma controls are demo evidence for the demo assessment
 // (issue #299, same segregation scheme as #297 gave users/findings/artifacts):
@@ -22,18 +43,6 @@ export const SEEDED_CONTROLS = normalizeControlFields({
     seedSource: DEMO_SEED_SOURCE
   }))
 }).controls;
-
-/**
- * Implementation status a control can carry (issue #306). The first value is
- * the default for a control that has never been given one; the shipped Alma
- * demo set already uses 'Implemented' and 'Partially Implemented'.
- */
-export const CONTROL_STATUSES = [
-  'Not Implemented',
-  'Partially Implemented',
-  'Implemented',
-  'Not Applicable'
-];
 
 const useControlsStore = create(
   persist(
@@ -101,8 +110,9 @@ const useControlsStore = create(
       createControl: (controlData) => {
         const newControl = {
           controlId: controlData.controlId || `CTL-${String(get().controls.length + 1).padStart(3, '0')}`,
-          // Human-readable control name, distinct from the control ID (issue #306)
-          name: sanitizeInput(controlData.name || ''),
+          // Human-readable control name, distinct from the control ID (issue #306).
+          // Not DOMPurify-stripped — see updateControl for why.
+          name: controlData.name || '',
           implementationDescription: sanitizeInput(controlData.implementationDescription || ''),
           ownerId: controlData.ownerId || null,
           stakeholderIds: controlData.stakeholderIds || [],
@@ -111,13 +121,13 @@ const useControlsStore = create(
           // How this control is tested (issue #306) — free text, one control's
           // test plan. Distinct from an assessment observation's testProcedures,
           // which is point-in-time evidence for one evaluation.
-          tests: sanitizeInput(controlData.tests || ''),
+          tests: controlData.tests || '',
           // Frameworks this control satisfies (issue #306). STORED and
           // importable per Steve's 2026-07-19 ratification: a control catalog
           // imported from elsewhere names its frameworks directly, and may
           // carry no linked requirements to derive them from. Free text; the
           // Linked Requirements list remains the machine-readable linkage.
-          frameworks: sanitizeInput(controlData.frameworks || ''),
+          frameworks: controlData.frameworks || '',
           // Optional fields from migration
           artifacts: controlData.artifacts || '',
           findings: controlData.findings || '',
@@ -167,16 +177,25 @@ const useControlsStore = create(
 
       // Update existing control
       updateControl: (controlId, updates) => {
-        // Sanitize every free-text field the panel can write, not just the
-        // description (issue #306 added name/tests/frameworks). Each key is
-        // only touched when the caller actually supplied it, so a partial
-        // update never resurrects a field it did not mean to change.
+        // The issue #306 fields (name/tests/frameworks) are deliberately NOT
+        // run through sanitizeInput. That helper is DOMPurify with
+        // ALLOWED_TAGS: [], which DELETES angle-bracket content outright:
+        // "Escalate to <soc@example.com> weekly" becomes "Escalate to  weekly".
+        // The panel writes on every keystroke against a controlled input, so
+        // the address would vanish as the user types it — and `Name <email>`
+        // is this app's own owner convention (see parseUserString below), so
+        // it is exactly the shape a Tests plan will contain.
+        //
+        // Dropping the strip is safe because there is no raw-HTML sink: name
+        // and frameworks render as JSX text (React escapes), and tests renders
+        // through <Markdown>, which is react-markdown WITHOUT rehype-raw, so
+        // embedded HTML is never parsed. CSV export goes through
+        // csvFormulaGuard. implementationDescription keeps its existing
+        // sanitize call — changing pre-existing behavior is not this issue's job.
         const sanitizedUpdates = { ...updates, lastModified: new Date().toISOString() };
-        ['implementationDescription', 'name', 'tests', 'frameworks'].forEach((field) => {
-          if (typeof updates[field] === 'string') {
-            sanitizedUpdates[field] = sanitizeInput(updates[field]);
-          }
-        });
+        if (typeof updates.implementationDescription === 'string') {
+          sanitizedUpdates.implementationDescription = sanitizeInput(updates.implementationDescription);
+        }
 
         const updatedControls = get().controls.map(c =>
           c.controlId === controlId ? { ...c, ...sanitizedUpdates } : c
@@ -332,10 +351,10 @@ const useControlsStore = create(
                   // rebuilt every record from scratch without one, so a
                   // export → import round-trip reset every control to the
                   // default. A blank cell still falls back to the default.
-                  name: sanitizeInput(row['Control Name'] || row.name || ''),
+                  name: row['Control Name'] || row.name || '',
                   status: (row['Status'] || row.status || '').trim() || CONTROL_STATUSES[0],
-                  tests: sanitizeInput(row['Tests'] || row.tests || ''),
-                  frameworks: sanitizeInput(row['Frameworks'] || row.frameworks || ''),
+                  tests: row['Tests'] || row.tests || '',
+                  frameworks: row['Frameworks'] || row.frameworks || '',
                   implementationDescription: sanitizeInput(row['Control Implementation Description'] || row.implementationDescription || ''),
                   ownerId,
                   stakeholderIds,
@@ -371,22 +390,22 @@ const useControlsStore = create(
         };
 
         const csvData = get().controls.map(c => ({
-          'Control ID': escapeCSVValue(c.controlId),
+          'Control ID': csvFormulaGuard(c.controlId),
           // issue #306 — these four round-trip through importControlsCSV
-          'Control Name': escapeCSVValue(c.name || ''),
-          'Status': escapeCSVValue(c.status || CONTROL_STATUSES[0]),
-          'Tests': escapeCSVValue(c.tests || ''),
-          'Frameworks': escapeCSVValue(c.frameworks || ''),
-          'Control Implementation Description': escapeCSVValue(c.implementationDescription),
-          'Control Owner': escapeCSVValue(getUserName(c.ownerId)),
-          'Control Owner ID': escapeCSVValue(c.ownerId || ''),
-          'Stakeholder(s)': escapeCSVValue((c.stakeholderIds || []).map(id => getUserName(id)).join('; ')),
+          'Control Name': csvFormulaGuard(c.name || ''),
+          'Status': csvFormulaGuard(c.status || CONTROL_STATUSES[0]),
+          'Tests': csvFormulaGuard(c.tests || ''),
+          'Frameworks': csvFormulaGuard(c.frameworks || ''),
+          'Control Implementation Description': csvFormulaGuard(c.implementationDescription),
+          'Control Owner': csvFormulaGuard(getUserName(c.ownerId)),
+          'Control Owner ID': csvFormulaGuard(c.ownerId || ''),
+          'Stakeholder(s)': csvFormulaGuard((c.stakeholderIds || []).map(id => getUserName(id)).join('; ')),
           'Stakeholder IDs': (c.stakeholderIds || []).join('; '),
           'Linked Requirements': (c.linkedRequirementIds || []).join('; '),
           // Importable columns are user-controlled; escape them all.
-          'Assessment ID': escapeCSVValue(c.assessmentId || ''),
-          'Created Date': escapeCSVValue(c.createdDate),
-          'Last Modified': escapeCSVValue(c.lastModified)
+          'Assessment ID': csvFormulaGuard(c.assessmentId || ''),
+          'Created Date': csvFormulaGuard(c.createdDate),
+          'Last Modified': csvFormulaGuard(c.lastModified)
         }));
 
         const csv = Papa.unparse(csvData);

--- a/src/stores/controlsStore.js
+++ b/src/stores/controlsStore.js
@@ -11,11 +11,29 @@ import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
 // stamped with the demo assessment's id + seed provenance so they appear only
 // in the demo assessment's scope, while anything a user creates (which never
 // carries an assessmentId unless a scope stamps one) stays visible everywhere.
-export const SEEDED_CONTROLS = DEFAULT_CONTROLS.map((c) => ({
-  ...c,
-  assessmentId: COMPREHENSIVE_ASSESSMENT_ID,
-  seedSource: DEMO_SEED_SOURCE
-}));
+// The issue #306 fields are normalized into the seed itself, so a FRESH
+// install and an UPGRADED install hold byte-identical demo records. Without
+// this the v7 migration would add name/tests/frameworks to an existing
+// install's copies while a fresh install's copies lacked them.
+export const SEEDED_CONTROLS = normalizeControlFields({
+  controls: DEFAULT_CONTROLS.map((c) => ({
+    ...c,
+    assessmentId: COMPREHENSIVE_ASSESSMENT_ID,
+    seedSource: DEMO_SEED_SOURCE
+  }))
+}).controls;
+
+/**
+ * Implementation status a control can carry (issue #306). The first value is
+ * the default for a control that has never been given one; the shipped Alma
+ * demo set already uses 'Implemented' and 'Partially Implemented'.
+ */
+export const CONTROL_STATUSES = [
+  'Not Implemented',
+  'Partially Implemented',
+  'Implemented',
+  'Not Applicable'
+];
 
 const useControlsStore = create(
   persist(
@@ -83,11 +101,23 @@ const useControlsStore = create(
       createControl: (controlData) => {
         const newControl = {
           controlId: controlData.controlId || `CTL-${String(get().controls.length + 1).padStart(3, '0')}`,
+          // Human-readable control name, distinct from the control ID (issue #306)
+          name: sanitizeInput(controlData.name || ''),
           implementationDescription: sanitizeInput(controlData.implementationDescription || ''),
           ownerId: controlData.ownerId || null,
           stakeholderIds: controlData.stakeholderIds || [],
           linkedRequirementIds: controlData.linkedRequirementIds || [],
-          status: controlData.status || 'Not Implemented',
+          status: controlData.status || CONTROL_STATUSES[0],
+          // How this control is tested (issue #306) — free text, one control's
+          // test plan. Distinct from an assessment observation's testProcedures,
+          // which is point-in-time evidence for one evaluation.
+          tests: sanitizeInput(controlData.tests || ''),
+          // Frameworks this control satisfies (issue #306). STORED and
+          // importable per Steve's 2026-07-19 ratification: a control catalog
+          // imported from elsewhere names its frameworks directly, and may
+          // carry no linked requirements to derive them from. Free text; the
+          // Linked Requirements list remains the machine-readable linkage.
+          frameworks: sanitizeInput(controlData.frameworks || ''),
           // Optional fields from migration
           artifacts: controlData.artifacts || '',
           findings: controlData.findings || '',
@@ -137,13 +167,16 @@ const useControlsStore = create(
 
       // Update existing control
       updateControl: (controlId, updates) => {
-        const sanitizedUpdates = {
-          ...updates,
-          implementationDescription: updates.implementationDescription
-            ? sanitizeInput(updates.implementationDescription)
-            : updates.implementationDescription,
-          lastModified: new Date().toISOString()
-        };
+        // Sanitize every free-text field the panel can write, not just the
+        // description (issue #306 added name/tests/frameworks). Each key is
+        // only touched when the caller actually supplied it, so a partial
+        // update never resurrects a field it did not mean to change.
+        const sanitizedUpdates = { ...updates, lastModified: new Date().toISOString() };
+        ['implementationDescription', 'name', 'tests', 'frameworks'].forEach((field) => {
+          if (typeof updates[field] === 'string') {
+            sanitizedUpdates[field] = sanitizeInput(updates[field]);
+          }
+        });
 
         const updatedControls = get().controls.map(c =>
           c.controlId === controlId ? { ...c, ...sanitizedUpdates } : c
@@ -294,6 +327,15 @@ const useControlsStore = create(
 
                 return {
                   controlId: row['Control ID'] || row.controlId,
+                  // issue #306 columns. Status closes a PRE-EXISTING silent
+                  // drop: the store has always held a status, but import
+                  // rebuilt every record from scratch without one, so a
+                  // export → import round-trip reset every control to the
+                  // default. A blank cell still falls back to the default.
+                  name: sanitizeInput(row['Control Name'] || row.name || ''),
+                  status: (row['Status'] || row.status || '').trim() || CONTROL_STATUSES[0],
+                  tests: sanitizeInput(row['Tests'] || row.tests || ''),
+                  frameworks: sanitizeInput(row['Frameworks'] || row.frameworks || ''),
                   implementationDescription: sanitizeInput(row['Control Implementation Description'] || row.implementationDescription || ''),
                   ownerId,
                   stakeholderIds,
@@ -330,15 +372,21 @@ const useControlsStore = create(
 
         const csvData = get().controls.map(c => ({
           'Control ID': escapeCSVValue(c.controlId),
+          // issue #306 — these four round-trip through importControlsCSV
+          'Control Name': escapeCSVValue(c.name || ''),
+          'Status': escapeCSVValue(c.status || CONTROL_STATUSES[0]),
+          'Tests': escapeCSVValue(c.tests || ''),
+          'Frameworks': escapeCSVValue(c.frameworks || ''),
           'Control Implementation Description': escapeCSVValue(c.implementationDescription),
           'Control Owner': escapeCSVValue(getUserName(c.ownerId)),
-          'Control Owner ID': c.ownerId || '',
+          'Control Owner ID': escapeCSVValue(c.ownerId || ''),
           'Stakeholder(s)': escapeCSVValue((c.stakeholderIds || []).map(id => getUserName(id)).join('; ')),
           'Stakeholder IDs': (c.stakeholderIds || []).join('; '),
           'Linked Requirements': (c.linkedRequirementIds || []).join('; '),
-          'Assessment ID': c.assessmentId || '',
-          'Created Date': c.createdDate,
-          'Last Modified': c.lastModified
+          // Importable columns are user-controlled; escape them all.
+          'Assessment ID': escapeCSVValue(c.assessmentId || ''),
+          'Created Date': escapeCSVValue(c.createdDate),
+          'Last Modified': escapeCSVValue(c.lastModified)
         }));
 
         const csv = Papa.unparse(csvData);
@@ -368,6 +416,11 @@ const useControlsStore = create(
           dataType: 'Controls',
           controls: get().controls.map(c => ({
             controlId: c.controlId,
+            // issue #306
+            name: c.name || '',
+            status: c.status || CONTROL_STATUSES[0],
+            tests: c.tests || '',
+            frameworks: c.frameworks || '',
             implementationDescription: c.implementationDescription,
             ownerId: c.ownerId || null,
             ownerName: getUserName(c.ownerId),
@@ -499,7 +552,7 @@ const useControlsStore = create(
     }),
     {
       name: 'csf-controls-storage',
-      version: 6,
+      version: 7,
       migrate: (persistedState, version) => migrateControlsState(persistedState, version),
       partialize: (state) => ({
         controls: state.controls
@@ -514,13 +567,54 @@ const useControlsStore = create(
  *   own data keep it untouched.
  * - v6 (issue #299): seeded demo controls gain assessmentId + seedSource so
  *   they appear only in the demo assessment's scope.
+ * - v7 (issue #306): name / tests / frameworks fields, and a status on every
+ *   record rather than only the ones the demo data happened to ship with.
+ *
+ * The v7 pass runs AFTER the version chain rather than as another branch in
+ * it — the branches return early, so a user coming from v4 would never reach
+ * a branch placed at the end (the lesson artifactStore's migration already
+ * learned). It is a no-op on states that already carry the fields.
  */
 export function migrateControlsState(persistedState, version) {
   let state = persistedState;
   if (version < 5) {
     state = state?.controls?.length > 0 ? state : { controls: SEEDED_CONTROLS };
   }
-  return stampSeededDemoControls(state);
+  return normalizeControlFields(stampSeededDemoControls(state));
+}
+
+/**
+ * Fill in the issue #306 fields on any control that predates them.
+ *
+ * Absent-only by construction: a field is written only when the record does
+ * not already carry a string there, so a user's own value — including a
+ * deliberate empty string — is never overwritten. Idempotent: after one pass
+ * every record has all four keys, so a second pass changes nothing and
+ * returns the SAME state object.
+ *
+ * Exported because the restore path (dataImport) uses zustand's bulk setters,
+ * which bypass this store's load-time migrate entirely.
+ */
+export function normalizeControlFields(state) {
+  const controls = state?.controls;
+  if (!Array.isArray(controls)) return state;
+
+  let changed = false;
+  const normalized = controls.map((control) => {
+    if (!control || typeof control !== 'object') return control;
+    const patch = {};
+    ['name', 'tests', 'frameworks'].forEach((field) => {
+      if (typeof control[field] !== 'string') patch[field] = '';
+    });
+    if (typeof control.status !== 'string' || control.status === '') {
+      patch.status = CONTROL_STATUSES[0];
+    }
+    if (Object.keys(patch).length === 0) return control;
+    changed = true;
+    return { ...control, ...patch };
+  });
+
+  return changed ? { ...state, controls: normalized } : state;
 }
 
 /**

--- a/src/stores/controlsStore.migration.test.js
+++ b/src/stores/controlsStore.migration.test.js
@@ -27,9 +27,14 @@ describe('SEEDED_CONTROLS (issue #299)', () => {
     });
   });
 
-  test('stamping adds ONLY the two classification fields', () => {
+  test('stamping adds ONLY the classification fields and the #306 field defaults', () => {
     SEEDED_CONTROLS.forEach((c, i) => {
-      const { assessmentId, seedSource, ...rest } = c;
+      // issue #306 normalizes name/tests/frameworks into the seed so a fresh
+      // install matches a migrated one. Those three are asserted to be exactly
+      // the empty defaults — a seed that smuggled content through them would
+      // fail here — and then removed so the original equality still bites.
+      const { assessmentId, seedSource, name, tests, frameworks, ...rest } = c;
+      expect({ name, tests, frameworks }).toEqual({ name: '', tests: '', frameworks: '' });
       expect(rest).toEqual(DEFAULT_CONTROLS[i]);
     });
   });
@@ -114,10 +119,16 @@ describe('migrateControlsState (v5 → v6 chain, issue #299)', () => {
     expect(after.controls).toEqual(SEEDED_CONTROLS);
   });
 
-  test('a pre-v5 install with its own controls keeps them untouched', () => {
+  test('a pre-v5 install with its own controls keeps them unclassified', () => {
     const mine = { controlId: 'CTL-001', implementationDescription: 'Mine', createdDate: '2026-01-01T00:00:00.000Z' };
     const after = migrateControlsState({ controls: [mine] }, 0);
-    expect(after.controls).toEqual([mine]);
+    // The #306 pass adds the new field defaults to EVERY record, demo or not.
+    // What must not happen is a demo classification landing on a user record.
+    expect(after.controls).toHaveLength(1);
+    expect(after.controls[0]).toMatchObject(mine);
+    expect(after.controls[0].assessmentId).toBeUndefined();
+    expect(after.controls[0].seedSource).toBeUndefined();
+    expect(after.controls[0]).toMatchObject({ name: '', tests: '', frameworks: '', status: 'Not Implemented' });
   });
 
   test('a v5 install with the pristine demo set converges to the fresh v6 seed state', () => {
@@ -130,7 +141,11 @@ describe('migrateControlsState (v5 → v6 chain, issue #299)', () => {
     const mine = { controlId: 'CTL-001', implementationDescription: 'Mine', createdDate: '2026-01-01T00:00:00.000Z' };
     const after = migrateControlsState({ controls: [{ ...SEED }, mine] }, 5);
     expect(after.controls[0].assessmentId).toBe(COMPREHENSIVE_ASSESSMENT_ID);
-    expect(after.controls[1]).toEqual(mine);
+    // The user control keeps its own content and stays unclassified; only the
+    // issue #306 field defaults are added to it.
+    expect(after.controls[1]).toMatchObject(mine);
+    expect(after.controls[1].assessmentId).toBeUndefined();
+    expect(after.controls[1].seedSource).toBeUndefined();
   });
 
   test('migration never changes the record count', () => {

--- a/src/utils/dataImport.js
+++ b/src/utils/dataImport.js
@@ -33,10 +33,10 @@ import {
   normalizeExternalTracking,
   normalizeExternalLinks
 } from './externalLinks';
-import { stampSeededDemoArtifacts } from '../stores/artifactStore';
+import { stampSeededDemoArtifacts, normalizeArtifactFields } from '../stores/artifactStore';
 import { stampSeededDemoFindings } from '../stores/findingsStore';
 import { stampSeededDemoUsers } from '../stores/userStore';
-import { stampSeededDemoControls } from '../stores/controlsStore';
+import { stampSeededDemoControls, normalizeControlFields } from '../stores/controlsStore';
 
 // Sections a restore knows how to apply, with the store + bulk setter each uses.
 // Format-2 exports carry no metrics section — it is simply skipped (untouched),
@@ -230,6 +230,20 @@ export const importCompleteDatabase = (parsed, stores, { backupFirst = true } = 
   }
   if (Array.isArray(data.controls)) {
     data.controls = stampSeededDemoControls({ controls: data.controls }).controls;
+  }
+
+  // Field normalization for the issue #306 additions is UNCONDITIONAL for the
+  // same reason the stamps above are: a file stamped at the current schema
+  // version skips the migration chain, and the bulk setters bypass each
+  // store's load-time migrate. Without this an older backup restores controls
+  // with no name/tests/frameworks/status and artifacts with no health, which
+  // render as permanently blank because nothing ever runs the migration on
+  // them again. Both passes are absent-only and idempotent.
+  if (Array.isArray(data.controls)) {
+    data.controls = normalizeControlFields({ controls: data.controls }).controls;
+  }
+  if (Array.isArray(data.artifacts)) {
+    data.artifacts = normalizeArtifactFields({ artifacts: data.artifacts }).artifacts;
   }
 
   // Resolve every write BEFORE applying any, so a missing setter can never

--- a/src/utils/dataImport.test.js
+++ b/src/utils/dataImport.test.js
@@ -95,7 +95,13 @@ describe('export → restore round-trip', () => {
     const parsed = JSON.parse(JSON.stringify(exportAllDataJSON(stores)));
     const { stores: targetStores, setters } = makeStores();
     importCompleteDatabase(parsed, targetStores, { backupFirst: false });
-    expect(setters.setArtifacts).toHaveBeenCalledWith(data.artifacts);
+    // The restore path also normalizes the issue #306 fields, so the record
+    // arrives with health/lastModified added. The scope stamp is what this
+    // test guards, and it must survive verbatim.
+    const restored = setters.setArtifacts.mock.calls[0][0];
+    expect(restored).toHaveLength(1);
+    expect(restored[0]).toMatchObject(data.artifacts[0]);
+    expect(restored[0].assessmentId).toBe('ASM-user-2026');
   });
 
   test('a pre-#297 backup gets its demo records stamped on restore (issue #297)', () => {
@@ -120,7 +126,9 @@ describe('export → restore round-trip', () => {
     const restoredArtifacts = setters.setArtifacts.mock.calls[0][0];
     expect(restoredArtifacts[0].assessmentId).toBe(SEEDED_ARTIFACTS[0].assessmentId);
     expect(restoredArtifacts[0].seedSource).toBe('demo-alma');
-    expect(restoredArtifacts[1]).toEqual(mineArtifact); // user record untouched
+    expect(restoredArtifacts[1]).toMatchObject(mineArtifact); // user content untouched
+    expect(restoredArtifacts[1].assessmentId).toBeUndefined();
+    expect(restoredArtifacts[1].seedSource).toBeUndefined();
 
     const restoredUsers = setters.setUsers.mock.calls[0][0];
     expect(restoredUsers[0].seedSource).toBe('demo-alma');
@@ -147,7 +155,9 @@ describe('export → restore round-trip', () => {
     importCompleteDatabase(parsed, targetStores, { backupFirst: false });
 
     const restored = setters.setArtifacts.mock.calls[0][0];
-    expect(restored[0]).toEqual(sameNameMine);          // untouched
+    expect(restored[0]).toMatchObject(sameNameMine);    // content untouched
+    expect(restored[0].assessmentId).toBeUndefined(); // never demo-stamped
+    expect(restored[0].seedSource).toBeUndefined();
     expect(restored[1].seedSource).toBe('user');        // classification kept
     expect(restored[1].assessmentId).toBeUndefined();   // not demo-stamped
   });
@@ -173,8 +183,14 @@ describe('export → restore round-trip', () => {
     const restored = setters.setControls.mock.calls[0][0];
     expect(restored[0].assessmentId).toBe(SEEDED_CONTROLS[0].assessmentId);
     expect(restored[0].seedSource).toBe('demo-alma');
-    expect(restored[1]).toEqual(collidingMine);   // colliding id, different createdDate — untouched
-    expect(restored[2]).toEqual(mineControl);     // user record untouched
+    // colliding id, different createdDate — never demo-stamped
+    expect(restored[1]).toMatchObject(collidingMine);
+    expect(restored[1].assessmentId).toBeUndefined();
+    expect(restored[1].seedSource).toBeUndefined();
+    // plain user control — content kept, classification never added
+    expect(restored[2]).toMatchObject(mineControl);
+    expect(restored[2].assessmentId).toBeUndefined();
+    expect(restored[2].seedSource).toBeUndefined();
   });
 
   test('a current-format backup round-trips control assessmentIds verbatim (issue #299)', () => {
@@ -184,7 +200,10 @@ describe('export → restore round-trip', () => {
     const parsed = JSON.parse(JSON.stringify(exportAllDataJSON(stores)));
     const { stores: targetStores, setters } = makeStores();
     importCompleteDatabase(parsed, targetStores, { backupFirst: false });
-    expect(setters.setControls.mock.calls[0][0]).toEqual([scoped]);
+    const restoredControls = setters.setControls.mock.calls[0][0];
+    expect(restoredControls).toHaveLength(1);
+    expect(restoredControls[0]).toMatchObject(scoped);
+    expect(restoredControls[0].assessmentId).toBe('ASM-user-2026');
   });
 });
 

--- a/src/utils/sanitize.js
+++ b/src/utils/sanitize.js
@@ -54,6 +54,32 @@ export function escapeCSVValue(value) {
 }
 
 /**
+ * CSV formula guard for values that are handed to `Papa.unparse`.
+ *
+ * `escapeCSVValue` above does two jobs: it prefixes formula-triggering
+ * characters AND it wraps-and-quotes. The second job is Papa's, and doing it
+ * twice is lossy: Papa sees the already-quoted string, quotes it again, and the
+ * value comes back from a re-import carrying literal `"` characters — which
+ * grow by two on every export → import cycle. An apostrophe alone triggers it,
+ * so `Sam's quarterly review` is enough.
+ *
+ * This helper does the half that is genuinely ours — the injection guard — and
+ * leaves quoting to Papa, which gets it right. Use it at every `Papa.unparse`
+ * call site. `escapeCSVValue` stays for hand-rolled CSV assembly, where the
+ * wrapping IS needed and nothing else quotes.
+ *
+ * @param {string} value - The value to guard
+ * @returns {string} - Value safe to hand to Papa.unparse
+ */
+export function csvFormulaGuard(value) {
+  if (value === null || value === undefined) return '';
+  const stringValue = String(value);
+  // =, +, -, @ (and leading tab/CR, which some parsers strip before the check)
+  // can execute formulas in Excel/LibreOffice.
+  return /^[=+\-@\t\r]/.test(stringValue) ? `'${stringValue}` : stringValue;
+}
+
+/**
  * Validate email format
  * @param {string} email - The email to validate
  * @returns {boolean} - Whether the email is valid


### PR DESCRIPTION
Closes #306
Closes #305

## What this does

### #306 — Controls panel and import template

| Field | Where it lives |
|---|---|
| **Control Name** | Panel input, sortable table column, searchable, CSV `Control Name` |
| **Status** | Panel select (Not Implemented / Partially Implemented / Implemented / Not Applicable), table badge, CSV `Status` |
| **Tests** | Panel textarea (markdown), CSV `Tests` |
| **Frameworks** | Panel input, table column, CSV `Frameworks` |

Status was already stored — the shipped Alma controls carry `Implemented` and `Partially Implemented` — but CSV import rebuilt every record without one, so an export → import round-trip silently reset every control to the default. It round-trips now.

The downloadable CSV template's headers are exactly the headers the importer reads, so a filled-in template imports without translation.

### #306 — Artifacts panel and import templates

- The CSV `Name` column is now `Artifact Name`, and the table header with it. Import still accepts the old `Name` header and the Jira `Summary` header, so files from earlier versions keep working.
- **Health** is a new field (`Healthy` / `Needs Remediation`), separate from the existing `ACTIVE` / `PENDING` / `ARCHIVED` lifecycle status.
- **Artifact ID**, **Control ID** and **Last Updated** are now on the panel. Control ID was already a first-class store field with no way to see or set it.
- The page's Export button emits the standard artifact CSV instead of the Jira AR shape.

### #305 — CSF function and category filters over scoped items

Two dropdowns narrow an assessment's scoped items, in the scope view and in the evaluations table, driven by shared state so a filter set in one holds in the other. Options come from the items actually in scope, and categories narrow to the selected function, so a dropdown never offers a choice that yields nothing. Control-scoped assessments derive function and category from the requirements each control links to.

## Bugs found and fixed along the way

**EVAL-nn used to come from the rendered index.** Filtering the list would have renumbered every row while the detail header kept the old number. Numbering now derives from the unfiltered position, so an item keeps its number no matter what is filtered.

**CSV injection on every importable export column.** Making `Last Updated` round-trip turned a store-stamped timestamp into a user-controlled value: a crafted CSV puts `=cmd|calc` in the cell, import stores it verbatim, export writes it straight back out. `Created Date`, `Assessment ID`, `Jira Key`, `Control Owner ID`, and the joined id lists (`Stakeholder IDs`, `Linked Requirements`, `Linked Evaluation IDs`, `Linked Subcategories`) were already importable and already exported raw — same defect class. All now go through the injection guard, with regression tests.

**Control CSV import dropped status**, as above.

**CSV export was not lossless.** `escapeCSVValue` wraps-and-quotes, and `Papa.unparse` then quotes again, so a re-imported value came back carrying literal `"` characters that grew by two on every cycle. An apostrophe alone triggered it — `Sam's quarterly review` corrupted with no comma involved. A new `csvFormulaGuard` does only the half that is genuinely ours (the injection prefix) and leaves quoting to Papa. The round-trip test is mutation-proven: restoring the old helper on one column reproduces the exact corruption.

**`Control Name` / `Tests` / `Frameworks` were DOMPurify-stripped on write**, which deletes angle-bracket content outright — `Escalate to <soc@example.com> weekly` became `Escalate to  weekly`, and because the panel writes on every keystroke against a controlled input, the address vanished as the user typed it. `Name <email>` is this app's own owner convention, so it is exactly the shape a test plan will contain. Safe to drop: no raw-HTML sink exists (JSX text, and `Markdown` is react-markdown without `rehype-raw`).

**The artifact panel showed a stale Last Updated after a save** — the row said today, the panel said last month. Invisible before this branch, because nothing rendered the field.

**The artifacts table header background stopped at the viewport edge**, so rows scrolled under a transparent header once the new columns pushed the row past the pane.

**`CONTROL_STATUSES` sat below the seed that transitively reads it.** Harmless today only because every shipped demo control already has a status; one status-less demo record would have white-screened the app with a temporal-dead-zone `ReferenceError` at module load.

## Migrations

Controls `v6 → v7` and artifacts `v8 → v9`. Both are absent-only (a value the record already carries is never overwritten, including a deliberately empty one) and idempotent (a second pass returns the same state object — these run on every load). Both run *after* the version chain rather than as another early-returning branch in it, so every upgrade path reaches them.

The same defaults are normalized into the shipped demo seed constants, so a fresh install and an upgraded install hold identical records.

Both normalizers also run unconditionally in the restore path, because the bulk setters there bypass each store's load-time `migrate`.

The demo-segregation guards from #297/#299 are untouched. They match on artifact `name` and control `createdDate`; neither normalizer writes either field, so no user record can be branded demo and no demo record can lose its stamp.

## Ratification items — please read before merging

1. **Artifact health is a second field, not a rename.** `status` keeps `ACTIVE` / `PENDING` / `ARCHIVED`. If you meant to replace those values with Healthy / Needs Remediation, say so and it's a small follow-up.
2. **Health defaults to "not set", not to Healthy.** A brand new artifact nobody has reviewed has not been judged healthy, and this is an audit register.
3. **Control `frameworks` is stored free text, not derived from linked requirements.** It can therefore disagree with the Linked Requirements list below it; that list stays the machine-readable linkage.
4. **The Artifacts page Export changed shape.** The Jira AR export is unchanged and still available under Settings → Artifacts (Jira AR Project), and the two write different filenames (`artifacts_<date>.csv` vs `jira_ar_import_<date>.csv`), so anything automating the old file fails loudly instead of importing the wrong columns.
5. **Control status refills when blank.** A control whose status is an empty string gets `Not Implemented` on load. Empty is not a selectable value, so this repairs a record the select could not otherwise render — unlike name/tests/frameworks, where an empty string is respected as a real value.
6. **The Jira AR export keeps the double-quoting bug.** It is a one-way export to a foreign system rather than a round-trip path, and the PR promises it is byte-identical, so it was left alone. Worth its own issue if you ever re-import from it.
7. **Filtering is view-only.** It never writes `scopeIds`, and prev/next stays inside the filtered set when the selected item is in it, falling back to the full list only when the selection sits outside the filter.

## Verification

- 700/700 tests, 41 suites, 57 new across three files — store fields and migrations, CSV round-trips both directions, injection, filter logic, and source-wiring probes that fail if the page stops using the filtered list or the stable EVAL numbering.
- `eslint --max-warnings=0` clean on every changed file outside the CI legacy allowlist. The three allowlisted pages carry the same six pre-existing warnings as `main`, unchanged in kind and count.
- `CI=false npm run build` compiles.
