### PR TITLE
Replace community string-equality provenance tests with bank predicates

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,16 @@
     "extends": [
       "react-app",
       "react-app/jest"
-    ]
+    ],
+    "rules": {
+      "no-restricted-syntax": [
+        "error",
+        {
+          "selector": "BinaryExpression[operator=/^(===|!==)$/] > Literal[value='community']",
+          "message": "Do not string-compare bank provenance — use the predicates in src/utils/procedureBank.js (isCommunityBankSource, isBankAttached, ...). The only permitted literal is the frozen v14 migration in assessmentsStore.js."
+        }
+      ]
+    }
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/src/components/ProcedureSourceBadge.js
+++ b/src/components/ProcedureSourceBadge.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { BookOpen } from 'lucide-react';
+import { procedureBadge } from '../utils/procedureBank';
+
+/**
+ * Provenance badge for a test procedure — pure presentation over
+ * procedureBadge(). Community renders green, org-tailored amber, and a
+ * bank this build does not recognize renders neutral blue: visible rather
+ * than silently badge-less, so records shared from a newer build keep
+ * their provenance on screen (plan §7 R-10).
+ */
+const BADGE_STYLES = {
+  community: 'flex items-center gap-1 bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300',
+  bank: 'flex items-center gap-1 bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  tailored: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+};
+
+const ProcedureSourceBadge = ({ source }) => {
+  const badge = procedureBadge(source);
+  if (!badge) return null;
+  return (
+    <span className={`px-1.5 py-0.5 rounded text-xs ${BADGE_STYLES[badge.kind]}`}>
+      {badge.kind !== 'tailored' && <BookOpen size={11} />}
+      {badge.label}
+    </span>
+  );
+};
+
+export default ProcedureSourceBadge;

--- a/src/components/ProcedureSourceBadge.test.js
+++ b/src/components/ProcedureSourceBadge.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ProcedureSourceBadge from './ProcedureSourceBadge';
+
+/**
+ * Provenance badge over the real component (PR-1, plan §7 R-10): the pin
+ * that matters is the unrecognized-bank case — a record shared from a newer
+ * build must render a visible badge, never silently lose its provenance.
+ */
+describe('ProcedureSourceBadge', () => {
+  test('renders nothing without a source', () => {
+    const { container } = render(<ProcedureSourceBadge source={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('community source renders the green Community badge', () => {
+    render(<ProcedureSourceBadge source={{ bank: 'community', bankId: 'GV.OC-01', modified: false }} />);
+    const badge = screen.getByText('Community');
+    expect(badge.className).toContain('bg-green-100');
+  });
+
+  test('customized community source names the customization', () => {
+    render(<ProcedureSourceBadge source={{ bank: 'community', bankId: 'GV.OC-01', modified: true }} />);
+    expect(screen.getByText('Community · customized')).toBeInTheDocument();
+  });
+
+  test('tailored no-bank source renders the amber org-tailor badge', () => {
+    render(<ProcedureSourceBadge source={{ bank: 'none', bankId: null, tailored: true, modified: true }} />);
+    const badge = screen.getByText('Tailored to your org');
+    expect(badge.className).toContain('bg-amber-100');
+  });
+
+  test('an unrecognized bank renders a VISIBLE badge naming the bank', () => {
+    render(<ProcedureSourceBadge source={{ bank: 'scuba-gws', bankId: 'gws.commoncontrols.1.1v1', modified: false }} />);
+    const badge = screen.getByText('scuba-gws');
+    expect(badge.className).toContain('bg-blue-100');
+  });
+
+  test('a tailored unrecognized-bank source shows its bank, not the org-tailor label', () => {
+    render(<ProcedureSourceBadge source={{ bank: 'scuba-gws', bankId: 'x', tailored: true, modified: true }} />);
+    expect(screen.getByText('scuba-gws · customized')).toBeInTheDocument();
+    expect(screen.queryByText('Tailored to your org')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -27,12 +27,13 @@ import useUserStore from '../stores/userStore';
 import useAIStore from '../stores/aiStore';
 import useUIStore from '../stores/uiStore';
 import { formatInlineMarkdown, stripMarkdown } from '../utils/markdownText';
-import { bankCoverage, getBankProcedure, buildProcedureSource, bankSourceUrl } from '../utils/procedureBank';
+import { bankCoverage, getBankProcedure, canResetToCommunity, resetToCommunityUpdate, sourceUrlFor } from '../utils/procedureBank';
 import { canUseProfileWithProvider, buildTailorPrompt, tailoredProvenance, deriveStackTargets, describeStackPlan, bankAttachObservation, deterministicTailorUpdate } from '../utils/procedureTailor';
 import { getScoringScale, scoreBand, CMMI_LEVELS } from '../utils/scoringScale';
 import { SYSTEM_NAME_MAX_LENGTH } from '../utils/externalLinks';
 import { belongsToAssessment, isUnassigned } from '../utils/assessmentScope';
 import ExternalLinksEditor from '../components/ExternalLinksEditor';
+import ProcedureSourceBadge from '../components/ProcedureSourceBadge';
 import useOrgProfileStore from '../stores/orgProfileStore';
 import OrgProfileWizard from '../components/OrgProfileWizard';
 
@@ -774,22 +775,21 @@ Format as a numbered list. Be specific and actionable.`;
   }, [currentAssessmentId, selectedItemId, updateObservation]);
 
   // Attach (or re-attach) the community procedure for the selected item.
-  // Both write pristine provenance explicitly so the store's modified-flag
-  // heuristic doesn't mark a deliberate attach as a customization.
+  // The pure producer stamps pristine provenance (so the store's
+  // modified-flag heuristic doesn't mark a deliberate attach as a
+  // customization) and refuses to overwrite another bank's content.
   const handleInsertBankProcedure = useCallback((existingText) => {
     if (!currentAssessmentId || !selectedItemId) return;
-    const entry = getBankProcedure(selectedItemId);
-    if (!entry) return;
+    const existing = getObservation(currentAssessmentId, selectedItemId);
+    const update = resetToCommunityUpdate(selectedItemId, existing?.procedureSource);
+    if (!update) return;
     if (existingText && existingText.trim() &&
         !window.confirm('Replace the current test procedures with the community version?')) {
       return;
     }
-    updateObservation(currentAssessmentId, selectedItemId, {
-      testProcedures: entry.markdown,
-      procedureSource: buildProcedureSource(entry.bankId)
-    });
-    toast.success(`Community procedure for ${entry.bankId} attached`);
-  }, [currentAssessmentId, selectedItemId, updateObservation]);
+    updateObservation(currentAssessmentId, selectedItemId, update);
+    toast.success(`Community procedure for ${update.procedureSource.bankId} attached`);
+  }, [currentAssessmentId, selectedItemId, getObservation, updateObservation]);
 
   // Deterministic tailoring of the selected item's procedure: canned
   // name + tool/platform substitutions from the org profile. No AI, no
@@ -1579,17 +1579,7 @@ Format as a numbered list. Be specific and actionable.`;
                     <div className="flex items-center justify-between mb-1">
                       <label className="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-2">
                         Test Procedures
-                        {currentObservation.procedureSource?.bank === 'community' && (
-                          <span className="px-1.5 py-0.5 rounded text-xs bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 flex items-center gap-1">
-                            <BookOpen size={11} />
-                            {currentObservation.procedureSource.modified ? 'Community · customized' : 'Community'}
-                          </span>
-                        )}
-                        {currentObservation.procedureSource?.tailored && currentObservation.procedureSource?.bank !== 'community' && (
-                          <span className="px-1.5 py-0.5 rounded text-xs bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
-                            Tailored to your org
-                          </span>
-                        )}
+                        <ProcedureSourceBadge source={currentObservation.procedureSource} />
                       </label>
                       <div className="flex items-center gap-3">
                         {editMode && hasOrgProfile && currentObservation.testProcedures && (
@@ -1615,7 +1605,7 @@ Format as a numbered list. Be specific and actionable.`;
                               : (<><Sparkles size={12} /> Tailor with AI</>)}
                           </button>
                         )}
-                        {editMode && getBankProcedure(selectedItemId) && (
+                        {editMode && getBankProcedure(selectedItemId) && canResetToCommunity(currentObservation.procedureSource) && (
                           <button
                             type="button"
                             onClick={() => handleInsertBankProcedure(currentObservation.testProcedures)}
@@ -1627,9 +1617,9 @@ Format as a numbered list. Be specific and actionable.`;
                               : (<><BookOpen size={12} /> Insert community procedure</>)}
                           </button>
                         )}
-                        {!editMode && currentObservation.procedureSource?.bank === 'community' && bankSourceUrl(currentObservation.procedureSource.bankId) && (
+                        {!editMode && sourceUrlFor(currentObservation.procedureSource) && (
                           <a
-                            href={bankSourceUrl(currentObservation.procedureSource.bankId)}
+                            href={sourceUrlFor(currentObservation.procedureSource)}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-xs text-blue-600 dark:text-blue-400 flex items-center gap-1 hover:underline"
@@ -2537,11 +2527,16 @@ Format as a numbered list. Be specific and actionable.`;
                           <div className="max-h-56 overflow-y-auto space-y-2 mt-2">
                             {scopeCoverage.covered.map((id) => {
                               const entry = getBankProcedure(id);
+                              // Preview through the same producer the create
+                              // path uses (in its untailored form), so the
+                              // previewed trunk text cannot diverge from what
+                              // attaches.
+                              const previewText = bankAttachObservation(entry).testProcedures;
                               return (
                                 <details key={id} className="p-2 bg-white dark:bg-gray-700 rounded border text-sm">
                                   <summary className="cursor-pointer font-medium">{id} — {entry.title}</summary>
                                   <pre className="whitespace-pre-wrap text-xs text-gray-600 dark:text-gray-300 mt-2 max-h-40 overflow-y-auto">
-                                    {entry.markdown.slice(0, 1500)}{entry.markdown.length > 1500 ? '\n…(full procedure attaches on create)' : ''}
+                                    {previewText.slice(0, 1500)}{previewText.length > 1500 ? '\n…(full procedure attaches on create)' : ''}
                                   </pre>
                                 </details>
                               );

--- a/src/stores/assessmentsStore.js
+++ b/src/stores/assessmentsStore.js
@@ -307,6 +307,12 @@ export const migrateAssessmentsState = (persistedState, version) => {
       const observations = {};
       for (const [itemId, obs] of Object.entries(a.observations)) {
         const src = obs?.procedureSource;
+        // FROZEN historical migration (plan §5/§7): the literal
+        // bank === 'community' equality is deliberate. This step rewrites
+        // relative links against the community catalog layout and must
+        // never run over another bank's records — do not generalize to the
+        // procedureBank predicates.
+        // eslint-disable-next-line no-restricted-syntax
         if (src?.bank === 'community' && src.modified === false && !src.tailored &&
             typeof src.bankId === 'string' && typeof obs.testProcedures === 'string') {
           const sourceDir = `ASSESSMENT_CATALOG/3_Test_Procedures/${src.bankId.slice(0, 2)}`;

--- a/src/utils/orgProfileExport.test.js
+++ b/src/utils/orgProfileExport.test.js
@@ -273,3 +273,93 @@ describe('deterministic tailoring', () => {
     expect(text).toBe('Review Alma Security policy.');
   });
 });
+
+// ---------------------------------------------------------------------------
+// R-6 provenance-inversion pin (PR-1, plan §7): the pristine swap is a
+// POSITIVE bank match. A tailored observation carrying a bank label this
+// build does not recognize — e.g. restored from a share made by a newer
+// build with a platform bank — must export with its text DROPPED, never
+// with community markdown shipped under the foreign bank's label. The
+// bankId here deliberately LOOKS like a community subcategory: a bank-blind
+// resolver would happily (and wrongly) resolve it.
+// ---------------------------------------------------------------------------
+describe('foreign-bank tailored sources in share exports', () => {
+  let assessmentId;
+
+  beforeEach(() => {
+    const created = useAssessmentsStore.getState().createAssessment({
+      name: 'Foreign bank export test',
+      description: '',
+      scopeType: 'requirements'
+    });
+    assessmentId = created.id;
+    useAssessmentsStore.getState().addToScope(assessmentId, 'GV.OC-01 Ex1');
+    useAssessmentsStore.getState().updateObservation(assessmentId, 'GV.OC-01 Ex1', {
+      testProcedures: 'Platform-bank addendum text with tenant facts baked in.',
+      procedureSource: {
+        bank: 'scuba-gws',
+        bankId: 'GV.OC-01',
+        bankVersion: 'future-1',
+        attachedAt: '2026-07-20T00:00:00.000Z',
+        tailored: true,
+        modified: true
+      }
+    });
+  });
+
+  afterEach(() => {
+    useAssessmentsStore.getState().deleteAssessment(assessmentId);
+  });
+
+  test('default share drops foreign-bank tailored text — never community markdown under a foreign label', () => {
+    const share = buildShareableExport(stores());
+    const shared = share.data.assessments.find((a) => a.id === assessmentId);
+    const obs = shared.observations['GV.OC-01 Ex1'];
+    expect(obs.testProcedures).toBe('');
+    expect(obs.testProcedures).not.toBe(getBankProcedure('GV.OC-01').markdown);
+    expect(obs.procedureSource.bank).toBe('scuba-gws');
+    expect(obs.procedureSource.tailored).toBe(false);
+  });
+
+  test('include-private opt-in deliberately keeps foreign-bank tailored text verbatim', () => {
+    const share = buildShareableExport(stores(), { includePrivate: true });
+    const shared = share.data.assessments.find((a) => a.id === assessmentId);
+    const obs = shared.observations['GV.OC-01 Ex1'];
+    expect(obs.testProcedures).toBe('Platform-bank addendum text with tenant facts baked in.');
+    expect(obs.procedureSource.tailored).toBe(true);
+  });
+});
+
+// The bankless variant of the same attack: no bank field at all, but a
+// bankId that resolves in the community bank. Never produced by any shipped
+// build (buildProcedureSource has stamped bank:'community' since birth,
+// tailoredProvenance's no-bank branch stamps bankId:null) — importable only
+// from tampered files, and it must fail closed the same way.
+describe('bankless tailored sources in share exports', () => {
+  let assessmentId;
+
+  beforeEach(() => {
+    const created = useAssessmentsStore.getState().createAssessment({
+      name: 'Bankless export test',
+      description: '',
+      scopeType: 'requirements'
+    });
+    assessmentId = created.id;
+    useAssessmentsStore.getState().addToScope(assessmentId, 'GV.OC-01 Ex1');
+    useAssessmentsStore.getState().updateObservation(assessmentId, 'GV.OC-01 Ex1', {
+      testProcedures: 'Tampered tailored text.',
+      procedureSource: { bankId: 'GV.OC-01', tailored: true, modified: true }
+    });
+  });
+
+  afterEach(() => {
+    useAssessmentsStore.getState().deleteAssessment(assessmentId);
+  });
+
+  test('default share drops bankless tailored text to empty — no bank match, no substitution', () => {
+    const share = buildShareableExport(stores());
+    const obs = share.data.assessments.find((a) => a.id === assessmentId).observations['GV.OC-01 Ex1'];
+    expect(obs.testProcedures).toBe('');
+    expect(obs.procedureSource.tailored).toBe(false);
+  });
+});

--- a/src/utils/procedureBank.js
+++ b/src/utils/procedureBank.js
@@ -48,18 +48,114 @@ export const bankCoverage = (itemIds) => {
   return { covered, uncovered };
 };
 
+/**
+ * Bank identity values. COMMUNITY_BANK is the only bank that exists today;
+ * NO_BANK is the explicit no-bank marker tailoredProvenance stamps on
+ * AI-tailored text for uncovered items. Provenance checks route through the
+ * predicates below rather than comparing strings at call sites, so a second
+ * bank value (plan §7 PR-3) cannot silently fall through a `=== 'community'`
+ * test somewhere. The ONLY other literal equality is the frozen v14
+ * migration step in assessmentsStore.js, which is historical by design.
+ */
+export const COMMUNITY_BANK = 'community';
+export const NO_BANK = 'none';
+
+/** The one community string-equality test — every provenance check routes here. */
+export const isCommunityBankSource = (source) => source?.bank === COMMUNITY_BANK;
+
+/**
+ * True when the source records an attach from SOME procedure bank —
+ * community today, any future bank value tomorrow. The no-bank marker is
+ * not an attach.
+ */
+export const isBankAttached = (source) =>
+  typeof source?.bank === 'string' && source.bank !== NO_BANK;
+
+/**
+ * Badge descriptor for a procedure's provenance, or null for none.
+ * A bank value this build does not recognize still gets a visible
+ * descriptor naming the bank — a record from a newer build must never
+ * silently lose its provenance badge (plan §7 R-10). A tailored source
+ * from an unrecognized bank shows that bank, not the org-tailor label.
+ */
+export const procedureBadge = (source) => {
+  if (!source) return null;
+  if (isCommunityBankSource(source)) {
+    return { kind: 'community', label: source.modified ? 'Community · customized' : 'Community' };
+  }
+  if (isBankAttached(source)) {
+    return { kind: 'bank', label: source.modified ? `${source.bank} · customized` : String(source.bank) };
+  }
+  return source.tailored ? { kind: 'tailored', label: 'Tailored to your org' } : null;
+};
+
+/**
+ * Deterministically restore the pristine payload a source points at.
+ * Positive match only: community sources resolve against the community
+ * bank; the no-bank marker and any bank value this build does not
+ * recognize return null. Callers treat null as "cannot restore — do not
+ * substitute" (the share scrub drops the text, Reset refuses), never as
+ * "use some other bank's text" — resolving foreign provenance against
+ * this bank is the R-6 inversion this predicate exists to prevent.
+ */
+export const resolvePristine = (source) => {
+  if (!isCommunityBankSource(source)) return null;
+  const entry = getBankProcedure(source.bankId);
+  return entry ? { bankId: entry.bankId, markdown: entry.markdown } : null;
+};
+
+/**
+ * Reset/insert safety: overwriting an observation with the community entry
+ * must never destroy content owned by ANOTHER bank. Hand-written text (no
+ * source — the insert path confirm-gates it), community attaches, and
+ * no-bank tailored text may be replaced; any other bank value may not.
+ */
+export const canResetToCommunity = (source) =>
+  !isBankAttached(source) || isCommunityBankSource(source);
+
 /** Provenance object the wizard/detail panel stamps on a bank attach. */
 export const buildProcedureSource = (bankId) => ({
-  bank: 'community',
+  bank: COMMUNITY_BANK,
   bankId,
   bankVersion: BANK_VERSION,
   attachedAt: new Date().toISOString(),
   modified: false
 });
 
-/** GitHub URL of the community source file — the "Improve this procedure" target. */
+/**
+ * Pure producer for the detail panel's Insert / Reset-to-community action.
+ * Returns the observation update (pristine markdown + pristine provenance),
+ * or null when the item has no bank entry or the existing source belongs to
+ * another bank — a community reset must never destroy foreign bank content
+ * (plan §7 R-10). The page stays a dumb dispatcher.
+ */
+export const resetToCommunityUpdate = (itemId, existingSource) => {
+  if (!canResetToCommunity(existingSource)) return null;
+  const entry = getBankProcedure(itemId);
+  if (!entry) return null;
+  return {
+    testProcedures: entry.markdown,
+    procedureSource: buildProcedureSource(entry.bankId)
+  };
+};
+
+/**
+ * Upstream URL of a bank entry's source. An explicit `upstreamUrl` on the
+ * entry wins — how a bank whose source is not this repo names its origin —
+ * with the repo blob URL derived from sourcePath as the community default.
+ */
 export const bankSourceUrl = (bankId) => {
   const entry = bank.procedures[bankId];
   if (!entry) return null;
+  if (entry.upstreamUrl) return entry.upstreamUrl;
   return `https://github.com/CPAtoCybersecurity/csf_profile/blob/main/${entry.sourcePath}`;
 };
+
+/**
+ * "Improve this procedure" link target for a provenance source. Community
+ * resolves through the bank; an unrecognized bank gets no link rather than
+ * a wrong community URL. The URL always comes from OUR bank data — never
+ * from the (possibly foreign) source object itself.
+ */
+export const sourceUrlFor = (source) =>
+  isCommunityBankSource(source) ? bankSourceUrl(source.bankId) : null;

--- a/src/utils/procedureBank.test.js
+++ b/src/utils/procedureBank.test.js
@@ -4,7 +4,16 @@ import {
   bankCoverage,
   buildProcedureSource,
   bankSourceUrl,
-  BANK_VERSION
+  BANK_VERSION,
+  COMMUNITY_BANK,
+  NO_BANK,
+  isCommunityBankSource,
+  isBankAttached,
+  procedureBadge,
+  resolvePristine,
+  canResetToCommunity,
+  resetToCommunityUpdate,
+  sourceUrlFor
 } from './procedureBank';
 import useAssessmentsStore from '../stores/assessmentsStore';
 
@@ -121,5 +130,142 @@ describe('bank attach + provenance in the assessments store', () => {
     const obs = store().getObservation(assessmentId, 'GV.OC-01 Ex1');
     expect(obs.testProcedures).toBe('My own procedure');
     expect(obs.procedureSource).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Predicate helpers (PR-1, plan §7 R-6/R-10): provenance checks must be
+// positive per-bank matches, total over every source shape — including bank
+// values this build does not recognize (records shared from a newer build).
+// ---------------------------------------------------------------------------
+describe('provenance predicates', () => {
+  const community = { bank: COMMUNITY_BANK, bankId: 'GV.OC-01', bankVersion: BANK_VERSION, attachedAt: '2026-07-20T00:00:00.000Z', modified: false };
+  const communityModified = { ...community, modified: true };
+  const communityTailored = { ...community, tailored: true, modified: true };
+  const communityDangling = { ...community, bankId: 'ZZ.NOPE-99' };
+  const noneTailored = { bank: NO_BANK, bankId: null, bankVersion: null, attachedAt: '2026-07-20T00:00:00.000Z', tailored: true, modified: true };
+  const banklessTailored = { tailored: true, modified: true };
+  const futureBank = { bank: 'scuba-gws', bankId: 'gws.commoncontrols.1.1v1', modified: false };
+  const futureTailored = { ...futureBank, tailored: true, modified: true };
+  // The mutation-killing shapes: bankIds that DO resolve in the community
+  // bank, under a foreign or absent bank label. A bank-blind resolver
+  // happily (and wrongly) resolves these — the predicates must not.
+  const foreignWithCommunityId = { bank: 'scuba-gws', bankId: 'GV.OC-01', tailored: true, modified: true };
+  const banklessWithCommunityId = { bankId: 'GV.OC-01', tailored: true, modified: true };
+
+  test('isCommunityBankSource matches only the community bank', () => {
+    expect(isCommunityBankSource(community)).toBe(true);
+    expect(isCommunityBankSource(communityTailored)).toBe(true);
+    expect(isCommunityBankSource(noneTailored)).toBe(false);
+    expect(isCommunityBankSource(banklessTailored)).toBe(false);
+    expect(isCommunityBankSource(futureBank)).toBe(false);
+    expect(isCommunityBankSource(null)).toBe(false);
+    expect(isCommunityBankSource(undefined)).toBe(false);
+  });
+
+  test('isBankAttached counts community AND unrecognized banks, never the no-bank marker', () => {
+    expect(isBankAttached(community)).toBe(true);
+    expect(isBankAttached(futureBank)).toBe(true);
+    expect(isBankAttached(noneTailored)).toBe(false);
+    expect(isBankAttached(banklessTailored)).toBe(false);
+    expect(isBankAttached(null)).toBe(false);
+  });
+
+  test('procedureBadge labels community sources, pristine and customized', () => {
+    expect(procedureBadge(null)).toBeNull();
+    expect(procedureBadge(undefined)).toBeNull();
+    expect(procedureBadge(community)).toEqual({ kind: 'community', label: 'Community' });
+    expect(procedureBadge(communityModified)).toEqual({ kind: 'community', label: 'Community · customized' });
+    expect(procedureBadge(communityTailored)).toEqual({ kind: 'community', label: 'Community · customized' });
+  });
+
+  test('procedureBadge labels no-bank tailored text as org-tailored', () => {
+    expect(procedureBadge(noneTailored)).toEqual({ kind: 'tailored', label: 'Tailored to your org' });
+    expect(procedureBadge(banklessTailored)).toEqual({ kind: 'tailored', label: 'Tailored to your org' });
+    expect(procedureBadge({ bank: NO_BANK, tailored: false })).toBeNull();
+  });
+
+  test('an unrecognized bank value gets a VISIBLE descriptor naming the bank — never null', () => {
+    expect(procedureBadge(futureBank)).toEqual({ kind: 'bank', label: 'scuba-gws' });
+    expect(procedureBadge({ ...futureBank, modified: true })).toEqual({ kind: 'bank', label: 'scuba-gws · customized' });
+  });
+
+  test('a tailored unrecognized-bank source shows its bank, NOT the org-tailor label', () => {
+    expect(procedureBadge(futureTailored)).toEqual({ kind: 'bank', label: 'scuba-gws · customized' });
+  });
+
+  test('resolvePristine restores the community entry byte-identically', () => {
+    const pristine = resolvePristine(communityTailored);
+    expect(pristine.bankId).toBe('GV.OC-01');
+    expect(pristine.markdown).toBe(getBankProcedure('GV.OC-01').markdown);
+  });
+
+  test('resolvePristine is a positive match — everything else resolves to null', () => {
+    expect(resolvePristine(null)).toBeNull();
+    expect(resolvePristine(undefined)).toBeNull();
+    expect(resolvePristine(noneTailored)).toBeNull();
+    expect(resolvePristine(banklessTailored)).toBeNull();
+    expect(resolvePristine(futureBank)).toBeNull();
+    expect(resolvePristine(futureTailored)).toBeNull();
+    expect(resolvePristine(communityDangling)).toBeNull();
+  });
+
+  test('resolvePristine refuses resolvable bankIds under a foreign or absent bank label (bank-blind mutant killer)', () => {
+    // Precondition making these discriminating: the bankId itself resolves.
+    expect(getBankProcedure('GV.OC-01')).not.toBeNull();
+    expect(resolvePristine(foreignWithCommunityId)).toBeNull();
+    expect(resolvePristine(banklessWithCommunityId)).toBeNull();
+  });
+
+  test('canResetToCommunity permits hand-written, community, and no-bank text only', () => {
+    expect(canResetToCommunity(undefined)).toBe(true);
+    expect(canResetToCommunity(null)).toBe(true);
+    expect(canResetToCommunity(community)).toBe(true);
+    expect(canResetToCommunity(communityTailored)).toBe(true);
+    expect(canResetToCommunity(noneTailored)).toBe(true);
+    expect(canResetToCommunity(banklessTailored)).toBe(true);
+    expect(canResetToCommunity(futureBank)).toBe(false);
+    expect(canResetToCommunity(futureTailored)).toBe(false);
+  });
+
+  test('sourceUrlFor resolves community sources only, from OUR bank data', () => {
+    expect(sourceUrlFor(community)).toBe(bankSourceUrl('GV.OC-01'));
+    expect(sourceUrlFor(communityDangling)).toBeNull();
+    expect(sourceUrlFor(noneTailored)).toBeNull();
+    expect(sourceUrlFor(futureBank)).toBeNull();
+    expect(sourceUrlFor(null)).toBeNull();
+  });
+
+  test('sourceUrlFor refuses a resolvable bankId under a foreign label — no community URL on foreign content', () => {
+    expect(sourceUrlFor(foreignWithCommunityId)).toBeNull();
+    expect(sourceUrlFor(banklessWithCommunityId)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resetToCommunityUpdate — the production decision behind the detail panel's
+// Insert / Reset-to-community button (the page is a dumb dispatcher).
+// ---------------------------------------------------------------------------
+describe('resetToCommunityUpdate producer', () => {
+  const foreign = { bank: 'scuba-gws', bankId: 'GV.OC-01', tailored: true, modified: true };
+
+  test('hand-written text (no source) gets the pristine community attach', () => {
+    const update = resetToCommunityUpdate('GV.OC-01 Ex1', undefined);
+    expect(update.testProcedures).toBe(getBankProcedure('GV.OC-01').markdown);
+    expect(update.procedureSource).toMatchObject({ bank: COMMUNITY_BANK, bankId: 'GV.OC-01', modified: false });
+  });
+
+  test('community and no-bank sources may be reset (today\'s exact behavior)', () => {
+    const communitySrc = buildProcedureSource('GV.OC-01');
+    expect(resetToCommunityUpdate('GV.OC-01 Ex1', { ...communitySrc, tailored: true, modified: true })).not.toBeNull();
+    expect(resetToCommunityUpdate('GV.OC-01 Ex1', { bank: NO_BANK, bankId: null, tailored: true })).not.toBeNull();
+  });
+
+  test('refuses to overwrite another bank\'s content — even with a resolvable community bankId', () => {
+    expect(resetToCommunityUpdate('GV.OC-01 Ex1', foreign)).toBeNull();
+  });
+
+  test('uncovered items produce no update', () => {
+    expect(resetToCommunityUpdate('CTRL-042', undefined)).toBeNull();
   });
 });

--- a/src/utils/procedureBank.upstream.test.js
+++ b/src/utils/procedureBank.upstream.test.js
@@ -1,0 +1,38 @@
+/**
+ * bankSourceUrl upstream capability (PR-1, plan §7 R-10): the helper must be
+ * able to express a source URL that is NOT a blob in this repo — the shape a
+ * platform bank's generator will emit (e.g. a CISA ScubaGoggles baseline
+ * file). Proven against a mocked bank so no real entry needs the field yet.
+ * (jest.mock hoists above the import, so import-order rules are satisfied
+ * with the import first.)
+ */
+import { bankSourceUrl } from './procedureBank';
+
+jest.mock('../data/communityProcedures.json', () => ({
+  bankVersion: 'mock-version',
+  procedures: {
+    'GV.OC-01': {
+      title: 'Repo-sourced entry',
+      markdown: 'M',
+      sourcePath: 'ASSESSMENT_CATALOG/3_Test_Procedures/GV/GV.OC-01.md'
+    },
+    'GV.OC-02': {
+      title: 'Upstream-sourced entry',
+      markdown: 'M2',
+      sourcePath: 'ASSESSMENT_CATALOG/3_Test_Procedures/GV/GV.OC-02.md',
+      upstreamUrl: 'https://github.com/cisagov/ScubaGoggles/blob/abc123/baselines/commoncontrols.md'
+    }
+  }
+}));
+
+test('an entry with upstreamUrl links to its non-repo upstream', () => {
+  expect(bankSourceUrl('GV.OC-02')).toBe(
+    'https://github.com/cisagov/ScubaGoggles/blob/abc123/baselines/commoncontrols.md'
+  );
+});
+
+test('entries without upstreamUrl keep the repo blob URL', () => {
+  expect(bankSourceUrl('GV.OC-01')).toBe(
+    'https://github.com/CPAtoCybersecurity/csf_profile/blob/main/ASSESSMENT_CATALOG/3_Test_Procedures/GV/GV.OC-01.md'
+  );
+});

--- a/src/utils/shareRegistry.js
+++ b/src/utils/shareRegistry.js
@@ -42,7 +42,7 @@
  */
 
 import { licenseIsRestricted } from './metricsImport';
-import { getBankProcedure } from './procedureBank';
+import { resolvePristine } from './procedureBank';
 
 export const SHARE = 'share';
 export const OMIT = 'omit';
@@ -63,16 +63,19 @@ const map = (of) => ({ kind: 'map', of });
  * (org name, systems, crown-jewel references) into observation text — a
  * derived leak path. Provenance (procedureSource.bankId) makes the fix
  * deterministic: shared copies get the untailored community markdown. If the
- * bank entry cannot be resolved, the text is dropped entirely — never leaked.
- * Registry-owned so the pristine rule has exactly one home; applied as the
- * observation record transform in default share mode.
+ * source cannot be resolved, the text is dropped entirely — never leaked.
+ * Resolution is a POSITIVE bank match (resolvePristine): a tailored source
+ * carrying a bank label this build does not recognize drops to '' rather
+ * than shipping community markdown under a foreign label. Registry-owned so
+ * the pristine rule has exactly one home; applied as the observation record
+ * transform in default share mode.
  */
 export const pristineObservation = (obs) => {
   if (!obs?.procedureSource?.tailored) return obs;
-  const bankEntry = getBankProcedure(obs.procedureSource.bankId);
+  const pristine = resolvePristine(obs.procedureSource);
   return {
     ...obs,
-    testProcedures: bankEntry ? bankEntry.markdown : '',
+    testProcedures: pristine ? pristine.markdown : '',
     procedureSource: { ...obs.procedureSource, tailored: false, modified: false }
   };
 };


### PR DESCRIPTION
# PR body — PR-1: bank predicate helpers (paste into gh pr create)

**Title:** `Replace community string-equality provenance tests with bank predicates`

**Base:** `main` · **Head:** `feat/pr1-bank-predicates`

---

## What

PR-1 of the platform-procedures sequence (follows #308's disposition registry). Every `bank === 'community'` provenance test outside the frozen v14 migration is replaced with predicate helpers in `src/utils/procedureBank.js`:

- `isCommunityBankSource` / `isBankAttached` — the one place the community string lives; `bank: 'none'` stays the explicit no-bank marker.
- `procedureBadge` + new `ProcedureSourceBadge` component — provenance badges are computed in one place. A bank value this build does not recognize (a share from a newer build) renders a **visible neutral badge naming the bank** instead of silently rendering nothing, and a tailored unrecognized-bank source shows its bank rather than the misleading "Tailored to your org" label.
- `canResetToCommunity` + `resetToCommunityUpdate` — the Insert/Reset decision is now a **pure producer** (same pattern as `bankAttachObservation` / `deterministicTailorUpdate`): it can replace hand-written, community, or no-bank tailored text (today's exact behavior) and refuses to destroy content owned by any other bank. The button visibility gates on the predicate; the handler applies the producer; both are out of the lint-allowlisted page.
- `resolvePristine` — the share-export pristine swap (`pristineObservation`) now resolves by **positive bank match**. A tailored source carrying a foreign bank label exports with its text dropped to `''`, never with community markdown shipped under that foreign label — even when its `bankId` happens to look like a community subcategory.
- `sourceUrlFor` + `upstreamUrl` support in `bankSourceUrl` — the "Improve this procedure" link resolves per-bank from **our** bank data (never from the possibly-foreign source object), and an entry can now carry a non-repo upstream URL (the shape a future platform bank's generator will emit).
- Wizard preview renders through `bankAttachObservation`, the same producer the create path uses — previewed bytes are attach bytes by construction.
- The v14 migration's literal equality is **frozen with a comment** (historical migrations get frozen, not generalized — it rewrites relative links against the community catalog layout and must never run over another bank's records).
- A new **ESLint `no-restricted-syntax` rule** bans `=== 'community'` / `!== 'community'` comparisons repo-wide so the sweep cannot decay; the frozen v14 line carries the one explicit disable. Polarity proven: an unguarded equality fails lint with the predicate-pointing message.

No second bank value ships in this PR. The bank JSON, demo data, and CSV lanes are untouched.

## Why now

The upcoming platform-procedure bank (CISA SCuBA) adds a second `bank` value. The adversarial review of that plan (R-6/R-10) found that every string-equality site fails **silently** when that value appears: no badge, a wrong badge, a Reset that destroys the platform addendum, a community repo URL on foreign content, and — worst — the share scrub shipping community text under a foreign bank label. This PR makes those failure modes structurally impossible before the value exists.

## Behavior

Pure refactor for every source shape today's producers can create — proven by:

- 745/745 jest (46 suites; 27 new tests), including all 3 share-export golden snapshots byte-unchanged and the whole pre-existing export/tailor/registry suites passing **unmodified**.
- New predicate matrix over community pristine/modified/tailored, dangling-bankId, `none`-tailored, bank-less, and future-bank shapes — including the **mutation-killing fixtures** (foreign or absent bank label with a bankId that *does* resolve in the community bank), added after the test-coverage review proved the original matrix passed under a bank-blind `resolvePristine`.
- New RTL suite for `ProcedureSourceBadge` (green/amber parity + the unrecognized-bank visibility pin).
- New production-path export tests: tailored foreign-bank AND bankless-with-resolvable-bankId observations export with `testProcedures: ''` in default share mode; the includePrivate opt-in deliberately keeps foreign text verbatim (pinned).
- History probe: `buildProcedureSource` has stamped `bank: 'community'` since its birth commit and `tailoredProvenance`'s no-bank branch has always stamped `bankId: null` — no released build ever produced the shapes whose handling sharpens, so the fail-closed change touches only hand-tampered/foreign files.
- `eslint --max-warnings=0` on all changed non-allowlisted files; `Assessments.js` (lint-debt allowlist) at exact warning parity with main (same 2 pre-existing `exhaustive-deps`, stdin compare).
- `CI=false npm run build` compiles.

The one deliberate semantic sharpening (unreachable via today's producers, stated for the record): a tailored source whose provenance is **not** a positive community match — foreign bank label, or a bank-less object with a resolvable-looking `bankId` — now fails **closed** (text dropped) in default share exports instead of resolving against the community bank. That is the R-6 fix.

## Ratification items

1. **Fail-closed on tampered/foreign provenance** (above) — confirm you want tampered shapes dropping to `''` rather than best-effort resolving. This is the plan's stated direction; flagging because it is the only reachable-in-principle output change.
2. **Unrecognized-bank badge styling** — blue tokens, labeled with the raw bank string (rendered as JSX text; XSS-safe). Note: this repo's dark theme remaps blue utilities to the green hacker palette, so in dark mode the badge is visible but not hue-distinct from Community — R-10's visibility requirement is still met. Cosmetic call, cheap to change.
3. **Reset button hidden** (rather than disabled-with-tooltip) when a future non-community source occupies the observation — the platform lane brings its own affordance in PR-5.

## Named gaps (deferred deliberately)

- **Reset JSX visibility line**: the decision logic is fully unit-tested via `resetToCommunityUpdate` / `canResetToCommunity` (production symbols); the one thing not machine-tested is the JSX visibility line itself (this repo deliberately never mounts the 2,900-line Assessments page). Verified by diff review + the post-merge click-through; PR-5's second-bank integration tests must cover it end-to-end.
- **Non-string / empty-string `bank` values** (crafted imports only): predicates classify them conservatively but semantics are undecided — candidate for import-side `procedureSource` validation alongside the platform lane's schema work (R-7).
