### PR TITLE
Add the license class + obligations model and third-party notices gate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # Generated files: LF-only so --check byte-comparison never trips on CRLF
 src/data/communityProcedures.json text eol=lf
 src/stores/comprehensiveAssessmentData.js text eol=lf
+THIRD-PARTY-NOTICES.md text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Comprehensive assessment data matches catalog
         run: node scripts/generate-comprehensive-assessment.mjs --check
 
+      # License gate (plan §7 PR-2): any attribution-obligated bank record
+      # missing a complete attribution block, any reference-only record found
+      # bundled, or notices drift from the shipped banks fails the build.
+      - name: Third-party notices match shipped banks (license gate)
+        run: node scripts/generate-third-party-notices.mjs --check
+
   private-data-leak-guard:
     name: Private data leak guard
     runs-on: ubuntu-latest

--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,9 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+Scope: this MIT License covers the source code of this repository. Files
+under src/data/ and vendor/ carry their own licenses — see
+THIRD-PARTY-NOTICES.md for the per-record license and attribution records.

--- a/README.md
+++ b/README.md
@@ -306,9 +306,13 @@ This tool is based on the NIST Cybersecurity Framework (CSF), developed by the N
 
 As a demonstration of how to conduct CSF profile assessment, fictional company "Alma Security" is used, inspired by Daniel Miessler's open source Telos project here: [https://github.com/danielmiessler/Telos/blob/main/corporate_telos.md](https://github.com/danielmiessler/Telos/blob/main/corporate_telos.md)
 
-## Disclaimer
+## License
 
-This software is provided under the MIT License. [https://github.com/CPAtoCybersecurity/csf_profile/blob/main/LICENSE](https://github.com/CPAtoCybersecurity/csf_profile/blob/main/LICENSE)
+The source code of this project is provided under the MIT License. [https://github.com/CPAtoCybersecurity/csf_profile/blob/main/LICENSE](https://github.com/CPAtoCybersecurity/csf_profile/blob/main/LICENSE)
+
+**Scope:** the MIT grant covers the code. Files under `src/data/` and `vendor/` carry their own licenses — generated data banks and vendored third-party content are governed by per-record license metadata, documented in [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md). A fork inherits those obligations along with the content.
+
+## Disclaimer
 
 By using this tool, you agree to the following:
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,20 @@
+# Third-Party Notices
+
+<!-- GENERATED FILE — do not edit by hand. -->
+<!-- Regenerate: node scripts/generate-third-party-notices.mjs -->
+
+## License scope
+
+The csf_profile source code is licensed under the MIT License (see LICENSE). Files under `src/data/` and `vendor/` carry their own licenses: generated data banks and vendored third-party content are governed by the per-record license metadata documented in this file, not by the MIT grant.
+
+## Standing notices
+
+### MITRE ATT&CK®
+
+This project references MITRE ATT&CK® technique identifiers. ATT&CK® is a registered trademark of The MITRE Corporation; © The MITRE Corporation. ATT&CK content is reproduced and distributed with the permission of The MITRE Corporation, per MITRE's Terms of Use. MITRE does not endorse this project.
+
+## Bundled third-party content
+
+### Community test-procedure bank (src/data/communityProcedures.json)
+
+This bank currently contains no third-party licensed content.

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Generates THIRD-PARTY-NOTICES.md from the shipped bank data. Thin fs
+// wrapper — all logic lives in src/utils/thirdPartyNotices.mjs (shared with
+// the jest suite, relatedSection.mjs precedent) so CI and tests exercise the
+// same code.
+//
+// The generator is also the license gate for bundled content: any
+// attribution-obligated record missing a complete attribution block
+// (attributionText, sourceUrl, licenseUrl, retrievedAt, upstream sha) and any
+// reference-only record found in a bank FAILS the build, before drift is even
+// considered.
+//
+// Deterministic: sorted rendering, no timestamps, no network — byte-identical
+// on re-run against unchanged banks.
+//
+// Usage:
+//   node scripts/generate-third-party-notices.mjs           # write the file
+//   node scripts/generate-third-party-notices.mjs --check   # exit 1 on
+//       validation failure OR if the committed file differs (CI gate)
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validateLicensedRecords, renderNotices } from '../src/utils/thirdPartyNotices.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const OUT = path.join(ROOT, 'THIRD-PARTY-NOTICES.md');
+
+// Every shipped bank, adapted to { name, records: { id: record } }. A future
+// bank (e.g. the platform-procedure bank, plan §7 PR-3) is added HERE and is
+// then covered by the validation gate automatically.
+const BANKS = [
+  {
+    name: 'Community test-procedure bank (src/data/communityProcedures.json)',
+    load: () =>
+      JSON.parse(
+        fs.readFileSync(path.join(ROOT, 'src', 'data', 'communityProcedures.json'), 'utf8')
+      ).procedures
+  }
+];
+
+// Stale-green guard: a bank JSON that exists on disk but is not enumerated in
+// BANKS would be silently un-covered by the license gate — the curated-list
+// rot mode. Any src/data/*.json carrying a bankVersion signature must be
+// declared above.
+const COVERED = new Set(['communityProcedures.json']);
+const dataDir = path.join(ROOT, 'src', 'data');
+const unregistered = fs.readdirSync(dataDir)
+  .filter((f) => f.endsWith('.json') && !COVERED.has(f))
+  .filter((f) => {
+    try {
+      return JSON.parse(fs.readFileSync(path.join(dataDir, f), 'utf8')).bankVersion !== undefined;
+    } catch {
+      return false;
+    }
+  });
+if (unregistered.length > 0) {
+  console.error(
+    'LICENSE GATE FAILED — bank file(s) not enumerated in generate-third-party-notices.mjs BANKS:\n' +
+    unregistered.map((f) => `  - src/data/${f}`).join('\n') +
+    '\nEvery bank must be covered by the notices/validation gate.'
+  );
+  process.exit(1);
+}
+
+const banks = BANKS.map(({ name, load }) => ({ name, records: load() }));
+
+const errors = validateLicensedRecords(banks);
+if (errors.length > 0) {
+  console.error('LICENSE GATE FAILED — bundled content violates its obligations:');
+  for (const e of errors) console.error(`  - ${e}`);
+  process.exit(1);
+}
+
+const output = renderNotices(banks);
+
+if (process.argv.includes('--check')) {
+  const committed = fs.existsSync(OUT) ? fs.readFileSync(OUT, 'utf8') : '';
+  if (committed !== output) {
+    console.error(
+      'DRIFT: THIRD-PARTY-NOTICES.md does not match the shipped bank data.\n' +
+      'Run: node scripts/generate-third-party-notices.mjs  (and commit the result)'
+    );
+    process.exit(1);
+  }
+  console.log('OK: third-party notices match the shipped bank data.');
+} else {
+  fs.writeFileSync(OUT, output);
+  console.log(`Wrote ${OUT}`);
+}

--- a/src/utils/licenseAttribution.test.js
+++ b/src/utils/licenseAttribution.test.js
@@ -1,0 +1,225 @@
+/**
+ * Attribution survives every egress — the emission binding of the license
+ * gate. A share export is redistribution: when licensed text ships, its
+ * attribution block must ship with it (mandatory-if-parent-present), in BOTH
+ * share modes, through the PRODUCTION fold — and the print/PDF surfaces must
+ * keep NOT rendering procedure text at all (§7 R-9), pinned here so the
+ * claim cannot rot silently.
+ */
+import fs from 'fs';
+import path from 'path';
+import { buildShareableExport } from './dataExport';
+import { pristineObservation } from './shareRegistry';
+import { requiresAttribution } from './licenseClass.mjs';
+import { bankAttachObservation, deterministicTailorUpdate } from './procedureTailor';
+import { getBankProcedure } from './procedureBank';
+import { importCompleteDatabase, validateDatabaseExport } from './dataImport';
+import { generateAuditReportMarkdown } from './auditReportMarkdown';
+import useAssessmentsStore from '../stores/assessmentsStore';
+import useControlsStore from '../stores/controlsStore';
+import useRequirementsStore from '../stores/requirementsStore';
+import useFrameworksStore from '../stores/frameworksStore';
+import useArtifactStore from '../stores/artifactStore';
+import useUserStore from '../stores/userStore';
+import useFindingsStore from '../stores/findingsStore';
+import useMetricsStore from '../stores/metricsStore';
+import useOrgProfileStore from '../stores/orgProfileStore';
+
+const stores = () => ({
+  controlsStore: useControlsStore,
+  assessmentsStore: useAssessmentsStore,
+  requirementsStore: useRequirementsStore,
+  frameworksStore: useFrameworksStore,
+  artifactStore: useArtifactStore,
+  userStore: useUserStore,
+  findingsStore: useFindingsStore,
+  metricsStore: useMetricsStore,
+  orgProfileStore: useOrgProfileStore
+});
+
+const ATTRIBUTION = {
+  attributionText: 'Derived from CISA ScubaGoggles Secure Configuration Baseline for Google Workspace',
+  sourceUrl: 'https://github.com/cisagov/ScubaGoggles/blob/main/scubagoggles/baselines/commoncontrols.md',
+  licenseUrl: 'https://creativecommons.org/publicdomain/zero/1.0/',
+  retrievedAt: '2026-07-20',
+  upstream: { repo: 'cisagov/ScubaGoggles', sha: 'fedcba987654', path: 'scubagoggles/baselines/commoncontrols.md' }
+};
+
+/** Attach a licensed fixture through the PRODUCTION producers. */
+const seedLicensedObservation = () => {
+  const assessments = useAssessmentsStore.getState();
+  const created = assessments.createAssessment({ name: 'License egress fixture', scopeType: 'requirements' });
+  assessments.addToScope(created.id, 'GV.OC-01 Ex1');
+  const entry = {
+    bankId: 'GV.OC-01',
+    title: 'Fixture licensed procedure',
+    markdown: '# Licensed fixture text\n\nVerbatim upstream content.',
+    license: 'CC BY 4.0',
+    attribution: ATTRIBUTION
+  };
+  const produced = bankAttachObservation(entry);
+  useAssessmentsStore.getState().updateObservation(created.id, 'GV.OC-01 Ex1', produced);
+  // Quarterly narrative on the SAME observation object that holds the
+  // licensed testProcedures — the report's positive control reads this
+  // field and must NOT read its sibling.
+  useAssessmentsStore.getState().updateQuarterlyObservation(created.id, 'GV.OC-01 Ex1', 'Q1', {
+    actualScore: 2,
+    targetScore: 3,
+    observations: 'Quarterly fixture narrative for the license egress test',
+    observationDate: '2026-01-15',
+    testingStatus: 'Tested'
+  });
+  return { assessmentId: created.id, produced };
+};
+
+afterEach(() => {
+  // The suites share module-level zustand stores; reset what we seeded.
+  const s = useAssessmentsStore.getState();
+  (s.assessments || []).filter((a) => a.name === 'License egress fixture')
+    .forEach((a) => s.deleteAssessment(a.id));
+});
+
+describe('share export — attribution rides the production fold in both modes', () => {
+  test.each([[false], [true]])('includePrivate=%s carries the attribution block byte-equal', (includePrivate) => {
+    const { assessmentId } = seedLicensedObservation();
+    const share = buildShareableExport(stores(), { includePrivate });
+    const shared = share.data.assessments.find((a) => a.id === assessmentId);
+    expect(shared).toBeDefined();
+    const source = shared.observations['GV.OC-01 Ex1'].procedureSource;
+    expect(source.license).toBe('CC BY 4.0');
+    expect(source.attribution).toEqual(ATTRIBUTION);
+  });
+
+  test('DECLARED-OVER-FLOOR: a CC0 record with record-declared obligations keeps them through the production fold in both modes (the R-1 case the model exists for)', () => {
+    const assessments = useAssessmentsStore.getState();
+    const created = assessments.createAssessment({ name: 'License egress fixture', scopeType: 'requirements' });
+    const entry = {
+      bankId: 'GV.OC-01',
+      title: 'CISA-style fixture',
+      markdown: '# CC0 text with asserted obligations',
+      license: 'CC0-1.0',
+      licenseObligations: { attribution: true, noticeText: ['cisa-no-endorsement'] },
+      attribution: ATTRIBUTION
+    };
+    useAssessmentsStore.getState().updateObservation(created.id, 'GV.OC-01 Ex1', bankAttachObservation(entry));
+
+    for (const includePrivate of [false, true]) {
+      const share = buildShareableExport(stores(), { includePrivate });
+      const source = share.data.assessments
+        .find((a) => a.id === created.id).observations['GV.OC-01 Ex1'].procedureSource;
+      expect(source.licenseObligations).toEqual({ attribution: true, noticeText: ['cisa-no-endorsement'] });
+      expect(requiresAttribution(source)).toBe(true);
+    }
+  });
+
+  test('pristineObservation preserves the attribution block through the tailored-swap', () => {
+    const communityEntry = getBankProcedure('GV.OC-01 Ex1');
+    const obs = {
+      testProcedures: 'tailored text with org facts',
+      procedureSource: {
+        bank: 'community',
+        bankId: communityEntry.bankId,
+        bankVersion: 'x',
+        tailored: true,
+        modified: true,
+        license: 'CC BY 4.0',
+        attribution: ATTRIBUTION
+      }
+    };
+    const pristine = pristineObservation(obs);
+    expect(pristine.testProcedures).toBe(communityEntry.markdown);
+    expect(pristine.procedureSource.attribution).toEqual(ATTRIBUTION);
+    expect(pristine.procedureSource.license).toBe('CC BY 4.0');
+  });
+});
+
+describe('import round-trip — attribution survives the wire in both directions', () => {
+  test('export → import → export keeps the attribution block byte-equal (no strip, no downgrade)', () => {
+    const { assessmentId } = seedLicensedObservation();
+    const exported = buildShareableExport(stores(), { includePrivate: false });
+    const wire = JSON.parse(JSON.stringify(exported)); // simulate file round-trip
+
+    const validation = validateDatabaseExport(wire);
+    expect(validation.ok).toBe(true);
+    const result = importCompleteDatabase(wire, stores(), { backupFirst: false });
+    expect(result.applied).toContain('assessments');
+
+    const reExported = buildShareableExport(stores(), { includePrivate: false });
+    const shared = reExported.data.assessments.find((a) => a.id === assessmentId);
+    expect(shared.observations['GV.OC-01 Ex1'].procedureSource.attribution).toEqual(ATTRIBUTION);
+  });
+
+  test('DECLARED-OVER-FLOOR round-trip: record-declared obligations survive the wire and still bind on the receiving install', () => {
+    const assessments = useAssessmentsStore.getState();
+    const created = assessments.createAssessment({ name: 'License egress fixture', scopeType: 'requirements' });
+    const entry = {
+      bankId: 'GV.OC-01',
+      title: 'CISA-style fixture',
+      markdown: '# CC0 text with asserted obligations',
+      license: 'CC0-1.0',
+      licenseObligations: { attribution: true, noDerivatives: true },
+      attribution: ATTRIBUTION
+    };
+    useAssessmentsStore.getState().updateObservation(created.id, 'GV.OC-01 Ex1', bankAttachObservation(entry));
+
+    const wire = JSON.parse(JSON.stringify(buildShareableExport(stores(), { includePrivate: false })));
+    importCompleteDatabase(wire, stores(), { backupFirst: false });
+
+    const source = useAssessmentsStore.getState().assessments
+      .find((a) => a.id === created.id).observations['GV.OC-01 Ex1'].procedureSource;
+    expect(source.licenseObligations).toEqual({ attribution: true, noDerivatives: true });
+    expect(requiresAttribution(source)).toBe(true);
+    // ...and the transform gate still refuses on the receiving install.
+    expect(deterministicTailorUpdate('Alma Security text.', source, 'GV.OC-01 Ex1',
+      { orgName: 'Contoso', infrastructure: [], securityTools: [] })).toBeNull();
+  });
+});
+
+describe('print/PDF surfaces — R-9 invariant, with positive control', () => {
+  // generateAuditReportMarkdown both returns the markdown and triggers a
+  // browser download; jsdom lacks the object-URL API, so stub it (the
+  // egress census, not this suite, owns download-surface accounting).
+  beforeAll(() => {
+    URL.createObjectURL = jest.fn(() => 'blob:fixture');
+    URL.revokeObjectURL = jest.fn();
+  });
+
+  test('the audit report consumes the fixture assessment but never its procedure text or attribution fields', () => {
+    const { assessmentId } = seedLicensedObservation();
+    const assessment = useAssessmentsStore.getState().assessments.find((a) => a.id === assessmentId);
+    const report = generateAuditReportMarkdown({
+      assessment,
+      requirements: useRequirementsStore.getState().requirements,
+      findings: [],
+      artifacts: [],
+      selectedQuarter: 1,
+      reportMetadata: {
+        reportNumber: 'R-1',
+        engagementType: 'Fixture',
+        assessmentPeriod: '2026',
+        reportDate: '2026-07-20',
+        classification: 'Internal',
+        preparedFor: 'Fixture',
+        preparedBy: 'Fixture',
+        leadAssessor: 'Fixture',
+        qualityReviewer: 'Fixture',
+        organizationName: 'Fixture Org'
+      }
+    });
+    // Positive control: the report DID walk this scoped observation record —
+    // Appendix A renders its controlId (from the same observations map that
+    // holds the licensed testProcedures)...
+    expect(report).toContain('GV.OC-01 Ex1');
+    // ...and still renders no procedure text and no attribution block fields.
+    expect(report).not.toContain('Licensed fixture text');
+    expect(report).not.toContain('Verbatim upstream content');
+    expect(report).not.toContain(ATTRIBUTION.attributionText);
+  });
+
+  test('no print/PDF builder references testProcedures (source-level pin so a future render cannot land silently)', () => {
+    for (const file of ['auditReportMarkdown.js', 'executiveSummaryPDF.js']) {
+      const src = fs.readFileSync(path.join(__dirname, file), 'utf8');
+      expect(src.includes('testProcedures')).toBe(false);
+    }
+  });
+});

--- a/src/utils/licenseClass.mjs
+++ b/src/utils/licenseClass.mjs
@@ -1,0 +1,247 @@
+/**
+ * License class + obligations model — the single license authority.
+ *
+ * Every question about what a third-party license permits routes through this
+ * module, the way provenance questions route through procedureBank's
+ * predicates. Two orthogonal axes, because a single enum provably cannot
+ * express the real corpus (plan §7 R-5: CC BY-ND, CC0-with-asserted-notices,
+ * MITRE's notice-conditioned terms, mixed-license single files):
+ *
+ *  - CLASS (the gate axis): may the text ship in this MIT/commercial repo at
+ *    all? PUBLIC_DOMAIN | ATTRIBUTION | REFERENCE_ONLY | UNDECLARED.
+ *  - OBLIGATIONS (the accompany/transform axis): what must ride along when it
+ *    ships, and what may be done to it —
+ *    { attribution, changeIndication, noDerivatives, noticeText[] }.
+ *
+ * The license STRING is the floor, never the ceiling: a record may declare
+ * additional obligations (CISA files are CC0 yet assert a no-endorsement
+ * notice; ScubaGear M365 files are CC0 at repo grain but CC BY-portioned per
+ * file — §7 R-1). Merging only ever tightens.
+ *
+ * Callers use the predicates (mayShipText / mayTailor / requiresAttribution),
+ * not the bare class: branching on `class === ATTRIBUTION` would ship a
+ * CC BY-ND derivative with credit and no other complaint. The class exists
+ * for display and notices grouping.
+ *
+ * Reserved name: product-licensing prose (e.g. ScubaGear's "License
+ * Requirements" sections — "requires Entra ID P2", Microsoft PRODUCT
+ * licensing, not content licensing) must be carried as `productLicenseNotes`
+ * and must never wire into any share-export or render block.
+ */
+
+/* The gate axis. Order matters: merging takes the MOST restrictive. */
+export const UNDECLARED = 'undeclared'; // blank/unrecognized — asserts nothing, restricts nothing
+export const PUBLIC_DOMAIN = 'public-domain'; // CC0, US Government work
+export const ATTRIBUTION = 'attribution'; // CC BY family — shippable with obligations
+export const REFERENCE_ONLY = 'reference-only'; // NC / proprietary / internal — IDs and links only, never text
+
+/* Total order for the tightening merge. UNDECLARED is BOTTOM: a record
+ * declaring nothing can never loosen a classification derived from its
+ * license string. */
+const CLASS_RANK = {
+  [UNDECLARED]: 0,
+  [PUBLIC_DOMAIN]: 1,
+  [ATTRIBUTION]: 2,
+  [REFERENCE_ONLY]: 3
+};
+
+/* Token vocabulary — the same tokenization contract the shipped
+ * licenseIsRestricted used, extended with class/attribution recognition.
+ * Single tokens match exactly; pairs match adjacent token sequences so
+ * ordinary words ("Vendor Standard License", "NDA") never false-positive. */
+const tokenize = (license) =>
+  String(license || '').toUpperCase().split(/[^A-Z0-9]+/).filter(Boolean);
+
+const NC_TOKENS = ['NC', 'NONCOMMERCIAL'];
+const NC_PAIRS = [['NON', 'COMMERCIAL']];
+const ND_TOKENS = ['ND', 'NODERIVATIVES', 'NODERIVS'];
+const ND_PAIRS = [['NO', 'DERIVATIVES'], ['NO', 'DERIVS']];
+const CLOSED_TOKENS = ['PROPRIETARY', 'INTERNAL'];
+const PD_TOKENS = ['CC0'];
+const PD_PAIRS = [['PUBLIC', 'DOMAIN'], ['US', 'GOVERNMENT']];
+const BY_TOKENS = ['BY', 'ATTRIBUTION'];
+
+const hasToken = (tokens, list) => list.some((t) => tokens.includes(t));
+const hasPair = (tokens, pairs) =>
+  pairs.some(([a, b]) => tokens.some((t, i) => t === a && tokens[i + 1] === b));
+
+const EMPTY_OBLIGATIONS = Object.freeze({
+  attribution: false,
+  changeIndication: false,
+  noDerivatives: false,
+  noticeText: Object.freeze([])
+});
+
+/**
+ * Classify a license STRING into { licenseClass, obligations }. Pure floor:
+ * only what the string itself asserts. Blank and unrecognized strings are
+ * UNDECLARED with no obligations — the shipped blank-stays-unrestricted
+ * contract depends on this (legacy and user records carry '' licenses).
+ */
+export const classifyLicense = (license) => {
+  const tokens = tokenize(license);
+  if (tokens.length === 0) return { licenseClass: UNDECLARED, obligations: EMPTY_OBLIGATIONS };
+
+  const nc = hasToken(tokens, NC_TOKENS) || hasPair(tokens, NC_PAIRS);
+  const nd = hasToken(tokens, ND_TOKENS) || hasPair(tokens, ND_PAIRS);
+  const closed = hasToken(tokens, CLOSED_TOKENS);
+  const by = hasToken(tokens, BY_TOKENS);
+  const pd = hasToken(tokens, PD_TOKENS) || hasPair(tokens, PD_PAIRS);
+
+  let licenseClass = UNDECLARED;
+  if (nc || closed) {
+    licenseClass = REFERENCE_ONLY;
+  } else if (by || nd) {
+    // ND without NC is ATTRIBUTION class: CC BY-ND permits verbatim
+    // commercial redistribution with credit. The noDerivatives OBLIGATION
+    // (not the class) is what forbids transformation — and what keeps the
+    // metrics-lane restriction (see licenseIsRestricted) byte-compatible.
+    licenseClass = ATTRIBUTION;
+  } else if (pd) {
+    licenseClass = PUBLIC_DOMAIN;
+  }
+
+  return {
+    licenseClass,
+    obligations: {
+      attribution: by,
+      // CC BY 4.0 §3(a)(1)(B): modifications must be indicated. Derived
+      // conservatively from the attribution family.
+      changeIndication: by,
+      noDerivatives: nd,
+      noticeText: []
+    }
+  };
+};
+
+/**
+ * Effective license of a bank RECORD: string-derived floor tightened by
+ * record-declared fields. Records may declare `licenseClass` and/or
+ * `licenseObligations: { attribution?, changeIndication?, noDerivatives?,
+ * noticeText?: [] }`. Merging can only ADD restriction: class by rank
+ * (UNDECLARED bottom), booleans by OR, noticeText by sorted union — sorted
+ * so downstream renders (the notices file) are byte-stable.
+ */
+export const recordLicense = (record) => {
+  const derived = classifyLicense(record?.license);
+  const declared = record?.licenseObligations || {};
+  const declaredClass = record?.licenseClass;
+
+  const licenseClass =
+    declaredClass && CLASS_RANK[declaredClass] > CLASS_RANK[derived.licenseClass]
+      ? declaredClass
+      : derived.licenseClass;
+
+  const noticeText = [
+    ...new Set([...derived.obligations.noticeText, ...(declared.noticeText || [])])
+  ].sort();
+
+  return {
+    licenseClass,
+    obligations: {
+      attribution: derived.obligations.attribution || declared.attribution === true,
+      changeIndication: derived.obligations.changeIndication || declared.changeIndication === true,
+      noDerivatives: derived.obligations.noDerivatives || declared.noDerivatives === true,
+      noticeText
+    }
+  };
+};
+
+/**
+ * True when a license string forbids redistribution on the metrics lane —
+ * NC/ND Creative Commons variants (abbreviated or spelled out), proprietary,
+ * or explicitly internal content. Re-expressed on the class+obligations
+ * model, byte-compatible with the shipped token matcher (pinned by a
+ * reference-implementation property test): REFERENCE_ONLY is a closed gate,
+ * and noDerivatives is restricted HERE because metric fields are recombined
+ * and re-rendered — that lane cannot guarantee the verbatim form ND requires.
+ * Blank stays unrestricted: three dataExport share-block call sites depend on
+ * legacy/user records with '' licenses riding shares.
+ */
+export const licenseIsRestricted = (license) => {
+  const { licenseClass, obligations } = classifyLicense(license);
+  return licenseClass === REFERENCE_ONLY || obligations.noDerivatives;
+};
+
+/**
+ * True when a record's attribution block is complete enough to discharge an
+ * attribution obligation at every egress. All five are load-bearing: the
+ * notices generator and the attach gate both refuse on any miss.
+ */
+export const attributionComplete = (record) => {
+  const a = record?.attribution;
+  return Boolean(
+    a &&
+      typeof a.attributionText === 'string' && a.attributionText.trim() &&
+      typeof a.sourceUrl === 'string' && a.sourceUrl.trim() &&
+      typeof a.licenseUrl === 'string' && a.licenseUrl.trim() &&
+      typeof a.retrievedAt === 'string' && a.retrievedAt.trim() &&
+      typeof a.upstream?.sha === 'string' && a.upstream.sha.trim()
+  );
+};
+
+/** May this record's TEXT ship (attach, render, export) at all? */
+export const mayShipText = (record) => {
+  const { licenseClass, obligations } = recordLicense(record);
+  if (licenseClass === REFERENCE_ONLY) return false;
+  if (obligations.attribution && !attributionComplete(record)) return false;
+  return true;
+};
+
+/** May this record's text be TRANSFORMED (tailored, truncated, reflowed)? */
+export const mayTailor = (record) =>
+  mayShipText(record) && !recordLicense(record).obligations.noDerivatives;
+
+/** Must an attribution block accompany this record's text at every egress? */
+export const requiresAttribution = (record) =>
+  recordLicense(record).obligations.attribution;
+
+/**
+ * The attach/render gate. Total — never throws, never returns null:
+ *  - { allow: true, verbatimOnly } when the text may ship (verbatimOnly set
+ *    for noDerivatives content: truncation/reflow/summarization are
+ *    derivatives, so the ONLY permitted forms are verbatim or omission);
+ *  - { allow: false, reason } when it may not (reference-only class, or an
+ *    attribution obligation with no resolvable attribution block).
+ * Entries with no license metadata are unlicensed own-content (the community
+ * bank today) and pass through untouched.
+ */
+export const licenseGate = (record) => {
+  const { licenseClass, obligations } = recordLicense(record);
+  if (licenseClass === REFERENCE_ONLY) {
+    return { allow: false, reason: 'reference-only' };
+  }
+  if (obligations.attribution && !attributionComplete(record)) {
+    return { allow: false, reason: 'attribution-incomplete' };
+  }
+  return { allow: true, verbatimOnly: obligations.noDerivatives };
+};
+
+/**
+ * License-metadata fields a licensed bank entry contributes to
+ * procedureSource at attach time. Empty for unlicensed own-content, so the
+ * community attach output is byte-identical to the pre-gate producer. Copies
+ * only license metadata — never text. Attribution traveling IN provenance is
+ * what lets every egress (share export, notices, future render surfaces)
+ * re-assert the obligation from data instead of re-deriving it per surface
+ * (§7 R-9).
+ */
+export const licenseProvenance = (record) => {
+  const out = {};
+  if (record?.license) out.license = record.license;
+  if (record?.licenseClass) out.licenseClass = record.licenseClass;
+  if (record?.licenseObligations) out.licenseObligations = record.licenseObligations;
+  if (record?.attribution) out.attribution = record.attribution;
+  return out;
+};
+
+/**
+ * Fail-closed placeholder for refused content. Explicit and visible (never a
+ * silent drop — §7 R-3 doctrine), and carries ZERO licensed text. Total-return
+ * contract: attach call sites dereference `.testProcedures` directly, so
+ * refusal must produce a string, not null.
+ */
+export const refusalPlaceholder = (reason) =>
+  reason === 'reference-only'
+    ? '> This content is reference-only under its license and cannot be included. Consult the linked source directly.'
+    : '> This content is unavailable: its license requires an attribution record that is missing or incomplete.';

--- a/src/utils/licenseClass.test.js
+++ b/src/utils/licenseClass.test.js
@@ -1,0 +1,399 @@
+/**
+ * License class + obligations model — the R-5 expressiveness cases, the
+ * byte-compat pin on licenseIsRestricted, and the gate proven on the
+ * PRODUCTION attach/transform path (bankAttachObservation /
+ * deterministicTailorUpdate), not on a re-implementation.
+ */
+import {
+  UNDECLARED,
+  PUBLIC_DOMAIN,
+  ATTRIBUTION,
+  REFERENCE_ONLY,
+  classifyLicense,
+  recordLicense,
+  licenseIsRestricted,
+  attributionComplete,
+  mayShipText,
+  mayTailor,
+  requiresAttribution,
+  licenseGate,
+  licenseProvenance,
+  refusalPlaceholder
+} from './licenseClass.mjs';
+import { licenseIsRestricted as reExported } from './metricsImport';
+import { bankAttachObservation, deterministicTailorUpdate } from './procedureTailor';
+import bank from '../data/communityProcedures.json';
+
+/** A complete attribution block — the fixture baseline the gate accepts. */
+const fullAttribution = (over = {}) => ({
+  attributionText: 'Derived from CISA ScubaGear Secure Configuration Baseline for Microsoft Entra ID',
+  sourceUrl: 'https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md',
+  licenseUrl: 'https://creativecommons.org/licenses/by/4.0/',
+  retrievedAt: '2026-07-20',
+  upstream: { repo: 'cisagov/ScubaGear', sha: 'abc123def456', path: 'PowerShell/ScubaGear/baselines/aad.md' },
+  ...over
+});
+
+describe('classifyLicense — the class axis', () => {
+  test.each([
+    ['', UNDECLARED],
+    [null, UNDECLARED],
+    [undefined, UNDECLARED],
+    ['MIT', UNDECLARED],
+    ['Apache-2.0', UNDECLARED],
+    ['Vendor Standard License', UNDECLARED],
+    ['CC0-1.0', PUBLIC_DOMAIN],
+    ['Public Domain', PUBLIC_DOMAIN],
+    ['US Government work', PUBLIC_DOMAIN],
+    ['CC BY 4.0', ATTRIBUTION],
+    ['CC-BY-4.0', ATTRIBUTION],
+    ['CC BY-SA 4.0', ATTRIBUTION],
+    ['CC BY-ND 4.0', ATTRIBUTION],
+    ['CC BY-NC 4.0', REFERENCE_ONLY],
+    ['CC-BY-NC-ND-4.0', REFERENCE_ONLY],
+    ['Creative Commons Noncommercial', REFERENCE_ONLY],
+    ['proprietary', REFERENCE_ONLY],
+    ['Internal use only', REFERENCE_ONLY]
+  ])('%s → %s', (license, expected) => {
+    expect(classifyLicense(license).licenseClass).toBe(expected);
+  });
+
+  test('blank asserts nothing: all-false obligations, empty noticeText', () => {
+    expect(classifyLicense('').obligations).toEqual({
+      attribution: false,
+      changeIndication: false,
+      noDerivatives: false,
+      noticeText: []
+    });
+  });
+
+  test('CC BY carries attribution AND change-indication (CC BY 4.0 §3(a)(1)(B))', () => {
+    const { obligations } = classifyLicense('CC BY 4.0');
+    expect(obligations.attribution).toBe(true);
+    expect(obligations.changeIndication).toBe(true);
+    expect(obligations.noDerivatives).toBe(false);
+  });
+
+  test('R-5: CC BY-ND holds attribution and noDerivatives SIMULTANEOUSLY — the case a 3-enum cannot express', () => {
+    const { licenseClass, obligations } = classifyLicense('CC BY-ND 4.0');
+    expect(licenseClass).toBe(ATTRIBUTION); // ND permits verbatim redistribution with credit
+    expect(obligations.attribution).toBe(true);
+    expect(obligations.noDerivatives).toBe(true);
+  });
+
+  test('NC forces the class closed but does not erase the other obligations', () => {
+    const { licenseClass, obligations } = classifyLicense('CC BY-NC-ND 4.0');
+    expect(licenseClass).toBe(REFERENCE_ONLY);
+    expect(obligations.attribution).toBe(true);
+    expect(obligations.noDerivatives).toBe(true);
+  });
+});
+
+describe('recordLicense — record-declared obligations merge over the string floor', () => {
+  test('CC0 record asserting notices keeps PUBLIC_DOMAIN class WITH the notices (CISA case)', () => {
+    const rec = { license: 'CC0-1.0', licenseObligations: { noticeText: ['cisa-no-endorsement'] } };
+    const { licenseClass, obligations } = recordLicense(rec);
+    expect(licenseClass).toBe(PUBLIC_DOMAIN);
+    expect(obligations.noticeText).toEqual(['cisa-no-endorsement']);
+  });
+
+  test('R-1 mixed-license file: CC0 string + declared attribution obligation requires attribution', () => {
+    const rec = { license: 'CC0-1.0', licenseObligations: { attribution: true, changeIndication: true } };
+    expect(recordLicense(rec).obligations.attribution).toBe(true);
+    expect(requiresAttribution(rec)).toBe(true);
+  });
+
+  test('MITRE notice-conditioned terms are expressible via record noticeText', () => {
+    const rec = { license: '', licenseObligations: { noticeText: ['mitre-terms-of-use'] } };
+    expect(recordLicense(rec).obligations.noticeText).toEqual(['mitre-terms-of-use']);
+  });
+
+  test('noticeText union deduplicates and sorts (byte-stable notices render)', () => {
+    const rec = { license: '', licenseObligations: { noticeText: ['b-notice', 'a-notice', 'b-notice'] } };
+    expect(recordLicense(rec).obligations.noticeText).toEqual(['a-notice', 'b-notice']);
+  });
+
+  test('declared class may only tighten — UNDECLARED at bottom never loosens a derived class', () => {
+    expect(recordLicense({ license: 'CC BY 4.0', licenseClass: UNDECLARED }).licenseClass).toBe(ATTRIBUTION);
+    expect(recordLicense({ license: 'CC BY 4.0', licenseClass: REFERENCE_ONLY }).licenseClass).toBe(REFERENCE_ONLY);
+    expect(recordLicense({ license: 'CC0-1.0', licenseClass: ATTRIBUTION }).licenseClass).toBe(ATTRIBUTION);
+  });
+
+  test('merge is never less restrictive than the string floor (universal over the fixture corpus)', () => {
+    const strings = ['', 'MIT', 'CC0-1.0', 'CC BY 4.0', 'CC BY-ND 4.0', 'CC BY-NC 4.0', 'proprietary'];
+    const declarations = [
+      undefined,
+      {},
+      { attribution: true },
+      { noDerivatives: true },
+      { noticeText: ['x'] },
+      { attribution: false, noDerivatives: false } // false can never un-restrict
+    ];
+    for (const license of strings) {
+      const floor = classifyLicense(license);
+      for (const licenseObligations of declarations) {
+        const merged = recordLicense({ license, licenseObligations });
+        expect(merged.obligations.attribution || !floor.obligations.attribution).toBe(true);
+        expect(merged.obligations.noDerivatives || !floor.obligations.noDerivatives).toBe(true);
+        for (const n of floor.obligations.noticeText) {
+          expect(merged.obligations.noticeText).toContain(n);
+        }
+      }
+    }
+  });
+});
+
+describe('licenseIsRestricted — byte-compatible re-expression (D2)', () => {
+  // The shipped token matcher, reimplemented VERBATIM as the reference.
+  const LEGACY_TOKENS = ['NC', 'ND', 'PROPRIETARY', 'INTERNAL', 'NONCOMMERCIAL', 'NODERIVATIVES', 'NODERIVS'];
+  const LEGACY_PAIRS = [['NON', 'COMMERCIAL'], ['NO', 'DERIVATIVES'], ['NO', 'DERIVS']];
+  const legacyRestricted = (license) => {
+    const tokens = String(license || '').toUpperCase().split(/[^A-Z0-9]+/).filter(Boolean);
+    if (LEGACY_TOKENS.some((t) => tokens.includes(t))) return true;
+    return LEGACY_PAIRS.some(([a, b]) =>
+      tokens.some((t, i) => t === a && tokens[i + 1] === b)
+    );
+  };
+
+  const CORPUS = [
+    '', null, undefined, 42, '   ',
+    'CC-BY-NC-ND-4.0', 'CC BY-NC 4.0', 'proprietary', 'PROPRIETARY', 'Internal use only',
+    'Creative Commons Noncommercial', 'CC Non-Commercial 4.0', 'CC BY No Derivatives',
+    'CC BY-NoDerivs 3.0', 'CC BY-ND 4.0', 'nd', 'ND', 'NoDerivatives',
+    'MIT', 'CC-BY-4.0', 'CC BY 4.0', 'CC BY-SA 4.0', 'CC0-1.0', 'Public Domain',
+    'US Government work', 'Apache-2.0', 'Vendor Standard License', 'NDA',
+    'AND', 'BOND', 'Second Edition', 'non commercial', 'no derivatives', 'no derivs',
+    'cc by-nc', 'GPL-3.0', 'license: internal', 'InternalDocs',
+    // Cross-category combinations: kill classifier branch-order mutants (a
+    // PD-first classifier would call these unrestricted; the legacy matcher
+    // does not care about order and restricts them all).
+    'CC0-1.0 (internal draft)', 'US Government work - Noncommercial',
+    'Public Domain, internal use only', 'CC BY 4.0 proprietary',
+    'CC0 NC', 'Public Domain No Derivatives', 'CC BY-ND public domain'
+  ];
+
+  test('property: identical verdict to the shipped matcher across the whole corpus', () => {
+    for (const s of CORPUS) {
+      expect(licenseIsRestricted(s)).toBe(legacyRestricted(s));
+    }
+  });
+
+  test('REGRESSION PIN: blank stays unrestricted — dataExport.js:221/:224/:251 (share hard-block) and the shareRegistry keepMetric filter depend on legacy/user records with empty licenses riding share exports', () => {
+    expect(licenseIsRestricted('')).toBe(false);
+    expect(licenseIsRestricted(null)).toBe(false);
+    expect(licenseIsRestricted(undefined)).toBe(false);
+  });
+
+  test('CC BY-SA stays unrestricted (never in the restricted set) while classifying ATTRIBUTION', () => {
+    expect(licenseIsRestricted('CC BY-SA 4.0')).toBe(false);
+    expect(classifyLicense('CC BY-SA 4.0').licenseClass).toBe(ATTRIBUTION);
+  });
+
+  test('metricsImport re-exports the SAME binding (no drifting copy)', () => {
+    expect(reExported).toBe(licenseIsRestricted);
+  });
+});
+
+describe('attributionComplete — all five fields load-bearing', () => {
+  test('complete block passes', () => {
+    expect(attributionComplete({ attribution: fullAttribution() })).toBe(true);
+  });
+
+  test.each([
+    ['attributionText'],
+    ['sourceUrl'],
+    ['licenseUrl'],
+    ['retrievedAt']
+  ])('missing %s fails', (field) => {
+    const a = fullAttribution();
+    delete a[field];
+    expect(attributionComplete({ attribution: a })).toBe(false);
+  });
+
+  test('missing upstream.sha fails', () => {
+    const a = fullAttribution();
+    a.upstream = { repo: 'cisagov/ScubaGear' };
+    expect(attributionComplete({ attribution: a })).toBe(false);
+  });
+
+  test('whitespace-only fields do not count as present', () => {
+    expect(attributionComplete({ attribution: fullAttribution({ attributionText: '   ' }) })).toBe(false);
+    expect(attributionComplete({ attribution: fullAttribution({ retrievedAt: '\n' }) })).toBe(false);
+  });
+
+  test('no attribution block at all fails', () => {
+    expect(attributionComplete({})).toBe(false);
+  });
+});
+
+describe('licenseGate + predicates', () => {
+  test('no license metadata → identity pass (the community bank today)', () => {
+    expect(licenseGate({ markdown: '# GV.OC-01' })).toEqual({ allow: true, verbatimOnly: false });
+  });
+
+  test('reference-only → refused', () => {
+    expect(licenseGate({ license: 'CC BY-NC 4.0' })).toEqual({ allow: false, reason: 'reference-only' });
+  });
+
+  test('attribution-obligated without a complete block → refused', () => {
+    expect(licenseGate({ license: 'CC BY 4.0' })).toEqual({ allow: false, reason: 'attribution-incomplete' });
+  });
+
+  test('attribution-obligated with a complete block → allowed', () => {
+    expect(licenseGate({ license: 'CC BY 4.0', attribution: fullAttribution() }))
+      .toEqual({ allow: true, verbatimOnly: false });
+  });
+
+  test('noDerivatives → allowed, verbatim only', () => {
+    expect(licenseGate({ license: 'CC BY-ND 4.0', attribution: fullAttribution() }))
+      .toEqual({ allow: true, verbatimOnly: true });
+  });
+
+  test('predicates agree with the gate across the fixture corpus (no caller ever needs the bare class)', () => {
+    const fixtures = [
+      { markdown: 'x' },
+      { license: 'CC0-1.0' },
+      { license: 'CC BY 4.0' },
+      { license: 'CC BY 4.0', attribution: fullAttribution() },
+      { license: 'CC BY-ND 4.0', attribution: fullAttribution() },
+      { license: 'CC BY-NC 4.0' },
+      { license: 'proprietary' }
+    ];
+    for (const f of fixtures) {
+      const { licenseClass, obligations } = recordLicense(f);
+      expect(mayShipText(f)).toBe(licenseGate(f).allow);
+      expect(mayTailor(f)).toBe(
+        licenseClass !== REFERENCE_ONLY && !obligations.noDerivatives && mayShipText(f)
+      );
+    }
+  });
+
+  test('refusalPlaceholder carries zero licensed text and is visibly a refusal', () => {
+    for (const reason of ['reference-only', 'attribution-incomplete']) {
+      const text = refusalPlaceholder(reason);
+      expect(text.startsWith('>')).toBe(true);
+      expect(text.toLowerCase()).toContain('license');
+    }
+  });
+});
+
+describe('licenseProvenance — attach stamps metadata, never text', () => {
+  test('empty for unlicensed entries', () => {
+    expect(licenseProvenance({ markdown: '# x', title: 'x' })).toEqual({});
+  });
+
+  test('copies license metadata fields only', () => {
+    const entry = {
+      markdown: '# x',
+      license: 'CC BY 4.0',
+      licenseObligations: { changeIndication: true },
+      attribution: fullAttribution()
+    };
+    const stamped = licenseProvenance(entry);
+    expect(stamped).toEqual({
+      license: 'CC BY 4.0',
+      licenseObligations: { changeIndication: true },
+      attribution: fullAttribution()
+    });
+    expect(stamped.markdown).toBeUndefined();
+  });
+});
+
+describe('PRODUCTION attach path — bankAttachObservation routes the gate', () => {
+  const licensedEntry = (over = {}) => ({
+    bankId: 'PR.AA-01',
+    title: 'Fixture licensed entry',
+    markdown: '# PR.AA-01 fixture\n\nUpstream licensed text with Alma Security named.',
+    license: 'CC BY 4.0',
+    attribution: fullAttribution(),
+    ...over
+  });
+
+  test('all real community entries attach byte-identically to the pre-gate producer (gate is identity on unlicensed content)', () => {
+    for (const [id, entry] of Object.entries(bank.procedures)) {
+      const out = bankAttachObservation({ bankId: id, ...entry });
+      expect(out.testProcedures).toBe(entry.markdown);
+      expect(out.procedureSource.bank).toBe('community');
+      expect(out.procedureSource.bankId).toBe(id);
+      expect(out.procedureSource.tailored).toBe(false);
+      expect(out.procedureSource.license).toBeUndefined();
+      expect(out.procedureSource.attribution).toBeUndefined();
+    }
+  });
+
+  test('attribution-complete licensed entry attaches with license + attribution stamped into provenance', () => {
+    const out = bankAttachObservation(licensedEntry());
+    expect(out.testProcedures).toBe(licensedEntry().markdown);
+    expect(out.procedureSource.license).toBe('CC BY 4.0');
+    expect(out.procedureSource.attribution).toEqual(fullAttribution());
+  });
+
+  test('DISCRIMINATION FIXTURE (G19 learning): attribution-incomplete entry with perfectly resolvable markdown is REFUSED — a gate-blind attach would succeed here', () => {
+    const out = bankAttachObservation(licensedEntry({ attribution: undefined }));
+    expect(out.testProcedures).toBe(refusalPlaceholder('attribution-incomplete'));
+    expect(out.testProcedures).not.toContain('Upstream licensed text');
+    expect(out.procedureSource.bankId).toBe('PR.AA-01');
+  });
+
+  test('refused attach stamps NO license metadata (intended: no licensed text shipped, so provenance must not claim a license relationship; the placeholder text carries the reason)', () => {
+    const out = bankAttachObservation(licensedEntry({ attribution: undefined }));
+    expect(out.procedureSource.license).toBeUndefined();
+    expect(out.procedureSource.attribution).toBeUndefined();
+    expect(out.procedureSource.licenseObligations).toBeUndefined();
+  });
+
+  test('reference-only entry is refused with zero licensed text', () => {
+    const out = bankAttachObservation(licensedEntry({ license: 'CC BY-NC 4.0', attribution: undefined }));
+    expect(out.testProcedures).toBe(refusalPlaceholder('reference-only'));
+    expect(out.testProcedures).not.toContain('Upstream licensed text');
+  });
+
+  test('total return: refused entries still expose .testProcedures (Assessments.js:2534 dereferences it)', () => {
+    expect(() => bankAttachObservation(licensedEntry({ attribution: undefined })).testProcedures).not.toThrow();
+    expect(typeof bankAttachObservation(licensedEntry({ attribution: undefined })).testProcedures).toBe('string');
+  });
+
+  test('ND entry attaches VERBATIM — tailor options are ignored (verbatim-or-omit on the production path)', () => {
+    const profile = { orgName: 'Contoso', infrastructure: ['Google Cloud'], securityTools: [] };
+    const entry = licensedEntry({ license: 'CC BY-ND 4.0' });
+    const out = bankAttachObservation(entry, profile, { substituteName: true, adaptStack: true });
+    expect(out.testProcedures).toBe(entry.markdown); // byte-equal: no substitution ran
+    expect(out.procedureSource.tailored).toBe(false);
+  });
+
+  test('non-ND licensed entry with the same options DOES tailor (the ND flag, not the license presence, drives verbatim)', () => {
+    const profile = { orgName: 'Contoso', infrastructure: [], securityTools: [] };
+    const out = bankAttachObservation(licensedEntry(), profile, { substituteName: true, adaptStack: false });
+    expect(out.testProcedures).toContain('Contoso');
+    expect(out.procedureSource.tailored).toBe(true);
+  });
+});
+
+describe('PRODUCTION transform path — deterministicTailorUpdate honors noDerivatives', () => {
+  const ndSource = {
+    bank: 'fixture-bank',
+    bankId: 'PR.AA-01',
+    license: 'CC BY-ND 4.0',
+    attribution: fullAttribution(),
+    tailored: false,
+    modified: false
+  };
+
+  test('ND source → null via the existing "nothing would change" contract, even when text WOULD change', () => {
+    const profile = { orgName: 'Contoso', infrastructure: [], securityTools: [] };
+    expect(deterministicTailorUpdate('Alma Security runs reviews.', ndSource, 'PR.AA-01', profile)).toBeNull();
+  });
+
+  test('attribution-obligated source whose attribution block was stripped → null (the mayShipText half of the transform gate, not just the ND half)', () => {
+    const profile = { orgName: 'Contoso', infrastructure: [], securityTools: [] };
+    const strippedSource = { bank: 'fixture-bank', bankId: 'PR.AA-01', license: 'CC BY 4.0', tailored: false, modified: false };
+    expect(deterministicTailorUpdate('Alma Security runs reviews.', strippedSource, 'PR.AA-01', profile)).toBeNull();
+  });
+
+  test('community source (no license metadata) tailors exactly as before', () => {
+    const profile = { orgName: 'Contoso', infrastructure: [], securityTools: [] };
+    const communitySource = { bank: 'community', bankId: 'PR.AA-01', tailored: false, modified: false };
+    const result = deterministicTailorUpdate('Alma Security runs reviews.', communitySource, 'PR.AA-01', profile);
+    expect(result.update.testProcedures).toContain('Contoso');
+  });
+});

--- a/src/utils/metricsImport.js
+++ b/src/utils/metricsImport.js
@@ -22,6 +22,7 @@
  */
 
 import Papa from 'papaparse';
+import { licenseIsRestricted } from './licenseClass.mjs';
 
 export const METRICS_CSV_FORMAT = 1;
 
@@ -45,25 +46,13 @@ const canonicalType = (raw) => {
 
 const DIRECTIONS = ['higher_is_better', 'lower_is_better', ''];
 
-const RESTRICTED_TOKENS = ['NC', 'ND', 'PROPRIETARY', 'INTERNAL', 'NONCOMMERCIAL', 'NODERIVATIVES', 'NODERIVS'];
-// Spelled-out two-word forms ("Non-Commercial", "No Derivatives") tokenize to
-// adjacent pairs — matched as sequences so ordinary words never false-positive.
-const RESTRICTED_PAIRS = [['NON', 'COMMERCIAL'], ['NO', 'DERIVATIVES'], ['NO', 'DERIVS']];
-
-/**
- * True when a license string forbids redistribution — NC/ND Creative Commons
- * variants (abbreviated or spelled out), proprietary, or explicitly internal
- * content. Token-based so "CC-BY-NC-ND-4.0", "CC BY-NC 4.0", "Creative
- * Commons Noncommercial", and "No Derivatives" all match without substring
- * false-positives.
- */
-export const licenseIsRestricted = (license) => {
-  const tokens = String(license || '').toUpperCase().split(/[^A-Z0-9]+/).filter(Boolean);
-  if (RESTRICTED_TOKENS.some((t) => tokens.includes(t))) return true;
-  return RESTRICTED_PAIRS.some(([a, b]) =>
-    tokens.some((t, i) => t === a && tokens[i + 1] === b)
-  );
-};
+// The restriction predicate is now expressed on the license class +
+// obligations model (licenseClass.js) — REFERENCE_ONLY class or a
+// noDerivatives obligation. Re-exported from HERE as the same binding so the
+// share-block call sites (dataExport/shareRegistry) and this module's
+// catalogue check are untouched. Byte-compatible with the historical token
+// matcher, pinned by a reference-implementation property test.
+export { licenseIsRestricted } from './licenseClass.mjs';
 
 /** True when ANY record in the catalogue carries a restricted license. */
 export const catalogIsRestricted = (records) =>

--- a/src/utils/procedureTailor.js
+++ b/src/utils/procedureTailor.js
@@ -20,6 +20,7 @@
  */
 
 import { getBankProcedure, buildProcedureSource } from './procedureBank';
+import { licenseGate, licenseProvenance, mayTailor, refusalPlaceholder } from './licenseClass.mjs';
 import { CLOUD_TERMS, EDR_PRODUCTS, GOOGLE_EMAIL_TERMS } from './stackTailorMaps';
 
 /**
@@ -208,14 +209,31 @@ export const tailorMarkdown = (markdown, profile, options = {}) => {
  * so the tailored flag can never be forgotten at a call site.
  */
 export const bankAttachObservation = (bankEntry, profile, options = {}) => {
+  // License gate — the attach binding of the single license authority.
+  // Unlicensed entries (the whole community bank) pass through untouched.
+  // A refused entry attaches a fail-closed explicit placeholder with ZERO
+  // licensed text; the return stays total because call sites dereference
+  // `.testProcedures` directly. noDerivatives content forces the tailor off:
+  // verbatim and omission are the only forms a no-derivatives license permits.
+  const gate = licenseGate(bankEntry);
+  if (!gate.allow) {
+    return {
+      testProcedures: refusalPlaceholder(gate.reason),
+      procedureSource: { ...buildProcedureSource(bankEntry.bankId), tailored: false }
+    };
+  }
   const { substituteName = false, adaptStack = false } = options;
-  const wantTailor = (substituteName || adaptStack) && profile;
+  const wantTailor = (substituteName || adaptStack) && profile && !gate.verbatimOnly;
   const { text, tailored } = wantTailor
     ? tailorMarkdown(bankEntry.markdown, profile, { substituteName, adaptStack })
     : { text: bankEntry.markdown, tailored: false };
   return {
     testProcedures: text,
-    procedureSource: { ...buildProcedureSource(bankEntry.bankId), tailored }
+    procedureSource: {
+      ...buildProcedureSource(bankEntry.bankId),
+      tailored,
+      ...licenseProvenance(bankEntry)
+    }
   };
 };
 
@@ -226,6 +244,10 @@ export const bankAttachObservation = (bankEntry, profile, options = {}) => {
  * for the toast.
  */
 export const deterministicTailorUpdate = (currentText, existingSource, itemId, profile) => {
+  // Transform binding of the license gate: tailoring no-derivatives content
+  // would create a derivative, so the action is a no-op via the existing
+  // "nothing would change" null contract every call site already handles.
+  if (existingSource && !mayTailor(existingSource)) return null;
   const { text, tailored, applied } = tailorMarkdown(currentText, profile, { substituteName: true, adaptStack: true });
   if (!tailored) return null;
   return {

--- a/src/utils/shareRegistry.js
+++ b/src/utils/shareRegistry.js
@@ -101,7 +101,33 @@ const OBSERVATION = struct({
     bankVersion: SHARE,
     attachedAt: SHARE,
     modified: SHARE,
-    tailored: SHARE
+    tailored: SHARE,
+    // License metadata stamped at attach for licensed bank content
+    // (licenseClass.js licenseProvenance). MANDATORY-if-parent-present:
+    // a share export is redistribution, so when licensed text ships, its
+    // attribution block must ship with it — SHARE here, and the
+    // licenseAttribution suite pins that the production fold carries the
+    // block byte-equal in BOTH modes. Nothing in this struct is private:
+    // it names public upstream sources, never org data.
+    license: SHARE,
+    licenseClass: SHARE,
+    licenseObligations: struct({
+      attribution: SHARE,
+      changeIndication: SHARE,
+      noDerivatives: SHARE,
+      noticeText: SHARE
+    }),
+    attribution: struct({
+      attributionText: SHARE,
+      sourceUrl: SHARE,
+      licenseUrl: SHARE,
+      retrievedAt: SHARE,
+      upstream: struct({
+        repo: SHARE,
+        sha: SHARE,
+        path: SHARE
+      })
+    })
   }),
   linkedArtifacts: SHARE,
   linkedFindings: SHARE,

--- a/src/utils/thirdPartyNotices.mjs
+++ b/src/utils/thirdPartyNotices.mjs
@@ -1,0 +1,175 @@
+/**
+ * THIRD-PARTY-NOTICES.md — pure generation + validation logic.
+ *
+ * Shared (relatedSection.mjs precedent) between the build-time generator
+ * (scripts/generate-third-party-notices.mjs) and the jest suite, so the CI
+ * gate and the tests exercise the SAME code. The notices file is generated
+ * from bank records — a hand-maintained notices file would be one more
+ * per-surface re-derivation of license knowledge, the exact structure behind
+ * the four historical share-export leaks.
+ *
+ * Deterministic by construction: banks and records render in sorted order,
+ * notice text renders verbatim (reflowing a required notice is a derivative
+ * of it), and nothing here reads the clock or the network — retrievedAt
+ * values come from the records themselves.
+ */
+
+import { recordLicense, requiresAttribution, REFERENCE_ONLY } from './licenseClass.mjs';
+
+/** noticeText key resolving to the canonical CISA no-endorsement form. */
+export const CISA_NOTICE_KEY = 'cisa-no-endorsement';
+
+/**
+ * Scope statement (also stated in README and LICENSE): the MIT grant covers
+ * the CODE. Generated data banks and vendored upstream content carry their
+ * own licenses, recorded per record.
+ */
+export const SCOPE_STATEMENT =
+  'The csf_profile source code is licensed under the MIT License (see LICENSE). ' +
+  'Files under `src/data/` and `vendor/` carry their own licenses: generated ' +
+  'data banks and vendored third-party content are governed by the per-record ' +
+  'license metadata documented in this file, not by the MIT grant.';
+
+/**
+ * Standing MITRE notice. ATT&CK technique identifiers already appear in the
+ * assessment catalog, and MITRE's Terms of Use condition reproduction on
+ * carrying this notice — cheap insurance, so it stands unconditionally.
+ */
+export const MITRE_NOTICE =
+  'This project references MITRE ATT&CK® technique identifiers. ATT&CK® is a ' +
+  'registered trademark of The MITRE Corporation; © The MITRE Corporation. ' +
+  'ATT&CK content is reproduced and distributed with the permission of The ' +
+  'MITRE Corporation, per MITRE\'s Terms of Use. MITRE does not endorse this project.';
+
+/**
+ * CISA no-endorsement disclaimer. Emitted whenever any bundled record is
+ * CISA-sourced — detected STRUCTURALLY from upstream provenance, not from a
+ * hand-entered notice key, so forgetting the key cannot silently omit a
+ * required notice (the key remains honored as a belt-and-braces trigger).
+ */
+export const CISA_DISCLAIMER =
+  'Portions of this project are derived from CISA Secure Configuration ' +
+  'Baselines (SCuBA), released under CC0 1.0 Universal. CISA and the United ' +
+  'States Government do not endorse this project or its authors, and no such ' +
+  'endorsement may be inferred; CISA material is referenced for informational ' +
+  'purposes only. CC0 1.0 does not waive trademark rights: no CISA or DHS ' +
+  'marks, seals, or logos are used by this project.';
+
+/** Structural CISA provenance: the record's upstream repo is a cisagov one. */
+export const isCisaSourced = (record) =>
+  /^cisagov\//i.test(record?.attribution?.upstream?.repo || '');
+
+/**
+ * Validate every bank record against its license obligations. Returns error
+ * strings; any error fails the build (the CI gate). Two rules:
+ *  - an attribution-obligated record must carry a COMPLETE attribution block
+ *    (attributionText, sourceUrl, licenseUrl, retrievedAt, upstream sha —
+ *    each individually load-bearing);
+ *  - a reference-only record must not be bundled in a bank at all (IDs and
+ *    links only is the whole meaning of the class).
+ * Banks: [{ name, records: { id: record } }].
+ */
+export const validateLicensedRecords = (banks) => {
+  const errors = [];
+  for (const bank of [...banks].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))) {
+    const ids = Object.keys(bank.records || {}).sort();
+    for (const id of ids) {
+      const record = bank.records[id];
+      const { licenseClass } = recordLicense(record);
+      if (licenseClass === REFERENCE_ONLY) {
+        errors.push(
+          `${bank.name} / ${id}: reference-only license ("${record.license}") — ` +
+          'this content must not be bundled; link and control IDs only.'
+        );
+        continue;
+      }
+      if (requiresAttribution(record)) {
+        const a = record.attribution || {};
+        const missing = [
+          ['attributionText', a.attributionText],
+          ['sourceUrl', a.sourceUrl],
+          ['licenseUrl', a.licenseUrl],
+          ['retrievedAt', a.retrievedAt],
+          ['upstream.sha', a.upstream?.sha]
+        ].filter(([, v]) => !(typeof v === 'string' && v.trim()));
+        for (const [field] of missing) {
+          errors.push(
+            `${bank.name} / ${id}: attribution-obligated record is missing "${field}" — ` +
+            'incomplete attribution cannot ship.'
+          );
+        }
+      }
+    }
+  }
+  return errors;
+};
+
+const licensedRecordEntries = (bank) =>
+  Object.entries(bank.records || {})
+    .filter(([, record]) => record.license || record.licenseClass || record.licenseObligations)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+/**
+ * Render THIRD-PARTY-NOTICES.md. Call validateLicensedRecords first — this
+ * renders whatever it is given. Notice text renders VERBATIM.
+ */
+export const renderNotices = (banks) => {
+  const sorted = [...banks].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  const allLicensed = sorted.flatMap((bank) => licensedRecordEntries(bank).map(([, r]) => r));
+  const cisaPresent = allLicensed.some(
+    (r) => isCisaSourced(r) || recordLicense(r).obligations.noticeText.includes(CISA_NOTICE_KEY)
+  );
+
+  const lines = [
+    '# Third-Party Notices',
+    '',
+    '<!-- GENERATED FILE — do not edit by hand. -->',
+    '<!-- Regenerate: node scripts/generate-third-party-notices.mjs -->',
+    '',
+    '## License scope',
+    '',
+    SCOPE_STATEMENT,
+    '',
+    '## Standing notices',
+    '',
+    '### MITRE ATT&CK®',
+    '',
+    MITRE_NOTICE,
+    ''
+  ];
+
+  if (cisaPresent) {
+    lines.push('### CISA', '', CISA_DISCLAIMER, '');
+  }
+
+  lines.push('## Bundled third-party content', '');
+  for (const bank of sorted) {
+    lines.push(`### ${bank.name}`, '');
+    const licensed = licensedRecordEntries(bank);
+    if (licensed.length === 0) {
+      lines.push('This bank currently contains no third-party licensed content.', '');
+      continue;
+    }
+    for (const [id, record] of licensed) {
+      const { obligations } = recordLicense(record);
+      const a = record.attribution || {};
+      lines.push(`#### ${id}`, '');
+      if (record.license) lines.push(`- License: ${record.license}`);
+      if (a.attributionText) lines.push(`- Attribution: ${a.attributionText}`);
+      if (a.sourceUrl) lines.push(`- Source: ${a.sourceUrl}`);
+      if (a.licenseUrl) lines.push(`- License text: ${a.licenseUrl}`);
+      if (a.upstream?.repo) {
+        lines.push(`- Upstream: ${a.upstream.repo}${a.upstream.sha ? `@${a.upstream.sha}` : ''}${a.upstream.path ? ` (${a.upstream.path})` : ''}`);
+      }
+      if (a.retrievedAt) lines.push(`- Retrieved: ${a.retrievedAt}`);
+      if (obligations.noDerivatives) lines.push('- No-derivatives: this content is included verbatim and must remain verbatim.');
+      const literalNotices = obligations.noticeText.filter((n) => n !== CISA_NOTICE_KEY);
+      for (const notice of literalNotices) {
+        lines.push('', `> ${notice}`);
+      }
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+};

--- a/src/utils/thirdPartyNotices.test.js
+++ b/src/utils/thirdPartyNotices.test.js
@@ -1,0 +1,197 @@
+/**
+ * Notices pipeline — validation polarity per required field, render
+ * determinism, structural CISA emission, and the verbatim discipline on
+ * notice text. Exercises the SAME module the build-time generator runs.
+ */
+import fs from 'fs';
+import path from 'path';
+import {
+  CISA_NOTICE_KEY,
+  SCOPE_STATEMENT,
+  MITRE_NOTICE,
+  CISA_DISCLAIMER,
+  isCisaSourced,
+  validateLicensedRecords,
+  renderNotices as noticesMarkdown
+} from './thirdPartyNotices.mjs';
+
+const fullAttribution = (over = {}) => ({
+  attributionText: 'Derived from CISA ScubaGear Secure Configuration Baselines',
+  sourceUrl: 'https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md',
+  licenseUrl: 'https://creativecommons.org/licenses/by/4.0/',
+  retrievedAt: '2026-07-20',
+  upstream: { repo: 'cisagov/ScubaGear', sha: 'abc123', path: 'baselines/aad.md' },
+  ...over
+});
+
+const bankWith = (records) => [{ name: 'Fixture bank', records }];
+
+describe('validateLicensedRecords — the CI gate', () => {
+  test('unlicensed records (the community bank today) validate clean', () => {
+    const real = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', 'data', 'communityProcedures.json'), 'utf8')
+    );
+    expect(validateLicensedRecords([
+      { name: 'Community bank', records: real.procedures }
+    ])).toEqual([]);
+  });
+
+  test('complete attribution-obligated record validates clean', () => {
+    expect(validateLicensedRecords(bankWith({
+      'MS.AAD.1.1v1': { license: 'CC BY 4.0', attribution: fullAttribution() }
+    }))).toEqual([]);
+  });
+
+  test.each([
+    ['attributionText'],
+    ['sourceUrl'],
+    ['licenseUrl'],
+    ['retrievedAt']
+  ])('POLARITY: missing %s fails the build with the field named', (field) => {
+    const a = fullAttribution();
+    delete a[field];
+    const errors = validateLicensedRecords(bankWith({
+      'MS.AAD.1.1v1': { license: 'CC BY 4.0', attribution: a }
+    }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain(`"${field}"`);
+  });
+
+  test('POLARITY: missing upstream sha fails the build', () => {
+    const errors = validateLicensedRecords(bankWith({
+      'MS.AAD.1.1v1': {
+        license: 'CC BY 4.0',
+        attribution: fullAttribution({ upstream: { repo: 'cisagov/ScubaGear' } })
+      }
+    }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('"upstream.sha"');
+  });
+
+  test('POLARITY: a reference-only record bundled in a bank fails the build (CIS/SCF fence is mechanical, not reviewer diligence)', () => {
+    const errors = validateLicensedRecords(bankWith({
+      'cis-thing': { license: 'CC BY-NC-SA 4.0', markdown: 'benchmark text' }
+    }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('reference-only');
+  });
+
+  test('a record missing multiple fields reports each one (no first-error masking)', () => {
+    const errors = validateLicensedRecords(bankWith({
+      'MS.AAD.1.1v1': { license: 'CC BY 4.0', attribution: { attributionText: 'x' } }
+    }));
+    expect(errors.length).toBe(4); // sourceUrl, licenseUrl, retrievedAt, upstream.sha
+  });
+
+  test('DECLARED-OVER-FLOOR: a CC0 record with record-declared attribution and no block fails — a floor-only validator would pass it (the R-1 case)', () => {
+    const errors = validateLicensedRecords(bankWith({
+      'MS.AAD.1.1v1': { license: 'CC0-1.0', licenseObligations: { attribution: true }, markdown: 'x' }
+    }));
+    expect(errors.length).toBe(5); // all five attribution fields missing
+  });
+
+  test('DECLARED-OVER-FLOOR: a declared reference-only class over a blank license string fails the bundling fence', () => {
+    const errors = validateLicensedRecords(bankWith({
+      'scf-thing': { license: '', licenseClass: 'reference-only', markdown: 'x' }
+    }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('reference-only');
+  });
+});
+
+describe('notices markdown — deterministic, scope + standing notices', () => {
+  test('deterministic: same input renders byte-identically, sorted regardless of input order', () => {
+    const a = noticesMarkdown([
+      { name: 'B bank', records: { z: { license: 'CC0-1.0' }, a: { license: 'CC0-1.0' } } },
+      { name: 'A bank', records: {} }
+    ]);
+    const b = noticesMarkdown([
+      { name: 'A bank', records: {} },
+      { name: 'B bank', records: { a: { license: 'CC0-1.0' }, z: { license: 'CC0-1.0' } } }
+    ]);
+    expect(a).toBe(b);
+    expect(a.indexOf('### A bank')).toBeLessThan(a.indexOf('### B bank'));
+  });
+
+  test('scope statement and standing MITRE notice always present', () => {
+    const out = noticesMarkdown([{ name: 'Empty bank', records: {} }]);
+    expect(out).toContain(SCOPE_STATEMENT);
+    expect(out).toContain(MITRE_NOTICE);
+    expect(out).toContain('src/data/');
+    expect(out).toContain('vendor/');
+  });
+
+  test('honest empty state for a bank with no licensed content', () => {
+    const out = noticesMarkdown([{ name: 'Empty bank', records: { 'GV.OC-01': { markdown: 'x' } } }]);
+    expect(out).toContain('no third-party licensed content');
+  });
+
+  test('the committed THIRD-PARTY-NOTICES.md matches a fresh render of the shipped banks (drift = red here AND in CI)', () => {
+    const real = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', 'data', 'communityProcedures.json'), 'utf8')
+    );
+    const committed = fs.readFileSync(
+      path.join(__dirname, '..', '..', 'THIRD-PARTY-NOTICES.md'), 'utf8'
+    );
+    expect(committed).toBe(noticesMarkdown([
+      { name: 'Community test-procedure bank (src/data/communityProcedures.json)', records: real.procedures }
+    ]));
+  });
+});
+
+describe('CISA no-endorsement disclaimer — structural emission', () => {
+  test('DISCRIMINATION FIXTURE: cisagov upstream with NO notice key still emits the disclaimer (forgetting the key cannot omit a required notice)', () => {
+    const out = noticesMarkdown(bankWith({
+      'GWS.COMMONCONTROLS.1.1v1': { license: 'CC0-1.0', attribution: fullAttribution() }
+    }));
+    expect(isCisaSourced({ attribution: fullAttribution() })).toBe(true);
+    expect(out).toContain(CISA_DISCLAIMER);
+  });
+
+  test('upstream.repo is THE structural trigger: cisagov repo with a non-cisagov sourceUrl emits; cisagov sourceUrl under a foreign repo does not', () => {
+    const cisaRepoOnly = fullAttribution({ sourceUrl: 'https://example.com/mirror/aad.md' });
+    expect(isCisaSourced({ attribution: cisaRepoOnly })).toBe(true);
+    const cisaUrlOnly = fullAttribution({ upstream: { repo: 'microsoft/mirror', sha: 'abc123' } });
+    expect(isCisaSourced({ attribution: cisaUrlOnly })).toBe(false);
+    const out = noticesMarkdown(bankWith({
+      'x': { license: 'CC0-1.0', attribution: cisaUrlOnly }
+    }));
+    expect(out).not.toContain(CISA_DISCLAIMER);
+  });
+
+  test('the notice key alone also triggers emission (belt and braces)', () => {
+    const out = noticesMarkdown(bankWith({
+      'x': { license: 'CC0-1.0', licenseObligations: { noticeText: [CISA_NOTICE_KEY] } }
+    }));
+    expect(out).toContain(CISA_DISCLAIMER);
+  });
+
+  test('no CISA-sourced content → no CISA section (the disclaimer never asserts a falsehood)', () => {
+    const out = noticesMarkdown(bankWith({ 'GV.OC-01': { markdown: 'community text' } }));
+    expect(out).not.toContain('### CISA');
+    expect(out).not.toContain(CISA_DISCLAIMER);
+  });
+
+  test('disclaimer form covers no-endorsement and the trademark carve-out', () => {
+    expect(CISA_DISCLAIMER).toContain('do not endorse');
+    expect(CISA_DISCLAIMER).toContain('CC0 1.0 does not waive trademark rights');
+  });
+});
+
+describe('licensed record rendering — verbatim discipline', () => {
+  test('attribution block fields all render, ND records state the verbatim requirement, literal notices render verbatim', () => {
+    const notice = 'This exact sentence must appear   unreflowed, with its spacing.';
+    const out = noticesMarkdown(bankWith({
+      'MS.AAD.1.1v1': {
+        license: 'CC BY-ND 4.0',
+        attribution: fullAttribution(),
+        licenseObligations: { noticeText: [notice] }
+      }
+    }));
+    expect(out).toContain('Derived from CISA ScubaGear');
+    expect(out).toContain('cisagov/ScubaGear@abc123');
+    expect(out).toContain('Retrieved: 2026-07-20');
+    expect(out).toContain('must remain verbatim');
+    expect(out).toContain(`> ${notice}`);
+  });
+});


### PR DESCRIPTION
## Summary

PR-2 of the platform-procedures plan — the ⛔ hard-gate PR (plan §7 revised sequencing): the license class + obligations model. Nothing in the program may stamp license values onto records until this schema lands; PR-3 (vendoring + parser) and later PRs build on it without touching any egress surface.

**One license authority, three bindings.** `src/utils/licenseClass.mjs` is the single home of license knowledge (`.mjs` so the node build script shares it — `relatedSection.mjs` precedent), bound at the three chokepoints licensed text passes through:

- **Attach** — `bankAttachObservation` routes every entry through `licenseGate`. Unlicensed entries (the entire community bank) pass byte-identically. A refused entry (reference-only class, or an attribution obligation without a complete attribution block) attaches a fail-closed explicit placeholder carrying zero licensed text; the return stays total because the page dereferences `.testProcedures` directly. No-derivatives content forces the tailor off — verbatim or omission are the only forms an ND license permits.
- **Transform** — `deterministicTailorUpdate` returns `null` (the existing "nothing would change" contract) for no-derivatives sources.
- **Emission** — the share-export disposition registry declares `procedureSource.license` + the full attribution struct (`attributionText`, `sourceUrl`, `licenseUrl`, `retrievedAt`, `upstream{repo, sha, path}`). A share export is redistribution: attribution rides BOTH share modes, survives the pristine swap and an export→import→export round-trip, and the print/PDF surfaces are test-pinned to never render `testProcedures` (with a positive control proving the report consumed the same observation record).

**Not a 3-enum.** Four classes on the gate axis (`public-domain | attribution | reference-only | undeclared`) crossed with orthogonal obligations `{attribution, changeIndication, noDerivatives, noticeText[]}`. A 3-value enum provably cannot express CC BY-ND (attribution AND no-derivatives simultaneously), CC0-with-asserted-notices (the CISA disclaimer), MITRE's notice-conditioned terms, or mixed-license single files (the ScubaGear M365 baselines). Record-declared obligations merge OVER the string-derived floor and can only tighten (class by rank with `undeclared` at bottom; booleans by OR; noticeText by sorted union). Callers use predicates — `mayShipText` / `mayTailor` / `requiresAttribution` — never the bare class, so `class === attribution` can never ship an ND derivative with credit.

**Byte-compatible restriction predicate.** `licenseIsRestricted` is re-expressed as `class === reference-only || noDerivatives` and re-exported from `metricsImport` as the same binding — all three share-block call sites in `dataExport.js` are untouched (zero diff to that file). A reference-implementation property test reimplements the shipped token matcher verbatim and pins identical verdicts across a corpus including `null`/`undefined`/non-strings and adversarial near-misses (`NDA`, `AND`, `Vendor Standard License`). **Blank stays unrestricted**, pinned by a named regression test — legacy/user records with empty licenses must never become share-blocked by this refactor.

**Generated third-party notices + CI gate.** `THIRD-PARTY-NOTICES.md` is generated from the shipped bank data (`scripts/generate-third-party-notices.mjs`; logic in `src/utils/thirdPartyNotices.mjs`, exercised by the same jest suite). Deterministic: sorted rendering, no timestamps, no network, double-run byte-identical. The CI `generated-data-sync` job runs `--check`: drift, an attribution-obligated record missing any of the five required fields, or a reference-only record found bundled in a bank fails the build — the CIS/SCF fence is now mechanical, not reviewer diligence. Standing MITRE ATT&CK® notice (technique IDs already ship in the catalog; MITRE's ToU is notice-conditioned). The CISA no-endorsement disclaimer emits **structurally** from `cisagov/*` upstream provenance — forgetting a hand-entered notice key cannot silently omit a required notice — and never asserts a falsehood: with no CISA-sourced content bundled (today), no CISA section renders.

**License scope statement.** README and LICENSE now state: the MIT grant covers the code; files under `src/data/` and `vendor/` carry their own licenses, documented per record in THIRD-PARTY-NOTICES.md.

## Verification

- 826/826 tests green (49 suites; +81 over the 745 baseline).
- Byte-compat property test against the verbatim legacy matcher; blank-unrestricted regression pin.
- All 106 real community entries attach byte-identically through the gated producer.
- Discrimination fixtures (per the PR-1 review learning): attribution-incomplete entry with perfectly resolvable markdown is refused (a gate-blind attach would succeed); cisagov-sourced record with NO notice key still emits the CISA disclaimer.
- Notices generator: double-run byte-identity proven; `--check` drift polarity proven (exit 1); per-field validation polarity proven for all five attribution fields + bundled reference-only content.
- Changed files lint at `--max-warnings=0`; `CI=false npm run build` compiles with no warnings from PR-2 files; 3 share-export goldens unchanged; zero diff to `src/pages/Assessments.js`, `src/utils/dataExport.js`, stores, and `communityProcedures.json`.

## Ratification items (merging ratifies)

1. **Unknown licenses are fail-open by design.** The gate is fail-closed on render shape (refusal placeholder, never partial text) but fail-open on unrecognized license strings: blank and unknown classify `undeclared` ⇒ unrestricted. This is forced by the shipped blank-stays-unrestricted contract (legacy/user records). A future tightening would need its own migration story.
2. **LICENSE file now carries a scope note** after the MIT text (clearly separated). GitHub's license detection (licensee) may start showing "MIT and other" instead of "MIT". If that matters for the repo badge, the alternative is README + NOTICES only — say the word and PR-2.1 drops the LICENSE appendix.
3. **CISA disclaimer text** (no-endorsement + trademark carve-out) is my drafting of the standard form, emitted only when CISA-sourced records exist. PR-3 should reconcile the wording against the vendored baseline files' own disclaimer language.
4. **`licenseIsRestricted` continues to treat ND as restricted on the metrics lane** (byte-compat). The model can now distinguish "ND but shippable verbatim" for future lanes; the metrics lane stays blocked because metric fields are recombined at export — verbatim form can't be guaranteed there.
5. **AI-tailor lane is not yet license-gated.** Today no licensed content can reach it (nothing stamps records until PR-3, and the platform attach UI lands in PR-5, which owns wiring the gate into the AI path). Named gap, not silent.
6. **`resetToCommunityUpdate` / `resolvePristine` emit bank markdown without the gate.** Harmless today — they resolve only against the unlicensed community bank — but when a licensed bank lands (PR-3+), the reset and pristine-swap resolvers must stay gate-covered. Named for the PR-5 checklist (reviewer-agent finding).

## Sequencing

PR-0 (#308, disposition registry) and PR-1 (#309, bank predicates) are in. This is the hard gate: PR-3 (vendoring + parser with per-file license-section detection) may now stamp attribution-class records against this schema.
