### PR TITLE
Vendor the CISA SCuBA baselines and generate the platform procedure bank

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,7 @@
 src/data/communityProcedures.json text eol=lf
 src/stores/comprehensiveAssessmentData.js text eol=lf
 THIRD-PARTY-NOTICES.md text eol=lf
+src/data/platformProcedures.json text eol=lf
+# Vendored upstream content is byte-frozen: any eol conversion would break
+# the sha256 pins in vendor/scuba/MANIFEST.json (verify-vendor-integrity.mjs)
+vendor/scuba/** -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,15 @@ jobs:
       - name: Comprehensive assessment data matches catalog
         run: node scripts/generate-comprehensive-assessment.mjs --check
 
+      # Vendored SCuBA baselines must match their MANIFEST sha256 pins:
+      # editing vendored upstream text is a build failure, never a silent
+      # fork. No network — the pins were recorded at vendoring time.
+      - name: Vendored SCuBA content matches MANIFEST pins
+        run: node scripts/verify-vendor-integrity.mjs
+
+      - name: Platform bank matches vendored baselines
+        run: node scripts/generate-platform-bank.mjs --check
+
       # License gate (plan §7 PR-2): any attribution-obligated bank record
       # missing a complete attribution block, any reference-only record found
       # bundled, or notices drift from the shipped banks fails the build.

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -28,5 +28,6 @@ jobs:
             --exclude 'example\.com'
             --exclude-path node_modules
             --exclude-path vendor
+            --exclude-path _future
             './**/*.md'
           fail: true

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -27,5 +27,6 @@ jobs:
             --exclude 'id\.atlassian\.com'
             --exclude 'example\.com'
             --exclude-path node_modules
+            --exclude-path vendor
             './**/*.md'
           fail: true

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -13,8 +13,2399 @@ The csf_profile source code is licensed under the MIT License (see LICENSE). Fil
 
 This project references MITRE ATT&CK® technique identifiers. ATT&CK® is a registered trademark of The MITRE Corporation; © The MITRE Corporation. ATT&CK content is reproduced and distributed with the permission of The MITRE Corporation, per MITRE's Terms of Use. MITRE does not endorse this project.
 
+### CISA
+
+Portions of this project are derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal. Per the disclaimer those baselines carry, the material is provided "as is" for informational purposes only. CISA and the United States Government do not endorse this project, its authors, or any commercial product or service, and no such endorsement may be inferred. CC0 1.0 does not waive trademark rights: no CISA or DHS marks, seals, or logos are used by this project.
+
 ## Bundled third-party content
 
 ### Community test-procedure bank (src/data/communityProcedures.json)
 
 This bank currently contains no third-party licensed content.
+
+### Platform procedure bank (src/data/platformProcedures.json)
+
+#### gws.assuredcontrols.1.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/assuredcontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/assuredcontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.assuredcontrols.1.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/assuredcontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/assuredcontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.assuredcontrols.2.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/assuredcontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/assuredcontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.calendar.1.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/calendar.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/calendar.md)
+- Retrieved: 2026-07-20
+
+#### gws.calendar.1.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/calendar.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/calendar.md)
+- Retrieved: 2026-07-20
+
+#### gws.calendar.2.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/calendar.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/calendar.md)
+- Retrieved: 2026-07-20
+
+#### gws.calendar.3.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/calendar.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/calendar.md)
+- Retrieved: 2026-07-20
+
+#### gws.calendar.3.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/calendar.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/calendar.md)
+- Retrieved: 2026-07-20
+
+#### gws.calendar.4.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/calendar.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/calendar.md)
+- Retrieved: 2026-07-20
+
+#### gws.chat.1.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/chat.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/chat.md)
+- Retrieved: 2026-07-20
+
+#### gws.chat.1.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/chat.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/chat.md)
+- Retrieved: 2026-07-20
+
+#### gws.chat.2.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/chat.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/chat.md)
+- Retrieved: 2026-07-20
+
+#### gws.chat.3.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/chat.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/chat.md)
+- Retrieved: 2026-07-20
+
+#### gws.chat.4.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/chat.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/chat.md)
+- Retrieved: 2026-07-20
+
+#### gws.chat.5.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/chat.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/chat.md)
+- Retrieved: 2026-07-20
+
+#### gws.chat.5.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/chat.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/chat.md)
+- Retrieved: 2026-07-20
+
+#### gws.classroom.1.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/classroom.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/classroom.md)
+- Retrieved: 2026-07-20
+
+#### gws.classroom.1.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/classroom.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/classroom.md)
+- Retrieved: 2026-07-20
+
+#### gws.classroom.2.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/classroom.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/classroom.md)
+- Retrieved: 2026-07-20
+
+#### gws.classroom.3.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/classroom.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/classroom.md)
+- Retrieved: 2026-07-20
+
+#### gws.classroom.4.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/classroom.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/classroom.md)
+- Retrieved: 2026-07-20
+
+#### gws.classroom.5.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/classroom.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/classroom.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.1.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.1.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.1.3v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.1.4v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.1.5v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.10.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.10.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.10.3v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.10.4v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.10.5v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.11.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.12.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.13.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.14.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.14.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.15.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.15.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.16.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.16.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.16.3v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.16.4v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.17.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.18.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.18.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.2.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.3.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.3.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.4.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.5.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.5.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.5.3v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.5.4v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.5.5v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.5.6v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.6.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.6.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.7.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.8.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.8.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.8.3v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.9.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.commoncontrols.9.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/commoncontrols.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.1.10v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.1.11v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.1.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.1.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.1.3v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.1.4v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.1.5v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.1.6v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.1.7v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.1.8v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.1.9v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.2.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.2.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.3.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.4.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.5.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.drivedocs.5.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/drive.md)
+- Retrieved: 2026-07-20
+
+#### gws.gemini.1.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gemini.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gemini.md)
+- Retrieved: 2026-07-20
+
+#### gws.gemini.2.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gemini.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gemini.md)
+- Retrieved: 2026-07-20
+
+#### gws.gemini.3.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gemini.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gemini.md)
+- Retrieved: 2026-07-20
+
+#### gws.gemini.3.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gemini.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gemini.md)
+- Retrieved: 2026-07-20
+
+#### gws.gemini.4.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gemini.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gemini.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.1.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.10.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.11.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.12.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.13.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.14.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.15.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.16.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.17.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.18.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.18.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.18.3v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.2.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.3.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.4.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.4.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.4.3v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.4.4v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.5.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.5.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.5.3v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.5.4v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.5.5v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.6.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.6.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.6.3v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.6.4v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.7.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.7.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.7.3v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.7.4v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.7.5v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.7.6v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.7.7v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.8.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.gmail.9.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/gmail.md)
+- Retrieved: 2026-07-20
+
+#### gws.groups.1.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/groups.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/groups.md)
+- Retrieved: 2026-07-20
+
+#### gws.groups.1.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/groups.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/groups.md)
+- Retrieved: 2026-07-20
+
+#### gws.groups.1.3v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/groups.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/groups.md)
+- Retrieved: 2026-07-20
+
+#### gws.groups.2.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/groups.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/groups.md)
+- Retrieved: 2026-07-20
+
+#### gws.groups.3.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/groups.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/groups.md)
+- Retrieved: 2026-07-20
+
+#### gws.groups.4.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/groups.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/groups.md)
+- Retrieved: 2026-07-20
+
+#### gws.meet.1.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/meet.md)
+- Retrieved: 2026-07-20
+
+#### gws.meet.2.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/meet.md)
+- Retrieved: 2026-07-20
+
+#### gws.meet.3.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/meet.md)
+- Retrieved: 2026-07-20
+
+#### gws.meet.4.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/meet.md)
+- Retrieved: 2026-07-20
+
+#### gws.meet.5.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/meet.md)
+- Retrieved: 2026-07-20
+
+#### gws.meet.5.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/meet.md)
+- Retrieved: 2026-07-20
+
+#### gws.meet.6.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/meet.md)
+- Retrieved: 2026-07-20
+
+#### gws.meet.6.2v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/meet.md)
+- Retrieved: 2026-07-20
+
+#### gws.sites.1.1v1
+
+- License: CC0-1.0
+- Attribution: Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.
+- Source: https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/sites.md
+- License text: https://creativecommons.org/publicdomain/zero/1.0/
+- Upstream: cisagov/ScubaGoggles@95d80462699e469b569e5b5caf921c4b8c6c884a (scubagoggles/baselines/sites.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.1.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.2.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.2.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.2.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.3.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.3.2v2
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.3.3v2
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.3.4v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.3.5v2
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.3.6v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.3.7v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.3.8v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.3.9v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.4.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.5.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.5.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.5.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.5.5v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.5.6v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.5.7v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.6.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.7.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.7.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.7.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.7.4v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.7.5v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.7.6v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.7.7v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.7.8v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.7.9v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.8.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.8.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.8.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.aad.9.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/aad.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.1.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.1.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.1.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.1.4v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.1.5v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.2.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.2.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.2.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.3.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.4.1v2
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.4.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.4.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.4.4v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.4.5v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.4.6v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.5.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.5.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.6.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.defender.6.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/defender.md)
+- Retrieved: 2026-07-20
+
+#### ms.exo.1.1v2
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/exo.md)
+- Retrieved: 2026-07-20
+
+#### ms.exo.13.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/exo.md)
+- Retrieved: 2026-07-20
+
+#### ms.exo.2.2v3
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/exo.md)
+- Retrieved: 2026-07-20
+
+#### ms.exo.3.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/exo.md)
+- Retrieved: 2026-07-20
+
+#### ms.exo.4.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/exo.md)
+- Retrieved: 2026-07-20
+
+#### ms.exo.4.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/exo.md)
+- Retrieved: 2026-07-20
+
+#### ms.exo.4.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/exo.md)
+- Retrieved: 2026-07-20
+
+#### ms.exo.4.4v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/exo.md)
+- Retrieved: 2026-07-20
+
+#### ms.exo.5.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/exo.md)
+- Retrieved: 2026-07-20
+
+#### ms.exo.6.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/exo.md)
+- Retrieved: 2026-07-20
+
+#### ms.exo.6.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/exo.md)
+- Retrieved: 2026-07-20
+
+#### ms.exo.7.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/exo.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerbi.1.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerbi.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerbi.2.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerbi.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerbi.3.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerbi.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerbi.4.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerbi.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerbi.4.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerbi.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerbi.5.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerbi.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerbi.6.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerbi.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerbi.7.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerbi.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerplatform.1.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerplatform.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerplatform.1.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerplatform.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerplatform.2.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerplatform.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerplatform.2.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerplatform.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerplatform.3.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerplatform.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerplatform.3.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerplatform.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerplatform.4.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerplatform.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerplatform.5.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerplatform.md)
+- Retrieved: 2026-07-20
+
+#### ms.powerplatform.6.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/powerplatform.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.1.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.1.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.1.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.1.4v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.2.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.2.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.2.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.2.4v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.3.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.3.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.3.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.3.4v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.3.5v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.4.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.4.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.5.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.5.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.6.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.6.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.7.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.7.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.7.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.8.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.securitysuite.8.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/securitysuite.md)
+- Retrieved: 2026-07-20
+
+#### ms.sharepoint.1.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/sharepoint.md)
+- Retrieved: 2026-07-20
+
+#### ms.sharepoint.1.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/sharepoint.md)
+- Retrieved: 2026-07-20
+
+#### ms.sharepoint.1.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/sharepoint.md)
+- Retrieved: 2026-07-20
+
+#### ms.sharepoint.2.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/sharepoint.md)
+- Retrieved: 2026-07-20
+
+#### ms.sharepoint.2.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/sharepoint.md)
+- Retrieved: 2026-07-20
+
+#### ms.sharepoint.3.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/sharepoint.md)
+- Retrieved: 2026-07-20
+
+#### ms.sharepoint.3.2v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/sharepoint.md)
+- Retrieved: 2026-07-20
+
+#### ms.sharepoint.3.3v2
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/sharepoint.md)
+- Retrieved: 2026-07-20
+
+#### ms.teams.1.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/teams.md)
+- Retrieved: 2026-07-20
+
+#### ms.teams.1.2v2
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/teams.md)
+- Retrieved: 2026-07-20
+
+#### ms.teams.1.3v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/teams.md)
+- Retrieved: 2026-07-20
+
+#### ms.teams.1.4v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/teams.md)
+- Retrieved: 2026-07-20
+
+#### ms.teams.1.5v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/teams.md)
+- Retrieved: 2026-07-20
+
+#### ms.teams.1.6v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/teams.md)
+- Retrieved: 2026-07-20
+
+#### ms.teams.1.7v2
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/teams.md)
+- Retrieved: 2026-07-20
+
+#### ms.teams.2.1v2
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/teams.md)
+- Retrieved: 2026-07-20
+
+#### ms.teams.2.2v2
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/teams.md)
+- Retrieved: 2026-07-20
+
+#### ms.teams.2.3v2
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/teams.md)
+- Retrieved: 2026-07-20
+
+#### ms.teams.4.1v1
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/teams.md)
+- Retrieved: 2026-07-20
+
+#### ms.teams.5.1v2
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/teams.md)
+- Retrieved: 2026-07-20
+
+#### ms.teams.5.2v2
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/teams.md)
+- Retrieved: 2026-07-20
+
+#### ms.teams.5.3v2
+
+- License: CC0-1.0 AND CC-BY-4.0
+- Attribution: Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).
+- Source: https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md
+- License text: https://creativecommons.org/licenses/by/4.0/
+- Upstream: cisagov/ScubaGear@d7cf55f53fcc7faddde61086581b06da86a8da1d (PowerShell/ScubaGear/baselines/teams.md)
+- Retrieved: 2026-07-20

--- a/scripts/generate-platform-bank.mjs
+++ b/scripts/generate-platform-bank.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Generates src/data/platformProcedures.json — the platform-procedure bank —
+// from the vendored CISA SCuBA baselines under vendor/scuba/ (pinned by
+// MANIFEST.json; integrity enforced by scripts/verify-vendor-integrity.mjs).
+//
+// SECOND bank, separate from communityProcedures.json (plan §7 R-8): one
+// record per SCuBA policy, keyed by lowercased policy ID. Records are
+// reference-shaped (R-3) — the bank holds the full content; observations
+// will reference it (PR-5). No subcategory mapping here — PR-4 owns the
+// 800-53 → CSF join; this bank carries only the raw upstream facts
+// (nist80053[], mitreAttack[]).
+//
+// License metadata is stamped per record from PER-FILE detection
+// (src/utils/scubaBaseline.mjs): the RAW license string + declared
+// obligation components, never the computed classification join. The
+// notices/validation gate (generate-third-party-notices.mjs) enumerates
+// this bank in BANKS and refuses attribution-incomplete or reference-only
+// records at build time; this generator runs the same validation before
+// writing, so a bad corpus can never even reach the tree.
+//
+// Deterministic: entries sorted by ID, no timestamps, no network;
+// bankVersion is a content hash, so re-running against an unchanged vendored
+// tree is byte-identical. retrievedAt values come from MANIFEST.json.
+//
+// Usage:
+//   node scripts/generate-platform-bank.mjs           # write the bank
+//   node scripts/generate-platform-bank.mjs --check   # exit 1 if the
+//       committed bank differs from a fresh generation (CI drift guard)
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { PARSER_VERSION, parseBaselineFile } from '../src/utils/scubaBaseline.mjs';
+import { LICENSE_SCHEMA_VERSION } from '../src/utils/licenseClass.mjs';
+import { validateLicensedRecords } from '../src/utils/thirdPartyNotices.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const VENDOR_DIR = path.join(ROOT, 'vendor', 'scuba');
+const MANIFEST = path.join(VENDOR_DIR, 'MANIFEST.json');
+const OUT = path.join(ROOT, 'src', 'data', 'platformProcedures.json');
+
+const manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+
+if (manifest.parserVersion !== PARSER_VERSION || manifest.licenseSchemaVersion !== LICENSE_SCHEMA_VERSION) {
+  console.error(
+    `MANIFEST version drift: manifest parser=${manifest.parserVersion}/schema=${manifest.licenseSchemaVersion}, ` +
+    `code parser=${PARSER_VERSION}/schema=${LICENSE_SCHEMA_VERSION}.\n` +
+    'Re-run: node scripts/vendor-scuba.mjs --update  (re-stamps the manifest versions)'
+  );
+  process.exit(1);
+}
+
+const procedures = {};
+let censusTotal = 0;
+
+for (const source of manifest.sources) {
+  censusTotal += source.policyCensus;
+  for (const relPath of Object.keys(source.files).sort()) {
+    const fileName = path.basename(relPath);
+    const text = fs.readFileSync(path.join(VENDOR_DIR, relPath), 'utf8');
+    const records = parseBaselineFile(text, {
+      platformId: source.platformId,
+      repo: source.repo,
+      sha: source.sha,
+      baselinesPath: source.baselinesPath,
+      retrievedAt: manifest.retrievedAt,
+      fileName,
+      sourcePath: `vendor/scuba/${relPath}`,
+      licenseId: source.licenseId
+    });
+    for (const record of records) {
+      if (procedures[record.id]) {
+        console.error(`DUPLICATE policy ID across vendored files: ${record.policyId}`);
+        process.exit(1);
+      }
+      procedures[record.id] = record;
+    }
+  }
+}
+
+const ids = Object.keys(procedures).sort();
+
+// The manifest census counts policy headings by regex, independently of the
+// parser — a parser that silently drops policies fails here, not in review.
+if (ids.length !== censusTotal) {
+  console.error(
+    `PARSE LOSS: parser produced ${ids.length} records, manifest census expects ${censusTotal}.`
+  );
+  process.exit(1);
+}
+
+// Same license gate the notices generator enforces — run it BEFORE writing
+// so an attribution-incomplete or reference-only record never reaches src/.
+const errors = validateLicensedRecords([
+  { name: 'platformProcedures (pre-write)', records: procedures }
+]);
+if (errors.length > 0) {
+  console.error('LICENSE GATE FAILED — generated records violate their obligations:');
+  for (const e of errors) console.error(`  - ${e}`);
+  process.exit(1);
+}
+
+const hash = crypto.createHash('sha256');
+for (const id of ids) hash.update(`${id}\n${JSON.stringify(procedures[id])}\n`);
+
+const bank = {
+  bankFormat: 'platform-procedures-v1',
+  bankVersion: hash.digest('hex').slice(0, 16),
+  parserVersion: PARSER_VERSION,
+  licenseSchemaVersion: LICENSE_SCHEMA_VERSION,
+  procedureCount: ids.length,
+  source: 'vendor/scuba',
+  procedures: Object.fromEntries(ids.map((id) => [id, procedures[id]]))
+};
+const output = JSON.stringify(bank, null, 2) + '\n';
+
+if (process.argv.includes('--check')) {
+  const committed = fs.existsSync(OUT) ? fs.readFileSync(OUT, 'utf8') : '';
+  if (committed !== output) {
+    console.error(
+      'DRIFT: src/data/platformProcedures.json does not match vendor/scuba/.\n' +
+      'Run: node scripts/generate-platform-bank.mjs  (and commit the result)'
+    );
+    process.exit(1);
+  }
+  console.log('OK: platform bank matches the vendored baselines.');
+} else {
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  fs.writeFileSync(OUT, output);
+  console.log(`Wrote ${OUT}`);
+  console.log(`  Procedures: ${ids.length}`);
+  console.log(`  bankVersion: ${bank.bankVersion}`);
+}

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -37,6 +37,13 @@ const BANKS = [
       JSON.parse(
         fs.readFileSync(path.join(ROOT, 'src', 'data', 'communityProcedures.json'), 'utf8')
       ).procedures
+  },
+  {
+    name: 'Platform procedure bank (src/data/platformProcedures.json)',
+    load: () =>
+      JSON.parse(
+        fs.readFileSync(path.join(ROOT, 'src', 'data', 'platformProcedures.json'), 'utf8')
+      ).procedures
   }
 ];
 
@@ -44,7 +51,7 @@ const BANKS = [
 // BANKS would be silently un-covered by the license gate — the curated-list
 // rot mode. Any src/data/*.json carrying a bankVersion signature must be
 // declared above.
-const COVERED = new Set(['communityProcedures.json']);
+const COVERED = new Set(['communityProcedures.json', 'platformProcedures.json']);
 const dataDir = path.join(ROOT, 'src', 'data');
 const unregistered = fs.readdirSync(dataDir)
   .filter((f) => f.endsWith('.json') && !COVERED.has(f))

--- a/scripts/vendor-scuba.mjs
+++ b/scripts/vendor-scuba.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+// Vendors the CISA SCuBA secure-configuration-baseline markdown into
+// vendor/scuba/ at PINNED upstream commits. Developer-time tool ONLY — this
+// is the single place in the platform-bank pipeline allowed to touch the
+// network. CI never runs it: scripts/verify-vendor-integrity.mjs recomputes
+// the per-file sha256 values recorded in MANIFEST.json, so editing vendored
+// upstream text (or a drifted re-fetch) is a build failure, not a silent fork.
+//
+// We import the baseline TEXT only (plan §6 item 3): the upstream repos
+// vendor third-party dependencies under their own licenses, so the per-file
+// license detection in src/utils/scubaBaseline.mjs — never the repo-level
+// CC0 label — decides what each record stamps. removedpolicies.md is
+// excluded: it catalogs deprecated policies, which are not procedures.
+//
+// Usage:
+//   node scripts/vendor-scuba.mjs --update   # re-fetch at the pins below
+//
+// To move a pin: update the sha here, run --update, re-run the platform-bank
+// generator, and review the corpus diff like any upstream refresh.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { PARSER_VERSION, POLICY_HEADING } from '../src/utils/scubaBaseline.mjs';
+import { LICENSE_SCHEMA_VERSION } from '../src/utils/licenseClass.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const VENDOR_DIR = path.join(ROOT, 'vendor', 'scuba');
+const MANIFEST = path.join(VENDOR_DIR, 'MANIFEST.json');
+
+const SOURCES = [
+  {
+    platformId: 'google-workspace',
+    repo: 'cisagov/ScubaGoggles',
+    sha: '95d80462699e469b569e5b5caf921c4b8c6c884a',
+    baselinesPath: 'scubagoggles/baselines',
+    vendorDirName: 'scubagoggles',
+    licenseId: 'CC0-1.0'
+  },
+  {
+    platformId: 'microsoft-365',
+    repo: 'cisagov/ScubaGear',
+    sha: 'd7cf55f53fcc7faddde61086581b06da86a8da1d',
+    baselinesPath: 'PowerShell/ScubaGear/baselines',
+    vendorDirName: 'scubagear',
+    licenseId: 'CC0-1.0'
+  }
+];
+
+const EXCLUDED_FILES = new Set(['README.md', 'removedpolicies.md']);
+
+if (!process.argv.includes('--update')) {
+  console.error('This tool re-fetches vendored upstream content. Run with --update to confirm.');
+  process.exit(1);
+}
+
+const fetchText = async (url) => {
+  const res = await fetch(url, { headers: { 'User-Agent': 'csf_profile-vendor-scuba' } });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText} fetching ${url}`);
+  return res.text();
+};
+
+const fetchJson = async (url) => {
+  const res = await fetch(url, { headers: { 'User-Agent': 'csf_profile-vendor-scuba' } });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText} fetching ${url}`);
+  return res.json();
+};
+
+const sha256 = (text) => crypto.createHash('sha256').update(text).digest('hex');
+
+// Independent census: count policy headings by regex, deliberately NOT via
+// the parser. The contract test compares the parser-derived bank count to
+// this manifest census, so a parser that silently drops policies diverges
+// from a number it did not produce.
+const censusPolicies = (text) => {
+  let count = 0;
+  for (const line of text.split('\n')) {
+    if (POLICY_HEADING.test(line.trim())) count++;
+  }
+  return count;
+};
+
+const retrievedAt = new Date().toISOString().slice(0, 10);
+const manifestSources = [];
+
+for (const source of SOURCES) {
+  const listing = await fetchJson(
+    `https://api.github.com/repos/${source.repo}/contents/${source.baselinesPath}?ref=${source.sha}`
+  );
+  const names = listing
+    .filter((e) => e.type === 'file' && e.name.endsWith('.md') && !EXCLUDED_FILES.has(e.name))
+    .map((e) => e.name)
+    .sort();
+
+  const outDir = path.join(VENDOR_DIR, source.vendorDirName, source.sha, 'baselines');
+  fs.rmSync(path.join(VENDOR_DIR, source.vendorDirName), { recursive: true, force: true });
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const files = {};
+  let policyCount = 0;
+  for (const name of names) {
+    const text = await fetchText(
+      `https://raw.githubusercontent.com/${source.repo}/${source.sha}/${source.baselinesPath}/${name}`
+    );
+    fs.writeFileSync(path.join(outDir, name), text);
+    files[`${source.vendorDirName}/${source.sha}/baselines/${name}`] = sha256(text);
+    policyCount += censusPolicies(text);
+    console.log(`  ${source.repo}@${source.sha.slice(0, 7)} ${name} (${censusPolicies(text)} policies)`);
+  }
+
+  manifestSources.push({
+    platformId: source.platformId,
+    repo: source.repo,
+    sha: source.sha,
+    baselinesPath: source.baselinesPath,
+    licenseId: source.licenseId,
+    policyCensus: policyCount,
+    files
+  });
+  console.log(`${source.repo}: ${names.length} files, ${policyCount} policies (census)`);
+}
+
+// The CC0 text ships alongside the vendored content. Both upstream repos
+// carry a verbatim CC0-1.0 LICENSE at repo root.
+const licenseText = await fetchText(
+  `https://raw.githubusercontent.com/${SOURCES[0].repo}/${SOURCES[0].sha}/LICENSE`
+);
+fs.writeFileSync(path.join(VENDOR_DIR, 'LICENSE-CC0-1.0.txt'), licenseText);
+
+const manifest = {
+  manifestFormat: 'scuba-vendor-v1',
+  parserVersion: PARSER_VERSION,
+  licenseSchemaVersion: LICENSE_SCHEMA_VERSION,
+  retrievedAt,
+  note:
+    'Baseline TEXT only is imported (plan §6 item 3). The upstream repos vendor ' +
+    'third-party dependencies under their own licenses; per-file license detection ' +
+    '(src/utils/scubaBaseline.mjs), never the repo-level CC0 label, decides what each ' +
+    'record stamps. removedpolicies.md (deprecated policies) and README.md are excluded.',
+  sources: manifestSources
+};
+
+fs.writeFileSync(MANIFEST, JSON.stringify(manifest, null, 2) + '\n');
+console.log(`Wrote ${MANIFEST}`);

--- a/scripts/verify-vendor-integrity.mjs
+++ b/scripts/verify-vendor-integrity.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Verifies vendor/scuba/ against MANIFEST.json: every manifest-listed file
+// must exist with a matching sha256, and no unlisted markdown may sit in the
+// vendored tree. Editing vendored upstream text — or a partial/drifted
+// re-fetch — is a build failure, never a silent fork of CISA's baselines.
+//
+// Runs in CI (generated-data-sync) with NO network and NO dependencies.
+//
+// Usage: node scripts/verify-vendor-integrity.mjs   (exit 0 = intact, 1 = not)
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const VENDOR_DIR = path.resolve(__dirname, '..', 'vendor', 'scuba');
+const MANIFEST = path.join(VENDOR_DIR, 'MANIFEST.json');
+
+const fail = (msg) => {
+  console.error(`VENDOR INTEGRITY FAILED — ${msg}`);
+  process.exitCode = 1;
+};
+
+if (!fs.existsSync(MANIFEST)) {
+  fail('vendor/scuba/MANIFEST.json is missing.');
+  process.exit(1);
+}
+
+const manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+const listed = new Set();
+
+for (const source of manifest.sources) {
+  for (const [relPath, expected] of Object.entries(source.files)) {
+    listed.add(relPath);
+    const abs = path.join(VENDOR_DIR, relPath);
+    if (!fs.existsSync(abs)) {
+      fail(`listed file missing on disk: vendor/scuba/${relPath}`);
+      continue;
+    }
+    const actual = crypto.createHash('sha256').update(fs.readFileSync(abs)).digest('hex');
+    if (actual !== expected) {
+      fail(
+        `sha256 mismatch for vendor/scuba/${relPath}\n` +
+        `  manifest: ${expected}\n  on disk:  ${actual}\n` +
+        '  Vendored upstream text must not be edited. Re-pin via scripts/vendor-scuba.mjs --update.'
+      );
+    }
+  }
+}
+
+// Unlisted content in the vendored tree is as much a fork as an edit.
+const walk = (dir) =>
+  fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const p = path.join(dir, e.name);
+    return e.isDirectory() ? walk(p) : [p];
+  });
+for (const abs of walk(VENDOR_DIR)) {
+  const rel = path.relative(VENDOR_DIR, abs);
+  if (rel === 'MANIFEST.json' || rel === 'LICENSE-CC0-1.0.txt') continue;
+  if (!listed.has(rel)) fail(`unlisted file in vendored tree: vendor/scuba/${rel}`);
+}
+
+if (process.exitCode !== 1) {
+  const total = listed.size;
+  console.log(`OK: ${total} vendored files match MANIFEST.json sha256 pins.`);
+}

--- a/src/data/platformProcedures.json
+++ b/src/data/platformProcedures.json
@@ -1,0 +1,10690 @@
+{
+  "bankFormat": "platform-procedures-v1",
+  "bankVersion": "9f530721501fd1f0",
+  "parserVersion": 1,
+  "licenseSchemaVersion": 1,
+  "procedureCount": 265,
+  "source": "vendor/scuba",
+  "procedures": {
+    "gws.assuredcontrols.1.1v1": {
+      "id": "gws.assuredcontrols.1.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.ASSUREDCONTROLS.1.1v1",
+      "group": "Google Support Staff Data Access",
+      "groupNumber": 1,
+      "assertion": "Access Approvals SHOULD be enabled.",
+      "obligation": "SHOULD",
+      "rationale": "Unauthorized data access increases the risk of exposing sensitive data to untrusted entities. Unauthorized access and actions to an organization's data may be reduced by requiring approval of Google staff requests to access organizations' data.",
+      "lastModified": "November 2025",
+      "nist80053": [
+        "SC-7(10)(a)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537",
+        "T1589"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin console](https://admin.google.com/) as a super admin.\n2.  Select **Data** -\\> **Compliance** -\\> **Access Approvals**.\n3.  Check the **Require Google staff to request approval before viewing data necessary for support services** box.\n4.  Click **SAVE**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/assuredcontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/assuredcontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/assuredcontrols.md"
+    },
+    "gws.assuredcontrols.1.2v1": {
+      "id": "gws.assuredcontrols.1.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.ASSUREDCONTROLS.1.2v1",
+      "group": "Google Support Staff Data Access",
+      "groupNumber": 1,
+      "assertion": "Agencies SHOULD restrict support access to U.S.-based Google staff only.",
+      "obligation": "SHOULD",
+      "rationale": "This policy prevents data processing by Google personnel located outside of the U.S., reducing potential exposure to unauthorized entities. Implementation of this policy accounts for organizational data sovereignty.",
+      "lastModified": "November 2025",
+      "nist80053": [
+        "SC-7(10)(a)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537",
+        "T1589"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin console](https://admin.google.com/) as a super admin.\n2.  Select **Data** -\\> **Compliance** -\\> **Access Management**.\n3.  Select either **Access by U.S. Google Staff Only** or **Access by CJIS-authorized and IRS 1075-authorized Google staff only**.\n4.  Click **SAVE**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/assuredcontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/assuredcontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/assuredcontrols.md"
+    },
+    "gws.assuredcontrols.2.1v1": {
+      "id": "gws.assuredcontrols.2.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.ASSUREDCONTROLS.2.1v1",
+      "group": "Data Regions Advanced Settings",
+      "groupNumber": 2,
+      "assertion": "Data processing across multiple regions SHOULD be disabled for all Google Workspace products.",
+      "obligation": "SHOULD",
+      "rationale": "This policy prevents data processing in a region other than the United States, reducing potential exposure to unauthorized entities. Implementation of this policy helps prevent agency data from being subject to the laws of other nations.",
+      "lastModified": "November 2025",
+      "nist80053": [
+        "SC-7(10)(a)"
+      ],
+      "mitreAttack": [
+        "T1591",
+        "T1591.001",
+        "T1530",
+        "T1537"
+      ],
+      "instructions": "1. Sign in to the [Google Admin Console](https://admin.google.com/) as an administrator.\n2. Navigate to **Data** -\\> **Compliance** -\\> **Data Regions** -\\> **Advanced Settings**.\n3. Select **Calendar** and choose **Disable features that may process data across multiple regions**, then click **SAVE**.\n4. Select **Drive Docs** and choose **Disable features that may process data across multiple regions**, then click **SAVE**.\n5. Select **Gmail** and choose **Disable features that may process data across multiple regions**, then click **SAVE**.\n6. Select **Google Chat and classic Hangouts**, choose **Disable features that may process data across multiple regions**, and click **SAVE**.\n7. Select **Google Meet** and choose **Disable features that may process data across multiple regions**, then click **SAVE**.\n8. Select **Gemini app and Gemini in Google Workspace apps**, choose **Disable features that may process data across multiple regions**, and click **SAVE**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/assuredcontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/assuredcontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/assuredcontrols.md"
+    },
+    "gws.calendar.1.1v1": {
+      "id": "gws.calendar.1.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CALENDAR.1.1v1",
+      "group": "External Sharing Options",
+      "groupNumber": 1,
+      "assertion": "External sharing options for primary calendars SHALL be configured to \"Only free/busy information (hide event details).\"",
+      "obligation": "SHALL",
+      "rationale": "Calendars can contain private or otherwise sensitive information. Restricting calendar details to \"only free/busy information (hide event details)\" helps prevent data leakage by restricting the amount of information that is viewable when a user shares their calendar with someone external to the organization.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-3",
+        "SC-7(10)(a)"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Calendar**.\n3.  Select **Sharing settings** -\\> **External sharing options for primary calendars**.\n4.  Select **Only free/busy information (hide event details)**.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/calendar.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/calendar.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/calendar.md"
+    },
+    "gws.calendar.1.2v1": {
+      "id": "gws.calendar.1.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CALENDAR.1.2v1",
+      "group": "External Sharing Options",
+      "groupNumber": 1,
+      "assertion": "External sharing options for secondary calendars SHALL be configured to \"Only free/busy information (hide event details).\"",
+      "obligation": "SHALL",
+      "rationale": "Calendars can contain private or otherwise sensitive information. Restricting calendar details to \"only free/busy information (hide event details)\" helps prevent data leakage by restricting the amount of information that is viewable when a user shares their calendar with someone external to the organization.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-3",
+        "SC-7(10)(a)"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "instructions": "To configure the settings for External Sharing in secondary calendars:\n\n1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Calendar**.\n3.  Select **General settings -\\> External sharing options for secondary calendars**.\n4.  Select **Only free/busy information (hide event details)**.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/calendar.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/calendar.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/calendar.md"
+    },
+    "gws.calendar.2.1v1": {
+      "id": "gws.calendar.2.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CALENDAR.2.1v1",
+      "group": "External Invitations Warnings",
+      "groupNumber": 2,
+      "assertion": "External invitations warnings SHALL be enabled to prompt users before sending invitations.",
+      "obligation": "SHALL",
+      "rationale": "Users may inadvertently include external guests in calendar event invitations, potentially resulting in data leakage. Warning users when external participants are included can help reduce this risk.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AT-2b"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1566.003"
+      ],
+      "instructions": "To configure the settings for Confidential Mode:\n\n1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Calendar**.\n3.  Select **Sharing settings** -\\> **External Invitations**.\n4.  Check the **Warn users when inviting guests outside of the domain** checkbox.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/calendar.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/calendar.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/calendar.md"
+    },
+    "gws.calendar.3.1v1": {
+      "id": "gws.calendar.3.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CALENDAR.3.1v1",
+      "group": "Calendar Interop Management",
+      "groupNumber": 3,
+      "assertion": "Calendar Interop SHOULD be disabled.",
+      "obligation": "SHOULD",
+      "rationale": "Enabling Calendar interop adds a layer of complexity to calendar management, possibly increasing the attack surface. Disabling this feature (unless required by the organization) conforms to the principle of least functionality.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1199"
+      ],
+      "note": "This policy applies unless agency mission fulfillment requires collaboration between internal and external users who both utilize Microsoft Exchange and Google Calendar",
+      "instructions": "To configure the settings for Calendar Interop:\n\n1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Calendar**.\n3.  Select **Calendar Interop management**.\n4.  Select **Exchange availability in Calendar**.\n5.  Uncheck the **Allow Google Calendar to display Exchange users' availability** checkbox.\n6.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/calendar.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/calendar.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/calendar.md"
+    },
+    "gws.calendar.3.2v1": {
+      "id": "gws.calendar.3.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CALENDAR.3.2v1",
+      "group": "Calendar Interop Management",
+      "groupNumber": 3,
+      "assertion": "Microsoft 365 (Graph API) SHALL be used instead of basic authentication to establish connectivity between tenants or organizations in cases where Calendar Interop is deemed necessary for agency mission fulfillment.",
+      "obligation": "SHALL",
+      "rationale": "Basic authentication is a deprecated and risk-prone authentication method. The Microsoft 365 (Graph API) helps reduce the risk of credential compromise.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ],
+      "mitreAttack": [
+        "T1555"
+      ],
+      "instructions": "To configure the settings for Calendar Interop:\n\n1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Calendar**.\n3.  Select **Calendar Interop management**.\n4.  Select **Exchange availability in Calendar**.\n5.  Check the **Allow Google Calendar to display Exchange users' availability** checkbox.\n6.  Select **Add an Exchange endpoint**.\n7.  Select **Microsoft 365 (Graph API)** as the endpoint type.\n8.  Enter the applicable **Exchange domain names**, **Exchange role accounts**, **Tenant ID**, **Application (client) ID**, and **Client secret**.\n9.  Click **Add**.\n10. Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/calendar.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/calendar.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/calendar.md"
+    },
+    "gws.calendar.4.1v1": {
+      "id": "gws.calendar.4.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CALENDAR.4.1v1",
+      "group": "Paid Appointments",
+      "groupNumber": 4,
+      "assertion": "\"Appointment Schedule with Payments\" SHOULD be disabled.",
+      "obligation": "SHOULD",
+      "rationale": "Enabling paid appointments adds a layer of complexity to calendar management, possibly increasing the attack surface. Disabling this feature conforms to the principle of least functionality.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1199"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Calendar**.\n3.  Select **Advanced settings -\\> Appointment schedules with payments**.\n4.  Ensure the **Allow appointment schedule users to require payments for booked appointments through their own payment provider accounts** checkbox is unchecked.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/calendar.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/calendar.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/calendar.md"
+    },
+    "gws.chat.1.1v1": {
+      "id": "gws.chat.1.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CHAT.1.1v1",
+      "group": "Chat History",
+      "groupNumber": 1,
+      "assertion": "Chat history SHALL be enabled for information traceability.",
+      "obligation": "SHALL",
+      "rationale": "Google Chat users may inadvertently share sensitive or private information during conversations. Preservation of chat history may be crucial if details discussed in chats are needed for future reference or dispute resolution. Enabling chat history for Google Chat may mitigate these risks by providing a traceable record of all conversations, enhancing information traceability and security.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AU-2",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.001"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Google Chat**.\n3.  Select **History for chats**.\n4.  Select **History is ON**.\n5.  Select **Save**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/chat.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/chat.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/chat.md"
+    },
+    "gws.chat.1.2v1": {
+      "id": "gws.chat.1.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CHAT.1.2v1",
+      "group": "Chat History",
+      "groupNumber": 1,
+      "assertion": "Users SHALL NOT be allowed to change their history setting.",
+      "obligation": "SHALL NOT",
+      "rationale": "Altering the Google Chat history settings can potentially allow users to obfuscate the sharing of sensitive information via Chat. This policy helps preserve all Google Chat histories, enhancing data security and promoting accountability among users.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AU-9"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.001"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Google Chat**.\n3.  Select **History for chats**.\n4.  Uncheck the **Allow users to change their history setting** checkbox.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/chat.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/chat.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/chat.md"
+    },
+    "gws.chat.2.1v1": {
+      "id": "gws.chat.2.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CHAT.2.1v1",
+      "group": "External File Sharing",
+      "groupNumber": 2,
+      "assertion": "External file sharing SHALL be disabled to protect sensitive information from unauthorized or accidental sharing.",
+      "obligation": "SHALL",
+      "rationale": "Enabling external file sharing in Google Chat opens an avenue for data loss that may not be as rigorously monitored or protected as traditional collaboration channels, such as email. This policy limits the potential for unauthorized or accidental sharing.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-3",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1048",
+        "T1048.002"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Google Chat**.\n3.  Select **Chat file sharing**.\n4.  In the **External file sharing** dropdown menu, select **No files.**\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/chat.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/chat.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/chat.md"
+    },
+    "gws.chat.3.1v1": {
+      "id": "gws.chat.3.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CHAT.3.1v1",
+      "group": "History for Spaces",
+      "groupNumber": 3,
+      "assertion": "Space history SHOULD be enabled for information traceability.",
+      "obligation": "SHOULD",
+      "rationale": "Google Chat users may inadvertently share sensitive or private information during conversations. Preservation of chat history may be crucial if details discussed in chats are needed for future reference or dispute resolution. Enabling chat history for Google Chat may mitigate these risks by providing a traceable record of all conversations, enhancing information traceability and security.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AU-2",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.001"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Google Chat**.\n3.  Select **History for spaces**.\n4.  Select **History is ALWAYS ON**.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/chat.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/chat.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/chat.md"
+    },
+    "gws.chat.4.1v1": {
+      "id": "gws.chat.4.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CHAT.4.1v1",
+      "group": "External Chat Messaging",
+      "groupNumber": 4,
+      "assertion": "External chat messaging SHALL be restricted to allowlisted domains only.",
+      "obligation": "SHALL",
+      "rationale": "Allowing Google Chat external chat messaging to unrestricted domains opens additional avenues for data exfiltration, increasing the risk of data leakage. Restricting external chat messaging to only allowlisted domains helps minimize the risk of sensitive information being shared outside the organization without explicit consent and approval.",
+      "lastModified": "November 2023",
+      "nist80053": [
+        "AC-3"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1213.005"
+      ],
+      "instructions": "To enable external chat for allowlisted domains only:\n1. Sign in to the [Google Admin Console](https://admin.google.com).\n2. Select **Apps** -\\> **Google Workspace** -\\> **Google Chat**.\n3. Select **External chat settings** -\\> **Chat externally**.\n4. Select **ON**.\n5. Select **Only allow this for allowlisted domains**.\n6. To add allowlisted domains select **Manage allowlisted domains**.\n7. Select **Save**.\n\nAlternatively, to disable external chat entirely:\n1. Sign in to the [Google Admin Console](https://admin.google.com).\n2. Select **Apps** -\\> **Google Workspace** -\\> **Google Chat**.\n3. Select **External chat settings** -\\> **Chat externally**.\n4. Select **OFF**.\n5. Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/chat.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/chat.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/chat.md"
+    },
+    "gws.chat.5.1v1": {
+      "id": "gws.chat.5.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CHAT.5.1v1",
+      "group": "Content Reporting",
+      "groupNumber": 5,
+      "assertion": "Chat content reporting SHALL be enabled for all conversation types.",
+      "obligation": "SHALL",
+      "rationale": "Chat messages could be used as an avenue for phishing, malware distribution, or other security risks. Enabling this feature allows users to report any suspicious messages to Google Workspace (GWS) admins, increasing threat awareness and facilitating threat mitigation. By selecting all conversation types, agencies help enable their users to report risky messages regardless of the conversation type.",
+      "lastModified": "February 2024",
+      "nist80053": [
+        "IR-6"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Chat**.\n3.  Click **Manage content reporting** then **Content reporting**.\n4.  Ensure **Allow users to report content in Chat** is enabled.\n5.  Ensure all conversation type checkboxes are selected.\n6.  Click **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/chat.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/chat.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/chat.md"
+    },
+    "gws.chat.5.2v1": {
+      "id": "gws.chat.5.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CHAT.5.2v1",
+      "group": "Content Reporting",
+      "groupNumber": 5,
+      "assertion": "All reporting message categories SHOULD be selected.",
+      "obligation": "SHOULD",
+      "rationale": "Users may be uncertain about what kind of messages should be reported. Enabling all message categories can help users determine which types of messages should be reported.",
+      "lastModified": "February 2024",
+      "nist80053": [
+        "IR-6"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Chat**.\n3.  Click **Manage content reporting** then **Content reporting**.\n4.  Ensure all checkboxes under **Reporting categories** are selected.\n5.  Click **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/chat.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/chat.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/chat.md"
+    },
+    "gws.classroom.1.1v1": {
+      "id": "gws.classroom.1.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CLASSROOM.1.1v1",
+      "group": "Class Membership",
+      "groupNumber": 1,
+      "assertion": "\"Who can join classes in your domain\" SHOULD be set to \"Users in your domain only.\"",
+      "obligation": "SHOULD",
+      "rationale": "Classes can contain personally identifiable information (PII) or sensitive information. Restricting access to the organization's classes helps prevent data leakage resulting from unauthorized classroom access.",
+      "lastModified": "April 2026",
+      "nist80053": [
+        "AC-3"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537"
+      ],
+      "instructions": "1.  For **Who can join classes in your domain**, select **Users in your domain only**.\n2.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/classroom.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/classroom.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/classroom.md"
+    },
+    "gws.classroom.1.2v1": {
+      "id": "gws.classroom.1.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CLASSROOM.1.2v1",
+      "group": "Class Membership",
+      "groupNumber": 1,
+      "assertion": "\"Which classes users in your domain can join\" SHOULD be set to \"Classes in your domain only.\"",
+      "obligation": "SHOULD",
+      "rationale": "Allowing users to join classes from outside the organization's domains could allow data to be exfiltrated to entities outside the organization's control, potentially creating a significant security risk.",
+      "lastModified": "April 2026",
+      "nist80053": [
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537"
+      ],
+      "instructions": "1.  For **Which classes can users in your domain join**, select **Classes in your domain only**.\n2.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/classroom.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/classroom.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/classroom.md"
+    },
+    "gws.classroom.2.1v1": {
+      "id": "gws.classroom.2.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CLASSROOM.2.1v1",
+      "group": "Classroom API",
+      "groupNumber": 2,
+      "assertion": "Users SHOULD NOT be able to authorize apps to access their Google Classroom data.",
+      "obligation": "SHOULD NOT",
+      "rationale": "Allowing non-administrator users to authorize apps granting access to classroom data opens a possibility for data loss. Allowing only administrators to authorize application access reduces this risk.",
+      "lastModified": "September 2023",
+      "nist80053": [
+        "AC-6(10)"
+      ],
+      "mitreAttack": [
+        "T1059",
+        "T1059.009",
+        "T1199"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Additional Google Service** -\\> **Classroom**.\n3.  Select **Data access**.\n4.  Uncheck **Users can authorize apps to access their Google Classroom data**.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/classroom.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/classroom.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/classroom.md"
+    },
+    "gws.classroom.3.1v1": {
+      "id": "gws.classroom.3.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CLASSROOM.3.1v1",
+      "group": "Roster Import",
+      "groupNumber": 3,
+      "assertion": "\"Roster Import\" with Clever SHOULD be turned off.",
+      "obligation": "SHOULD",
+      "rationale": "If an organization does not use Clever, allowing roster imports could create a way for unauthorized data to be incorporated into the organization's environment. If an organization does use Clever, then roster imports may be enabled.",
+      "lastModified": "April 2026",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1199"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Additional Google Service** -\\> **Classroom**.\n3.  Select **Roster import**.\n4.  Select **OFF**.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/classroom.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/classroom.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/classroom.md"
+    },
+    "gws.classroom.4.1v1": {
+      "id": "gws.classroom.4.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CLASSROOM.4.1v1",
+      "group": "Student Unenrollment",
+      "groupNumber": 4,
+      "assertion": "Only teachers SHOULD be allowed to unenroll students from classes.",
+      "obligation": "SHOULD",
+      "rationale": "Allowing students to unenroll themselves from classes within Google Classroom creates the opportunity for data loss or other inconsistencies, especially for K-12 classrooms. Restricting this ability to teachers mitigates this risk.",
+      "lastModified": "April 2026",
+      "nist80053": [
+        "AC-6(10)"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Additional Google Service** -\\> **Classroom**.\n3.  Select **Student unenrollment**.\n4.  Select **Teachers only**.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/classroom.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/classroom.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/classroom.md"
+    },
+    "gws.classroom.5.1v1": {
+      "id": "gws.classroom.5.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.CLASSROOM.5.1v1",
+      "group": "Class Creation",
+      "groupNumber": 5,
+      "assertion": "Class creation SHOULD be restricted to verified teachers only.",
+      "obligation": "SHOULD",
+      "rationale": "Allowing \"pending teachers\" to create classes could potentially allow students to impersonate teachers. This could result in exploiting the trusted relationship between teacher and student, such as if the role was used to phish sensitive information from other students. Restricting class creation to verified teachers reduces this risk.",
+      "lastModified": "April 2026",
+      "nist80053": [
+        "AC-6(5)",
+        "AC-6(10)"
+      ],
+      "mitreAttack": [
+        "T1656",
+        "T1534",
+        "T1598",
+        "T1598.002",
+        "T1598.003",
+        "T1598.004"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Additional Google Service** -\\> **Classroom**.\n3.  Select **General settings**.\n4.  Select **Teacher permissions**.\n5.  Select **Verified teachers only** for **Who can create classes?**\n6.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/classroom.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/classroom.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/classroom.md"
+    },
+    "gws.commoncontrols.1.1v1": {
+      "id": "gws.commoncontrols.1.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.1.1v1",
+      "group": "Phishing-Resistant Multifactor Authentication",
+      "groupNumber": 1,
+      "assertion": "Phishing-Resistant MFA SHALL be required for all users.",
+      "obligation": "SHALL",
+      "rationale": "Weaker forms of MFA do not protect against sophisticated phishing attacks. Enforcing phishing-resistant MFA methods reduces those risks. Additionally, the Office of Management and Budget (OMB) Memorandum M-22-09, “Moving the U.S. Government Toward Zero Trust Cybersecurity Principles,” requires phishing-resistant MFA for FCEB agency staff, contractors, and partners.",
+      "lastModified": "January 2025",
+      "nist80053": [
+        "IA-2(1)",
+        "IA-2(2)",
+        "IA-5c",
+        "IA-5g",
+        "IA-2(8)"
+      ],
+      "mitreAttack": [
+        "T1621",
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003",
+        "T1556",
+        "T1556.006",
+        "T1566",
+        "T1566.001"
+      ],
+      "details": "> Phishing-resistant methods:\n            - FIDO2 Security Key (directly in Google Workspace)\n            - Phone as Security Key\n            - FIDO2 Security Key (Federated from Identity Provider)\n            - Federal Personal Identity Verification (PIV) card (Federated from agency Active Directory or other identity provider).\n            - Google Passkeys",
+      "instructions": "1.  Under **Authentication**, ensure that **Allow users to turn on 2-Step Verification** is checked.\n2.  Set **Enforcement** to **On.**\n3.  Under **Methods** select **Only security key.**\n4.  Under **Security codes** select **Don't allow users to select security codes.**\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.1.2v1": {
+      "id": "gws.commoncontrols.1.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.1.2v1",
+      "group": "Phishing-Resistant Multifactor Authentication",
+      "groupNumber": 1,
+      "assertion": "If phishing-resistant MFA has not been enforced, an alternative MFA method SHALL be enforced for all users.",
+      "obligation": "SHALL",
+      "rationale": "This is a stopgap security policy to help protect the tenant if phishing-resistant MFA has not been enforced. This policy requires MFA enforcement, thus reducing single-form authentication risk.",
+      "lastModified": "April 2025",
+      "nist80053": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ],
+      "mitreAttack": [
+        "T1621",
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003",
+        "T1556",
+        "T1556.006",
+        "T1566",
+        "T1566.001"
+      ],
+      "instructions": "1.  Under **Authentication**, ensure that **Allow users to turn on 2-Step Verification** is checked.\n2.  Set **Enforcement** to **On**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.1.3v1": {
+      "id": "gws.commoncontrols.1.3v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.1.3v1",
+      "group": "Phishing-Resistant Multifactor Authentication",
+      "groupNumber": 1,
+      "assertion": "SMS or Voice SHALL NOT be used as the MFA method.",
+      "obligation": "SHALL NOT",
+      "rationale": "Weaker forms of MFA, such as SMS or Voice, do not protect against sophisticated phishing attacks. Enforcing methods phishing-resistant reduces those risks. Additionally, OMB M-22-09 requires phishing-resistant MFA for FCEB agency staff, contractors, and partners.",
+      "lastModified": "April 2025",
+      "nist80053": [
+        "CM-7b",
+        "IA-5c"
+      ],
+      "mitreAttack": [
+        "T1621",
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003",
+        "T1556",
+        "T1556.006",
+        "T1566",
+        "T1566.001"
+      ],
+      "instructions": "1.  Under **Methods**, select **Any except verification codes via text, phone call**.\n2.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.1.4v1": {
+      "id": "gws.commoncontrols.1.4v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.1.4v1",
+      "group": "Phishing-Resistant Multifactor Authentication",
+      "groupNumber": 1,
+      "assertion": "The Google 2-Step Verification (2SV) new user enrollment period SHALL be set to at least one day and at most one week.",
+      "obligation": "SHALL",
+      "rationale": "Enrollment must be enforced within a reasonable timeframe. One week balances the need for allowing new personnel time to set up their authentication methods while minimizing the risks inherent to not enforcing MFA immediately.",
+      "lastModified": "April 2025",
+      "nist80053": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ],
+      "mitreAttack": [
+        "T1621",
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003",
+        "T1556",
+        "T1556.006",
+        "T1566",
+        "T1566.001"
+      ],
+      "instructions": "1.  Set **New user enrollment** period to at least **1 Day** or at most **1 Week**.\n2.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.1.5v1": {
+      "id": "gws.commoncontrols.1.5v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.1.5v1",
+      "group": "Phishing-Resistant Multifactor Authentication",
+      "groupNumber": 1,
+      "assertion": "Allow users to trust the device SHALL be disabled.",
+      "obligation": "SHALL",
+      "rationale": "Trusting the device allows users to bypass 2-Step Verification (2SV) for future logins on that device. Disabling this option makes it possible for multifactor authentication (MFA) to protect future logins on the device.",
+      "lastModified": "February 2025",
+      "nist80053": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ],
+      "mitreAttack": [
+        "T1621",
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003",
+        "T1556",
+        "T1556.006",
+        "T1566",
+        "T1566.001"
+      ],
+      "instructions": "1.  Under Frequency, deselect the **Allow user to trust device** checkbox.\n2.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.10.1v1": {
+      "id": "gws.commoncontrols.10.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.10.1v1",
+      "group": "App Access to Google APIs",
+      "groupNumber": 10,
+      "assertion": "Agencies SHALL use GWS application access control policies to restrict access to all GWS services by third-party applications.",
+      "obligation": "SHALL",
+      "rationale": "Third-party applications may include malicious content. Restricting application access to only trusted applications reduces the risk of malicious applications connecting to GWS.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-3"
+      ],
+      "mitreAttack": [
+        "T1550",
+        "T1550.001",
+        "T1195",
+        "T1195.002",
+        "T1059",
+        "T1059.009"
+      ],
+      "instructions": "1.  Sign in to [Google Admin console](https://admin.google.com).\n2.  Go to **Security** -\\> **Access and Data Control** -\\> **API controls.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.10.2v1": {
+      "id": "gws.commoncontrols.10.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.10.2v1",
+      "group": "App Access to Google APIs",
+      "groupNumber": 10,
+      "assertion": "Agencies SHALL NOT allow users to grant consent for access to low-risk scopes.",
+      "obligation": "SHALL NOT",
+      "rationale": "Allowing users to grant access to OAuth scopes not classified as high-risk could enable untrusted applications to gain access without non-administrative approval being allowlisted, violating policy 10.1.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-6"
+      ],
+      "mitreAttack": [
+        "T1550",
+        "T1550.001",
+        "T1195",
+        "T1195.002",
+        "T1059",
+        "T1059.009"
+      ],
+      "instructions": "1.  Sign in to [Google Admin console](https://admin.google.com).\n2.  Go to **Security** -\\> **Access and Data Control** -\\> **API controls.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.10.3v1": {
+      "id": "gws.commoncontrols.10.3v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.10.3v1",
+      "group": "App Access to Google APIs",
+      "groupNumber": 10,
+      "assertion": "Agencies SHALL NOT trust unconfigured internal applications.",
+      "obligation": "SHALL NOT",
+      "rationale": "Internal applications may contain vulnerabilities or malicious content created by compromised user accounts. Restricting access to these applications reduces the risk of unsafe applications connecting to GWS.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-3"
+      ],
+      "mitreAttack": [
+        "T1550",
+        "T1550.001",
+        "T1195",
+        "T1195.002",
+        "T1059",
+        "T1059.009"
+      ],
+      "instructions": "1.  Select **Settings.**\n2.  Select **Internal apps** and uncheck the box next to **Trust internal apps.**\n3.  Select **SAVE.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.10.4v1": {
+      "id": "gws.commoncontrols.10.4v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.10.4v1",
+      "group": "App Access to Google APIs",
+      "groupNumber": 10,
+      "assertion": "Agencies SHALL NOT allow users to access unconfigured third-party applications.",
+      "obligation": "SHALL NOT",
+      "rationale": "External applications may contain vulnerabilities and malicious content. Restricting access to these applications reduces the risk of unsafe applications connecting to GWS.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-3"
+      ],
+      "mitreAttack": [
+        "T1550",
+        "T1550.001",
+        "T1195",
+        "T1195.002",
+        "T1059",
+        "T1059.009"
+      ],
+      "instructions": "1.  Select **Settings.**\n2.  Select **Unconfigured third-party apps** and select **Don't allow users to access any third-party apps**\n3.  Select **SAVE.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.10.5v1": {
+      "id": "gws.commoncontrols.10.5v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.10.5v1",
+      "group": "App Access to Google APIs",
+      "groupNumber": 10,
+      "assertion": "Access to GWS applications by less secure applications that do not meet security authentication standards SHALL be prevented.",
+      "obligation": "SHALL",
+      "rationale": "Antiquated authentication methods introduce additional risk into the GWS environment. Allowing only applications using modern authentication standards helps reduce the risk of credential compromise.",
+      "lastModified": "January 2025",
+      "nist80053": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003",
+        "T1566",
+        "T1566.002"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin console](https://admin.google.com) as an administrator.\n2.  Select **Security** -\\> **Overview**.\n3.  Select **Less Secure Apps**.\n4.  Select **Disable access to less secure apps (Recommended)**.\n5.  Click **Save** to commit this configuration change.\n\nIt should be noted that administrators will have to manually approve each trusted application. The implementation steps for this activity are outlined in Google's [documentation on controlling which third-party & internal apps access GWS data](https://support.google.com/a/answer/7281227) (also listed under Resources).",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.11.1v1": {
+      "id": "gws.commoncontrols.11.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.11.1v1",
+      "group": "Authorized Google Marketplace Apps",
+      "groupNumber": 11,
+      "assertion": "Only approved Google Workspace (GWS) Marketplace applications SHALL be allowed for installation.",
+      "obligation": "SHALL",
+      "rationale": "Marketplace applications may include malicious content. Restricting application access to only organization-trusted applications reduces the risk of malicious applications connecting to GWS.",
+      "lastModified": "October 2023",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1195",
+        "T1195.002"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin console](https://admin.google.com) as an administrator.\n2.  Select **Apps** -\\> **Google Workspace Marketplace apps** -\\> **Settings.**\n3.  Select **Allow users to install and run allowlisted apps from the Marketplace.**\n4.  Ensure that the **Allow exception for internal apps. Users can install and run any internal app, even if it's not allowlisted** checkbox is unchecked.\n5.  Click **Save.**\n\nTo add an application to the allowlist:\n1.  On the left-hand side above **Setting,** click **Apps lists.**\n2.  Click the **ALLOWLIST APP** to add an application to the allowlist.\n\n    or\n\n3.  Click **Allowlisted Apps** to manage the allowlist.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.12.1v1": {
+      "id": "gws.commoncontrols.12.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.12.1v1",
+      "group": "Google Takeout Services for Users",
+      "groupNumber": 12,
+      "assertion": "Google Takeout services SHALL be disabled.",
+      "obligation": "SHALL",
+      "rationale": "Google Takeout is a service that allows users to download a copy of their data stored within 40+ Google products and services, including data from Gmail, Drive, Photos, and Calendar. While there may be a valid use case for users to back up their data in non-enterprise settings, this feature represents considerable attack surface as a mass data exfiltration mechanism, particularly in enterprise settings where other backup mechanisms are likely in use.",
+      "lastModified": "January 2025",
+      "nist80053": [
+        "CM-7",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "instructions": "1.  Sign in to [Google Admin console](https://admin.google.com).\n2.  Select **Data** -\\> **Data import and export** -\\> **Google Takeout**.\n3.  Select **User access to Takeout for Google services**.\n4.  For services without an individual administrator control, select **Services without an individual administrator control** then **Edit**.\n5.  Select **Don't allow for everyone**.\n6.  Click **Save**.\n7.  For services with an individual administrator control, under **Applications** select the checkbox next to **Service name** and select **Don't allow**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.13.1v1": {
+      "id": "gws.commoncontrols.13.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.13.1v1",
+      "group": "System-defined Rules",
+      "groupNumber": 13,
+      "assertion": "Required system-defined alerting rules, as listed in the policy group description, SHALL be enabled with alerts.",
+      "obligation": "SHALL",
+      "rationale": "Potentially malicious or service-impacting events may go undetected. Setting up a mechanism to alert administrators to the required system-defined events draws attention to these events while minimizing any user or organizational impact.",
+      "lastModified": "January 2025",
+      "nist80053": [
+        "SI-4(5)"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.001"
+      ],
+      "note": "Any system-defined rules not listed are considered optional but should be reviewed and considered for activation by an administrator.",
+      "instructions": "1.\tSign in to the [Google Admin console](https://admin.google.com) as an administrator.\n2.  Click **Rules**.\n3.  From the Rules page, click **Add a filter**.\n4.  From the drop-down menu, select **Type**.\n5.  Select the **System defined** check box.\n6.  Click **Apply**.\n7.  A list of system-defined rules will appear. For each of the rules listed above, edit the configuration:\n    1.  Select the rule by clicking the table row for the rule.\n    2.  Select **Actions**.\n    3.  From the Actions page, configure the **Severity** for the alert to High, Medium, or Low, and select **Send to alert center** if available. If alerts are not available or supported, select **Send email notifications** and specify recipients for those notifications.\n    4.  Click **Next: Review**.\n    5.  Review the updated rule details, and then click **Update Rule**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.14.1v1": {
+      "id": "gws.commoncontrols.14.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.14.1v1",
+      "group": "Google Workspace Logs",
+      "groupNumber": 14,
+      "assertion": "The following critical logs SHALL be sent to the agency's centralized SIEM.",
+      "obligation": "SHALL",
+      "rationale": "This policy enhances security by centralizing critical logs in the agency's Security Information and Event Management (SIEM) system, enabling timely detection and response to potential security incidents. It also aids agency compliance with applicable laws and binding policy, and helps maintain the confidentiality, integrity, and availability of the agency's information systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-4(5)"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.008"
+      ],
+      "details": "> Admin Audit logs\n        > Enterprise Groups Audit logs\n        > Login Audit logs\n        > OAuth Token Audit logs\n        > SAML Audit log\n        > Context Aware Access logs",
+      "instructions": "Follow the configuration instructions unique to the products and integration patterns at your organization to send the security logs to the security operations center for monitoring.\n\nNote: Agencies can benefit from security detection capabilities offered by the CISA Cloud Log Aggregation Warehouse (CLAW) system. Agencies are urged to send the logs to CLAW. Contact CISA at [cyberliason@cisa.dhs.gov]",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.14.2v1": {
+      "id": "gws.commoncontrols.14.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.14.2v1",
+      "group": "Google Workspace Logs",
+      "groupNumber": 14,
+      "assertion": "Audit logs SHALL be retained and searchable for a minimum of 3 months and retrievable for a minimum of 12 months.",
+      "obligation": "SHALL",
+      "rationale": "Audit logs should be retained for a sufficient duration to ensure availability when needed. Extending log retention provides an agency with the necessary visibility to investigate incidents that occurred in the past. Additionally, the Office of Management and Budget (OMB) Memorandum M-26-14, \"Ensuring Effective and Efficient Agency Logging and Network Visibility to Defend Against Evolving Cyber Threats\", establishes data retention times that are dependent on the \"maturity level\" and targets for when those maturity levels should be reached, contingent on CISA publishing a logging reference architecture (LRA).",
+      "lastModified": "June 2026",
+      "nist80053": [
+        "AU-11"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.008"
+      ],
+      "note": "Google offers the ability to export certain logs to Google BiqQuery or Google Cloud log buckets for an additional cost. Though these tools could be used to satisfy this baseline requirement, agencies may use the tool that best fits their individual circumstances.",
+      "instructions": "1.  There is no implementation for this policy.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.15.1v1": {
+      "id": "gws.commoncontrols.15.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.15.1v1",
+      "group": "Data Regions and Storage",
+      "groupNumber": 15,
+      "assertion": "The data storage region SHALL be set to be the United States for all users in the agency's GWS environment.",
+      "obligation": "SHALL",
+      "rationale": "Without this policy, data could be stored in various regions, potentially exposing it to unauthorized entities. Implementing this policy keeps most data in the United States, making it harder for potential threat actors to compromise data.",
+      "lastModified": "January 2025",
+      "nist80053": [
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1591",
+        "T1591.001",
+        "T1530",
+        "T1537"
+      ],
+      "instructions": "To configure Data Regions per the policy:\n1.\tSign in to the [Google Admin console](https://admin.google.com) as an administrator.\n2.\tNavigate to **Data** -\\> **Compliance** -\\> **Data Regions.**\n3.\tClick the **Region** card.\n4.\tClick the **Data at rest** card.\n5.\tSelect the radio button option: \"**United States.**\"\n6.\tClick **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.15.2v1": {
+      "id": "gws.commoncontrols.15.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.15.2v1",
+      "group": "Data Regions and Storage",
+      "groupNumber": 15,
+      "assertion": "Data SHALL be processed in the region selected for data at rest.",
+      "obligation": "SHALL",
+      "rationale": "Implementing this policy accounts for sovereignty over organizational data. Without this policy, data could be processed in a region other than the United States, potentially exposing it to unauthorized entities.",
+      "lastModified": "January 2025",
+      "nist80053": [
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1591",
+        "T1591.001",
+        "T1530",
+        "T1537",
+        "T1567",
+        "T1567.002"
+      ],
+      "instructions": "1. Sign in to the [Google Admin console](https://admin.google.com) as an administrator.\n2. Navigate to **Data** -\\> **Compliance** -\\> **Data Regions.**\n3. Click the **Region** card.\n4. Click the **Data processing** card.\n5. Select the radio button option: \"**Process data in the region selected for data at rest.**\"\n6. Click **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.16.1v1": {
+      "id": "gws.commoncontrols.16.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.16.1v1",
+      "group": "Additional Google Services",
+      "groupNumber": 16,
+      "assertion": "Service status for Google services that do not have an individual control SHOULD be set to OFF for everyone.",
+      "obligation": "SHOULD",
+      "rationale": "Accessing additional Google services without necessity can introduce potential vulnerabilities within the GWS environment. Disabling these services mitigates the risk of restricting unnecessary access.",
+      "lastModified": "January 2025",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1199",
+        "T1204",
+        "T1204.001",
+        "T1204.002",
+        "T1204.003"
+      ],
+      "instructions": "1. Click **CHANGE** at the top where it says if **Access to additional services without individual control for all organizational units is On/Off**.\n2. Select the option: \"**OFF for everyone**\"\n3. Click **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.16.2v1": {
+      "id": "gws.commoncontrols.16.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.16.2v1",
+      "group": "Additional Google Services",
+      "groupNumber": 16,
+      "assertion": "User access to Early Access applications SHOULD be disabled.",
+      "obligation": "SHOULD",
+      "rationale": "Allowing early access to applications may expose users to applications that have not yet been fully vetted and may still need to undergo robust testing to ensure compliance with applicable security standards.",
+      "lastModified": "January 2025",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1199",
+        "T1204",
+        "T1204.001",
+        "T1204.002",
+        "T1204.003"
+      ],
+      "instructions": "1. In the list of all services, scroll to and click on the **Early Access Apps** service.\n2. Click on **Service status**.\n3. Ensure **OFF for everyone** is checked.\n4. Click **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.16.3v1": {
+      "id": "gws.commoncontrols.16.3v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.16.3v1",
+      "group": "Additional Google Services",
+      "groupNumber": 16,
+      "assertion": "Looker Studio Sharing outside org SHOULD be set to OFF.",
+      "obligation": "SHOULD",
+      "rationale": "Disabling Looker Studio asset sharing outside of the organization helps keep sensitive data, reports, and dashboards within the organization's control. This policy helps mitigate the risk of unauthorized access, data leakage, or exposure of proprietary information to external entities. By restricting sharing, the organization can maintain compliance with data governance standards, protect intellectual property, and safeguard customer or business-critical data. Additionally, this approach reduces the likelihood of accidental sharing or misuse of information, enhancing overall security and operational integrity.",
+      "lastModified": "February 2026",
+      "nist80053": [
+        "AC-3",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1567",
+        "T1567.002",
+        "T1078",
+        "T1078.004",
+        "T1565",
+        "T1565.003",
+        "T1213",
+        "T1213.002"
+      ],
+      "instructions": "1. In the list of all services, scroll to and click on the **Looker Studio** service.\n2. Select **Sharing setting**.\n3. Ensure **OFF** is checked.\n4. Click **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.16.4v1": {
+      "id": "gws.commoncontrols.16.4v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.16.4v1",
+      "group": "Additional Google Services",
+      "groupNumber": 16,
+      "assertion": "Pinpoint access to drive SHOULD be set to OFF.",
+      "obligation": "SHOULD",
+      "rationale": "Disabling Pinpoint access to Google Drive helps protect sensitive files and data stored within the organization's Drive from inadvertent access, analysis, or sharing through Pinpoint. This policy helps protect organizational data confidentiality and integrity by preventing unauthorized or unintended interactions between Pinpoint and Drive. By restricting access, the organization can reduce the risk of data breaches, maintain compliance with data privacy regulations, and uphold strict data governance practices. This approach also reduces potential misuse or exposure of sensitive information, enhancing overall security and operational control.",
+      "lastModified": "February 2026",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1567",
+        "T1567.002",
+        "T1078",
+        "T1078.004",
+        "T1565",
+        "T1565.003",
+        "T1213",
+        "T1213.002",
+        "T1189"
+      ],
+      "instructions": "1. In the list of all services, scroll to and click on the **Pinpoint** service.\n2. Click on **Data Access Settings**.\n3. Ensure **OFF - Users cannot copy files from Drive to Pinpoint** is checked.\n4. Click **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.17.1v1": {
+      "id": "gws.commoncontrols.17.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.17.1v1",
+      "group": "Multi-Party Approval",
+      "groupNumber": 17,
+      "assertion": "Require multi-party approval for sensitive admin actions SHOULD be enabled.",
+      "obligation": "SHOULD",
+      "rationale": "Changes to sensitive admin settings, such as disabling 2-step verification (2SV), could introduce serious vulnerabilities to the GWS environment. Requiring multiple super admins to approve changes to those settings mitigates this risk.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "AC-5"
+      ],
+      "mitreAttack": [],
+      "instructions": "To configure additional services per the policy:\n1.\tSign in to the [Google Admin console](https://admin.google.com) as an administrator.\n2.\tNavigate to **Security** -> **Authentication** -> **Multi-party approval settings**.\n3.\tEnsure **Require multi party approval for sensitive admin actions** is checked.\n4.\tClick **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.18.1v1": {
+      "id": "gws.commoncontrols.18.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.18.1v1",
+      "group": "Data Loss Prevention",
+      "groupNumber": 18,
+      "assertion": "A custom policy SHALL be configured for Google Drive, Google Calendar, Google Chat, and Gmail to protect PII and sensitive information as defined by the agency, covering at a minimum: credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN).",
+      "obligation": "SHALL",
+      "rationale": "Users may inadvertently share sensitive information with others who should not have access to it. DLP policies provide a way for agencies to detect and prevent unauthorized disclosures.",
+      "lastModified": "April 2026",
+      "nist80053": [
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1048",
+        "T1048.002",
+        "T1213"
+      ],
+      "details": "[//]: # (Keep the version suffix out of the anchor.)",
+      "instructions": "1. In the **Name and apps** section, add the name and description of the rule.\n2. In the **Name and apps** section, under **Google Calendar**, choose the trigger for **Event saved**.\n3. In the **Name and apps** section, under **Google Chat**, choose the trigger for **Message Sent** and **File uploaded**.\n4. In the **Name and apps** section, under **Google Drive**, choose the trigger for **Drive files**.\n5. In the **Name and apps** section, under **Gmail**, choose the trigger for **Message Sent** and **Message received**.\n6. In the **Actions** section, select the appropriate action for each application (per [GWS.COMMONCONTROLS.18.2](#commoncontrols182)).\n7. In the **Alerting** section, choose a severity level, and optionally, check **Send to alert center to trigger notifications**.\n8. Under **Scope** Click **All in your tennant**\n9. In the **Conditions** section:\n    1. Click **Add Condition**. For **Content type to scan**, select **All content**. For **What to scan for**, select **Matches predefined data type**. For **Select data type**, select **Global - Credit card number**. Select the remaining condition properties according to agency need.\n    2. Click **Add Condition**. For **Content type to scan**, select **All content**. For **What to scan for**, select **Matches predefined data type**. For **Select data type**, select **United States - Individual Taxpayer Identification Number**. Select the remaining condition properties according to agency need.\n    3. Click **Add Condition**. For **Content type to scan**, select **All content**. For **What to scan for**, select **Matches predefined data type**. For **Select data type**, select **United States - Social Security Number**. Select the remaining condition properties according to agency need.\n    4. Configure other appropriate content and condition definition(s) based upon the agency's individual requirements and click **Continue**.\n10. Review the rule details, mark the rule as **Active**, and click **Create.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.18.2v1": {
+      "id": "gws.commoncontrols.18.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.18.2v1",
+      "group": "Data Loss Prevention",
+      "groupNumber": 18,
+      "assertion": "The action for DLP policies SHOULD be set to block.",
+      "obligation": "SHOULD",
+      "rationale": "Users may inadvertently share sensitive information with others who should not have access to it. DLP policies provide a way for agencies to detect and prevent unauthorized disclosures.",
+      "lastModified": "January 2025",
+      "nist80053": [
+        "AC-3",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1048",
+        "T1048.002",
+        "T1213"
+      ],
+      "instructions": "1.  For each rule in the **Actions** section follow these steps depending on application:\n    1. For Google Calendar policies select **Block event**.\n    2. For Chat policies rules select **Block message** and select **External Conversations** and **Spaces**, **Group chats**, and **1:1 chats**.\n    3. Optionally, for Chat policies rules select **Block message** and select **Internal Conversations** and **Spaces**, **Group chats**, and **1:1 chats**.\n    4. For Gmail policies select **Audit Only**, and then select **Messages sent to external recipients**, **Messages to internal recipients**, **Messages from external senders**, and **Messages from internal senders** .\n    5. For Google Drive policies select **Block external sharing**.\n2. Click **Continue**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.2.1v1": {
+      "id": "gws.commoncontrols.2.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.2.1v1",
+      "group": "Context-aware Access",
+      "groupNumber": 2,
+      "assertion": "Policies restricting access to Google Workspace (GWS) based on enterprise device signals SHOULD be implemented.",
+      "obligation": "SHOULD",
+      "rationale": "Granular device access control afforded by context-aware access aligns with federal zero trust strategy and principles. Context-aware access can help to increase the security of GWS data by allowing organizations to restrict access to certain applications or services based on user/device attributes.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "IA-3"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.005"
+      ],
+      "note": "Agencies may use controls with greater granularity if needed.",
+      "instructions": "To turn on Context-Aware Access:\n\n1.  Access the [Google Admin console](https://admin.google.com/).\n2.  From the menu, go to **Security** -\\> **Access and data control** -\\> **Context-Aware Access**.\n3.  Verify **Context-Aware Access** is **ON for everyone**. If not, click **Turn On**.\n4.  Select **Access Level** and then **Create Access Level**. Then determine the rule conditions per agency needs.\n5.  Select **Assign access levels to applications**, then select the applications to which the rule should apply.\n\nNote that the implementation details of context-aware access use cases will vary per agency. Refer to [Google's documentation](https://support.google.com/a/answer/12643733) on implementing context-aware access for your specific use cases. Common use cases include:\n-   Require company-owned access on desktop but not on mobile device\n-   Require basic device security\n-   Allow access to contractors only through the corporate network\n-   Block access from known hijacker IP addresses\n-   Allow or disallow access from specific locations\n-   Use nested access levels instead of selecting multiple access levels during assignment",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.3.1v1": {
+      "id": "gws.commoncontrols.3.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.3.1v1",
+      "group": "Login Challenges",
+      "groupNumber": 3,
+      "assertion": "Post-single sign-on (SSO) verification SHOULD be enabled for users signing in using the organization's SSO profile.",
+      "obligation": "SHOULD",
+      "rationale": "Without enabling post-SSO verification, Google 2-Step Verification (2SV) configurations are not enforced for third-party SSO users. Enabling post-SSO verification ensures the application of 2SV verification policies.",
+      "lastModified": "January 2025",
+      "nist80053": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003"
+      ],
+      "instructions": "1. For **Settings for users signing in using the SSO profile for your organization**, select **Ask users for additional verifications from Google if a sign-in looks suspicious, and always apply 2-Step Verification policies (if configured)**.\n2. Click **SAVE**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.3.2v1": {
+      "id": "gws.commoncontrols.3.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.3.2v1",
+      "group": "Login Challenges",
+      "groupNumber": 3,
+      "assertion": "Post-SSO verification SHOULD be enabled for users signing in using other SSO profiles.",
+      "obligation": "SHOULD",
+      "rationale": "Without enabling post-SSO verification, any Google 2-Step Verification (2SV) configuration is ignored for third-party SSO users. Enabling post-SSO verification will apply 2SV verification policies.",
+      "lastModified": "November 2024",
+      "nist80053": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003"
+      ],
+      "instructions": "1. For **Settings for users signing in using other SSO profiles**, select **Ask users for additional verifications from Google if a sign-in looks suspicious, and always apply 2-Step Verification policies (if configured)**.\n2. Click **SAVE**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.4.1v1": {
+      "id": "gws.commoncontrols.4.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.4.1v1",
+      "group": "User Session Duration",
+      "groupNumber": 4,
+      "assertion": "Users SHALL be forced to re-authenticate after an established 12-hour GWS login session has expired.",
+      "obligation": "SHALL",
+      "rationale": "Allowing sessions to persist indefinitely enables users to bypass 2-Step Verification (2SV) for future activity on that device. Limiting sessions to 12 hours may reduce the possibility of session hijacking attacks and prevent users from inadvertently remaining logged in on unattended devices.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "IA-11"
+      ],
+      "mitreAttack": [
+        "T1550",
+        "T1550.004",
+        "T1078",
+        "T1078.004"
+      ],
+      "instructions": "To configure Google session control:\n\n1.  Sign in to the [Google Admin console](https://admin.google.com) as an administrator.\n2.  Select **Security.**\n3.  Select **Access and data control** -\\> **Google session control.**\n4.  Look for the **Web session duration** heading.\n5.  Set the duration to **12 hours.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.5.1v1": {
+      "id": "gws.commoncontrols.5.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.5.1v1",
+      "group": "Secure Passwords",
+      "groupNumber": 5,
+      "assertion": "User password strength SHALL be enforced.",
+      "obligation": "SHALL",
+      "rationale": "Weak passwords increase the risk of account compromise. Enforcing password strength adds an additional layer of defense, reducing the risk of account compromise. Strong password policies protect an organization by discouraging the use of weak passwords.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "IA-5(1)"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003"
+      ],
+      "instructions": "1.  Under **Strength**, select the **Enforce strong password** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.5.2v1": {
+      "id": "gws.commoncontrols.5.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.5.2v1",
+      "group": "Secure Passwords",
+      "groupNumber": 5,
+      "assertion": "User password length SHALL be at least 12 characters.",
+      "obligation": "SHALL",
+      "rationale": "The National Institute of Standards and Technology (NIST) published guidance indicating that password length is a primary factor in characterizing password strength (NIST SP 800-63B). Longer passwords tend to be more resistant to brute force and dictionary-based attacks.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "IA-5(1)"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003"
+      ],
+      "instructions": "1.  Under **Length**, set **Minimum Length** to 12+.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.5.3v1": {
+      "id": "gws.commoncontrols.5.3v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.5.3v1",
+      "group": "Secure Passwords",
+      "groupNumber": 5,
+      "assertion": "User password length SHOULD be at least 16 characters.",
+      "obligation": "SHOULD",
+      "rationale": "The National Institute of Standards and Technology (NIST) published guidance indicating that password length is a primary factor in characterizing password strength (NIST SP 800-63B). Longer passwords tend to be more resistant to brute force and dictionary-based attacks.",
+      "lastModified": "January 2025",
+      "nist80053": [
+        "IA-5(1)"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003"
+      ],
+      "instructions": "1.  Under **Length**, set **Minimum Length** to 16+.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.5.4v1": {
+      "id": "gws.commoncontrols.5.4v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.5.4v1",
+      "group": "Secure Passwords",
+      "groupNumber": 5,
+      "assertion": "Password policy SHALL be enforced at next sign-in.",
+      "obligation": "SHALL",
+      "rationale": "If the password policy is not enforced at next login, a user could potentially operate indefinitely using a weak password. Enforcing the policy at next login helps ensure that all active user passwords meet current requirements.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "IA-5(1)"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003"
+      ],
+      "instructions": "1.  Under **Strength and Length enforcement**, select the **Enforce password policy at next sign-in** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.5.5v1": {
+      "id": "gws.commoncontrols.5.5v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.5.5v1",
+      "group": "Secure Passwords",
+      "groupNumber": 5,
+      "assertion": "User passwords SHALL NOT be reused.",
+      "obligation": "SHALL NOT",
+      "rationale": "Password reuse represents a significant security risk. When possible, preventing password reuse limits the scope of a compromised password.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "IA-5(1)"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003"
+      ],
+      "instructions": "1.  Under **Reuse**, uncheck the **Allow password reuse** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.5.6v1": {
+      "id": "gws.commoncontrols.5.6v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.5.6v1",
+      "group": "Secure Passwords",
+      "groupNumber": 5,
+      "assertion": "User passwords SHALL NOT expire.",
+      "obligation": "SHALL NOT",
+      "rationale": "The National Institute of Standards and Technology (NIST), OMB, and Microsoft have published guidance indicating mandated periodic password changes make user accounts less secure. For example, OMB M-22-09 states, \"Password policies must not require use of special characters or regular rotation.\"",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "IA-5(1)"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003"
+      ],
+      "instructions": "1.  Under **Expiration**, select **Never Expires.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.6.1v1": {
+      "id": "gws.commoncontrols.6.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.6.1v1",
+      "group": "Privileged Accounts",
+      "groupNumber": 6,
+      "assertion": "All administrative accounts SHALL be provisioned as cloud-only accounts separate from an agency's authoritative on-premises or other federated identity providers.",
+      "obligation": "SHALL",
+      "rationale": "Cloud-only accounts leveraging Google Account authentication with phishing resistant MFA for highly privileged accounts reduces the risks associated with a compromise of on-premises federation infrastructure. Enforcing this policy makes it more challenging for a threat actor to pivot from a compromised on-premises environment to the cloud with privileged access.",
+      "lastModified": "November 2025",
+      "nist80053": [
+        "AC-6(5)"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003",
+        "T1556",
+        "T1556.006"
+      ],
+      "instructions": "1.  Determine how to track highly privileged accounts. For example, create an OU or a group containing all highly privileged accounts.\n2.  Follow the instructions in the [Set up SSO for your organization](https://support.google.com/a/answer/12032922?hl=en) guide, under \"Decide which users should use SSO.\" For all OUs or groups with highly privileged users, set the **SSO profile assignment** to **None**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.6.2v1": {
+      "id": "gws.commoncontrols.6.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.6.2v1",
+      "group": "Privileged Accounts",
+      "groupNumber": 6,
+      "assertion": "A minimum of **two** and a maximum of **eight** separate and distinct super admin users SHALL be configured.",
+      "obligation": "SHALL",
+      "rationale": "The super admin role provides unfettered access to Google Workspace. Properly managing the number of users with this access level reduces the risk of a GWS compromise. Having too few super admin accounts can increase the risk of losing admin access entirely (e.g., if a super admin forgets their password). Maintaining between two to eight super admin accounts helps mitigate accessibility and security concerns.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-6(5)"
+      ],
+      "mitreAttack": [
+        "T1136",
+        "T1136.003",
+        "T1098",
+        "T1098.003"
+      ],
+      "note": "The total number of super admin accounts does not include \"break-glass\" super admin accounts.",
+      "instructions": "To obtain a list of all GWS Super Admins:\n\n1.  Sign in to the [Google Admin console](https://admin.google.com) as an administrator.\n2.  Navigate to **Account** -\\> **Admin Roles**.\n3.  Click the **Super Admin** role in the list of roles\n4.  The subsequent dialog provides a list of Super Admins.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.7.1v1": {
+      "id": "gws.commoncontrols.7.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.7.1v1",
+      "group": "Conflicting Account Management",
+      "groupNumber": 7,
+      "assertion": "Account conflict management SHOULD be configured to replace conflicting unmanaged accounts with managed accounts.",
+      "obligation": "SHOULD",
+      "rationale": "Unmanaged user accounts cannot be controlled or monitored by GWS administrators. By resolving conflicting accounts, organizations can ensure all users have managed user accounts.",
+      "lastModified": "April 2025",
+      "nist80053": [
+        "IA-2"
+      ],
+      "mitreAttack": [
+        "T1136",
+        "T1136.003",
+        "T1098",
+        "T1098.003",
+        "T1078"
+      ],
+      "instructions": "To configure account conflict management per the policy:\n1.\tSign in to the [Google Admin console](https://admin.google.com) as an administrator.\n2.\tNavigate to **Account** -\\> **Account settings.**\n3.\tClick the **Conflicting accounts management** section.\n4.\tSelect the radio button option reading **\"Replace conflicting unmanaged accounts with managed ones.\"**\n5.\tClick **Save.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.8.1v1": {
+      "id": "gws.commoncontrols.8.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.8.1v1",
+      "group": "Account Recovery Options",
+      "groupNumber": 8,
+      "assertion": "Account self-recovery for super admins SHALL be disabled.",
+      "obligation": "SHALL",
+      "rationale": "If enabled, a threat actor could attempt to access a super admin account through the account recovery method. Disabling this feature forces super admins to contact another super admin in order to recover their account, making it more difficult for a potential threat actor to compromise the account.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "IA-5d",
+        "IA-5g"
+      ],
+      "mitreAttack": [
+        "T1556",
+        "T1556.006"
+      ],
+      "instructions": "To disable Super Admin account self-recovery:\n\n1.  Sign in to https://admin.google.com as an administrator.\n2.  Select **Security** -\\> **Authentication**.\n3.  Select **Account Recovery**.\n4.  Click **Super admin account recovery**.\n5.  Deselect the **Allow Super Admins to recover their account** checkbox.\n6.  Click **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.8.2v1": {
+      "id": "gws.commoncontrols.8.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.8.2v1",
+      "group": "Account Recovery Options",
+      "groupNumber": 8,
+      "assertion": "Account self-recovery for users and non-super admins SHALL be disabled.",
+      "obligation": "SHALL",
+      "rationale": "If enabled, a user could add a personal email or phone number for account recovery. Disabling this feature requires account recovery to go through official channels, making it more difficult for a potential threat actor to compromise an account.",
+      "lastModified": "February 2025",
+      "nist80053": [
+        "IA-5d",
+        "IA-5g"
+      ],
+      "mitreAttack": [
+        "T1556",
+        "T1556.006"
+      ],
+      "instructions": "1.  Sign in to https://admin.google.com as an administrator.\n2.  Select **Security** -\\> **Authentication**.\n3.  Select **Account Recovery**.\n4.  Click **User account recovery**.\n5.  Deselect the **Allow users and all non-super admins to recover their account** checkbox.\n6.  Click **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.8.3v1": {
+      "id": "gws.commoncontrols.8.3v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.8.3v1",
+      "group": "Account Recovery Options",
+      "groupNumber": 8,
+      "assertion": "Ability to add recovery information SHOULD be disabled.",
+      "obligation": "SHOULD",
+      "rationale": "If enabled, a user could add a personal email or phone number for account recovery. Disabling this feature prevents a user from adding personally identifiable information (PII) to their organizational account and makes it more difficult for a potential threat actor to steal PII in the event of a compromise.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "note": "This setting is not applicable if using single sign-on (SSO) with a third-party identity provider or password sync. GWS.COMMONCONTROLS.8.3 acts as a defense in-depth policy when GWS.COMMONCONTROLS.8.1 and GWS.COMMONCONTROLS.8.2 are not enabled.",
+      "instructions": "1.  Sign in to https://admin.google.com as an administrator.\n2.  Select **Security** -\\> **Authentication**.\n3.  Select **Account Recovery**.\n4.  Click **Recovery Information**.\n5.  Deselect the **Allow admins and users to add recovery email information to their account** checkbox.\n6.  Deselect the **Allow admins and users to add recovery phone information to their account** checkbox.\n7.  Click **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.9.1v1": {
+      "id": "gws.commoncontrols.9.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.9.1v1",
+      "group": "GWS Advanced Protection Program",
+      "groupNumber": 9,
+      "assertion": "Highly privileged accounts SHALL be enrolled in the Google Workspace (GWS) Advanced Protection Program.",
+      "obligation": "SHALL",
+      "rationale": "Sophisticated phishing tactics can trick even savvy users into giving their sign-in credentials to attackers. The Advanced Protection Program requires users to use a security key – a hardware device or special software on mobile devices used to verify identity – to sign in to a Google Account. Unauthorized users will not be able to sign in without the user's security key, even if they have the user's username and password. The Advanced Protection Program includes a curated group of high-security policies that are applied to enrolled accounts. Additional policies may be added to the Advanced Protection Program to ensure protections are current.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "IA-2(1)",
+        "IA-2(2)",
+        "IA-5c",
+        "IA-5d",
+        "IA-5g",
+        "SI-3",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003",
+        "T1556",
+        "T1556.006"
+      ],
+      "instructions": "To allow all users to enroll:\n\n1.  Sign in to the [Google Admin console](https://admin.google.com) as an administrator.\n2.  Select **Security -**\\> **Authentication** -\\> **Advanced Protection Program.**\n3.  On the right, locate the **Advanced Protection** header.\n4.  Locate the **Allow users to enroll in the Advanced Protection Program** header.\n5.  Select **Enable user enrollment.**\n6.  Click **SAVE.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.commoncontrols.9.2v1": {
+      "id": "gws.commoncontrols.9.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.COMMONCONTROLS.9.2v1",
+      "group": "GWS Advanced Protection Program",
+      "groupNumber": 9,
+      "assertion": "All sensitive user accounts SHOULD be enrolled into the GWS Advanced Protection Program.",
+      "obligation": "SHOULD",
+      "rationale": "Sophisticated phishing tactics can trick even savvy users into giving their sign-in credentials to attackers. The Advanced Protection Program requires users to use a security key – a hardware device or special software on mobile devices used to verify identity – to sign in to a Google Account. Unauthorized users will not be able to sign in without the user's security key, even if they have the user's username and password. The Advanced Protection Program includes a curated group of high-security policies that are applied to enrolled accounts. Additional policies may be added to the Advanced Protection Program to ensure protections are current.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "IA-2(1)",
+        "IA-2(2)",
+        "IA-5c",
+        "IA-5d",
+        "IA-5g",
+        "SI-3",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003",
+        "T1556",
+        "T1556.006"
+      ],
+      "note": "This control enforces more secure protection of sensitive user accounts from targeted attacks. Sensitive user accounts include political appointees, Senior Executive Service (SES) officials, or other senior officials whose account compromise would pose a level of risk prohibitive to agency mission fulfillment",
+      "instructions": "To allow all users to enroll:\n\n1.  Sign in to the [Google Admin console](https://admin.google.com) as an administrator.\n2.  Select **Security -**\\> **Authentication** -\\> **Advanced Protection Program.**\n3.  On the right, locate the **Advanced Protection** header.\n4.  Locate the **Allow users to enroll in the Advanced Protection Program** header.\n5.  Select **Enable user enrollment.**\n6.  Click **SAVE.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/commoncontrols.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/commoncontrols.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md"
+    },
+    "gws.drivedocs.1.10v1": {
+      "id": "gws.drivedocs.1.10v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.1.10v1",
+      "group": "Sharing Outside the Organization",
+      "groupNumber": 1,
+      "assertion": "If external sharing is not allowed, then forms owned by users within the organization SHOULD NOT be able to accept responses from anyone accessing the link from outside the organization.",
+      "obligation": "SHOULD NOT",
+      "rationale": "If external sharing is not allowed, enabling the ability to accept responses from anyone bypasses the external sharing restrictions in place. Users external to the organization could use forms to maliciously collect and share data without oversight. Implementing this policy reduces these risks.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "IA-8",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537"
+      ],
+      "instructions": "1.  Select **Sharing settings -\\> Sharing options**\n2.  Select **Form responses**\n3.  Check the **Allow forms owned by users in XXXX to accept responses from anyone with the link outside XXXX, even if external sharing isn't allowed. If this option isn’t selected, settings for sharing outside XXXX apply to forms** box\n4.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.1.11v1": {
+      "id": "gws.drivedocs.1.11v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.1.11v1",
+      "group": "Sharing Outside the Organization",
+      "groupNumber": 1,
+      "assertion": "If receiving external files is not allowed, then users in the organization SHOULD NOT be able to submit responses to forms from users or shared drives outside of the organization.",
+      "obligation": "SHOULD NOT",
+      "rationale": "If receiving external files is not allowed, enabling the ability to submit responses to forms from users or shared drives outside of the organization bypasses the external sharing restrictions in place. Users external to the organization could use forms to maliciously collect and share data without oversight. Implementing this policy reduces these risks.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "IA-8",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537"
+      ],
+      "instructions": "1.  Select **Sharing settings -\\> Sharing options**\n2.  Select **Form responses**\n3.  Check the **Allow users in XXXX to submit responses to forms from users or shared drives outside of XXXX, even if receiving external files isn’t allowed. If this option isn’t selected, settings for receiving files external to XXXX apply to forms** box\n4.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.1.1v1": {
+      "id": "gws.drivedocs.1.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.1.1v1",
+      "group": "Sharing Outside the Organization",
+      "groupNumber": 1,
+      "assertion": "External sharing SHALL be restricted to allowlisted domains.",
+      "obligation": "SHALL",
+      "rationale": "Documents may contain personally identifiable information or sensitive information. Disabling external sharing reduces the risk of inadvertent data leakage.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "AC-3",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537"
+      ],
+      "note": "- This policy restricts information sharing - This policy prevents data leakage outside of the organization - If specific users have a need for broader external sharing (e.g., for community outreach), external sharing MAY be enabled for specific Organization Units (OUs).",
+      "instructions": "1.  Select **Sharing settings** -\\> **Sharing options**.\n2.  Select **Sharing outside of your domain** -\\> **OFF – Files owned by users in your domain cannot be shared outside of your domain**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.1.2v1": {
+      "id": "gws.drivedocs.1.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.1.2v1",
+      "group": "Sharing Outside the Organization",
+      "groupNumber": 1,
+      "assertion": "Receiving files from non-allowlisted domains SHOULD be disabled.",
+      "obligation": "SHOULD",
+      "rationale": "Users given access to external files may inadvertently input personally identifiable information or sensitive information. Additionally, files created externally may contain malicious content. Disallowing external files from being shared may reduce the risk of data loss or external threats.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "SI-3",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537"
+      ],
+      "note": "This policy is only applicable if external sharing is set to **ALLOWLISTED DOMAINS**.",
+      "instructions": "1.  Select **Sharing settings** -\\> **Sharing options**.\n2.  Deselect **Allow users to receive files from users or shared drives outside of allowlisted domains**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.1.3v1": {
+      "id": "gws.drivedocs.1.3v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.1.3v1",
+      "group": "Sharing Outside the Organization",
+      "groupNumber": 1,
+      "assertion": "Warnings SHALL be enabled when a user is attempting to share with someone in a non-allowlisted domain.",
+      "obligation": "SHALL",
+      "rationale": "Users may not always be aware that a given user is external to their organization. Warning them before sharing increases user awareness and accountability.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "AT-2b"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537"
+      ],
+      "note": "This policy is only applicable if external sharing is set to **ALLOWLISTED DOMAINS**.",
+      "instructions": "1.  Select **Sharing settings** -\\> **Sharing options**.\n2.  Select **Warn when files owned by users or shared drives in your organization are shared with users in allowlisted domains**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.1.4v1": {
+      "id": "gws.drivedocs.1.4v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.1.4v1",
+      "group": "Sharing Outside the Organization",
+      "groupNumber": 1,
+      "assertion": "If sharing outside of the organization, agencies SHOULD disable sharing of files with individuals who are not using a Google account.",
+      "obligation": "SHOULD",
+      "rationale": "Allowing users to view shared files when they are not signed in to a Google account diminishes oversight and accountability, increasing the potential for a data breach. This policy reduces that risk by requiring all users to be signed in when viewing shared Google Docs/Google Drive materials.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "IA-8",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537"
+      ],
+      "note": "This policy is only applicable if external sharing is set to **ON**.",
+      "instructions": "1.  Select **Sharing settings** -\\> **Sharing options**.\n2.  Deselect **Allow users or shared drives in your organization to share items with people outside of your organization who aren't using a Google account.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.1.5v1": {
+      "id": "gws.drivedocs.1.5v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.1.5v1",
+      "group": "Sharing Outside the Organization",
+      "groupNumber": 1,
+      "assertion": "Any Organizational Units that allow external sharing SHOULD disable content availability to \"anyone with the link.\"",
+      "obligation": "SHOULD",
+      "rationale": "Allowing users to view shared files when they are not signed in to a Google account diminishes oversight and accountability and increases the chance of a potential data breach. This policy reduces that risk by requiring all people to be signed in when viewing shared Google Docs/Google Drive materials.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "IA-8"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537"
+      ],
+      "instructions": "1.  Select **Sharing settings** -\\> **Sharing options**.\n2.  Deselect **When sharing outside of your organization is allowed, users in your organization can make files and published web content visible to anyone with the link.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.1.6v1": {
+      "id": "gws.drivedocs.1.6v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.1.6v1",
+      "group": "Sharing Outside the Organization",
+      "groupNumber": 1,
+      "assertion": "Agencies SHALL set access checking to \"recipients only.\"",
+      "obligation": "SHALL",
+      "rationale": "The \"Access Checker\" feature can be configured to allow users to grant a recipient open access, creating the potential for data leakage. This control mitigates the risk by allowing access to be granted to recipients only.",
+      "lastModified": "June 2024",
+      "nist80053": [
+        "AC-3",
+        "IA-8",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537"
+      ],
+      "instructions": "1.  Select **Sharing settings** -\\> **Sharing options**.\n2.  Select **Access Checker** -\\> **Recipients only.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.1.7v1": {
+      "id": "gws.drivedocs.1.7v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.1.7v1",
+      "group": "Sharing Outside the Organization",
+      "groupNumber": 1,
+      "assertion": "Users SHOULD NOT be allowed to upload or move content to shared drives owned by another organization.",
+      "obligation": "SHOULD NOT",
+      "rationale": "Once a document is moved outside of the organization's drives, the organization no longer has control over the dissemination of the document. By preventing users from distributing content to external shared drives, the organization maintains more control over the document.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537"
+      ],
+      "instructions": "1.  Select **Sharing settings** -\\> **Sharing options**.\n2.  Select **Distributing content outside of your domain** -\\> **No one**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.1.8v1": {
+      "id": "gws.drivedocs.1.8v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.1.8v1",
+      "group": "Sharing Outside the Organization",
+      "groupNumber": 1,
+      "assertion": "\"Private to owner\" SHALL be the default access level for newly created items.",
+      "obligation": "SHALL",
+      "rationale": "By implementing least privilege and setting the default to \"Private to owner,\" the organization is able to prevent broad accidental sharing of information.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "AC-6"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537",
+        "T1538"
+      ],
+      "instructions": "1.  Select **Sharing settings -\\> General access default.**\n2.  Select **When users in your organization create items, the default access will be -\\> Private to the owner.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.1.9v1": {
+      "id": "gws.drivedocs.1.9v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.1.9v1",
+      "group": "Sharing Outside the Organization",
+      "groupNumber": 1,
+      "assertion": "Out-of-Domain file-level warnings SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Implementing out-of-domain file-level warnings can help users identify potentially risky files and avoid phishing scams when working with files shared from external entities.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "IA-8",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1537"
+      ],
+      "instructions": "1.  Select **Sharing settings -\\> Highlight External Files**.\n2.  Check the **Mark files shared or owned externally as \"external\" to indicate that content may be viewable outside your organization. Applies to Drive, Docs, Sheets, Slides, Drawings, and Vids.** box to turn on the indicator.\n3.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.2.1v1": {
+      "id": "gws.drivedocs.2.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.2.1v1",
+      "group": "Shared Drive Creation",
+      "groupNumber": 2,
+      "assertion": "Agencies SHOULD NOT allow members with manager access to override shared Google Drive creation settings.",
+      "obligation": "SHOULD NOT",
+      "rationale": "Allowing users who are not the Google Drive manager to override settings violates the principle of least privilege. This policy reduces the risk of Google Drive settings being modified by unauthorized individuals.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-6"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "instructions": "1.  Uncheck the **Allow members with manager access to override the settings below** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.2.2v1": {
+      "id": "gws.drivedocs.2.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.2.2v1",
+      "group": "Shared Drive Creation",
+      "groupNumber": 2,
+      "assertion": "Agencies SHALL allow users who are not members of a shared Google Drive to be added to files.",
+      "obligation": "SHALL",
+      "rationale": "Prohibiting non-members from being added to a file would require they be added as Google Drive members to access the file, potentially exposing all Google Drive files and increasing the risk of sensitive content exposure. Disallowing the sharing of these individual files reduces the risk of internal documents from being distributed outside the organization without explicit consent and approval.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-3"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "instructions": "1.  Check the **Allow people who aren't shared drive members to be added to files** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.3.1v1": {
+      "id": "gws.drivedocs.3.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.3.1v1",
+      "group": "Security Updates for Files",
+      "groupNumber": 3,
+      "assertion": "Agencies SHALL enable the security update for Google Drive files.",
+      "obligation": "SHALL",
+      "rationale": "Failure to enable the resource key security update may result in unauthorized access to files. Enabling this update reduces the risk of unauthorized access and potential data spillage by enhancing control for files in Google Drive.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-3"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Drive and Docs.**\n3.  Select **Sharing settings -\\> Security update for files.**\n4.  Select **Apply security update to all impacted files.**\n5.  Uncheck the **Allow users to remove/apply the security update for files they own or manage** checkbox.\n6.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.4.1v1": {
+      "id": "gws.drivedocs.4.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.4.1v1",
+      "group": "Drive SDK",
+      "groupNumber": 4,
+      "assertion": "Agencies SHOULD disable Google Drive SDK access.",
+      "obligation": "SHOULD",
+      "rationale": "The Google Drive SDK allows third-party applications to access Google Drive data, potentially leading to unintentional information sharing and data leakage. By disabling the Google Drive SDK, agencies can decrease the risk of internal documents being distributed externally without explicit consent and approval.",
+      "lastModified": "January 2024",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1059",
+        "T1059.009"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Drive and Docs.**\n3.  Select **Features and Applications -\\> Drive SDK.**\n4.  Uncheck the **Allow users to access Google Drive with the Drive SDK API** checkbox.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.5.1v1": {
+      "id": "gws.drivedocs.5.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.5.1v1",
+      "group": "Drive for Desktop",
+      "groupNumber": 5,
+      "assertion": "Google Drive for Desktop SHALL be enabled for authorized devices only.",
+      "obligation": "SHALL",
+      "rationale": "Some users may attempt to use Google Drive for Desktop to connect unapproved devices (e.g., a personal computer) to the agency's Google Drive. Even if unintentional, this poses a security risk as the agency lacks the ability to audit or secure personal devices. Implementing this policy helps reduce these risks.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "instructions": "To Disable Google Drive for Desktop:\n\n1.  Sign in to the [Google Admin console](https://admin.google.com).\n2.  Select **Menu-\\>Apps-\\>Google Workspace-\\>Drive and Docs**.\n3.  Select **Google Drive for Desktop**.\n4.  Select **Enable Drive for Desktop**.\n5.  Uncheck the **Allow Google Drive for desktop in your organization** checkbox.\n6.  Select **Save**.\n\nTo limit Google Drive for Desktop to authorized devices:\n\n1.  Sign in to the [Google Admin console](https://admin.google.com).\n2.  Select **Menu-\\>Apps-\\>Google Workspace-\\>Drive and Docs**.\n3.  Select **Google Drive for Desktop**.\n4.  Select **Enable Drive for Desktop**.\n5.  Check the **Allow Google Drive for desktop in your organization** checkbox.\n6.  Check the **Only allow Google Drive for desktop on authorized devices checkbox**.\n7.  Ensure authorized devices are added to [company-owned inventory](https://support.google.com/a/answer/7129612?hl=en).\n8.  Select Save.\n\nAlternatively, [Context-Aware access policies](https://support.google.com/a/answer/9275380?hl=en) can be configured for more granular controls around authorized devices. The access level applied to Google Drive must have the \"Apply to Google desktop and mobile apps\" enabled to meet this requirement. For additional guidance, see [Context-Aware Access](/scubagoggles/baselines/commoncontrols.md#2-context-aware-access).",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.drivedocs.5.2v1": {
+      "id": "gws.drivedocs.5.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.DRIVEDOCS.5.2v1",
+      "group": "Drive for Desktop",
+      "groupNumber": 5,
+      "assertion": "Monitoring for potential ransomware corruption SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "This setting helps protect against malware and ransomware by auto-detecting potential attacks. This strengthens the overall security posture and limits potential damage from ransomware.",
+      "lastModified": "April 2026",
+      "nist80053": [
+        "CP-9",
+        "CP-10"
+      ],
+      "mitreAttack": [
+        "T1486",
+        "T1490"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin console](https://admin.google.com).\n2.  Select **Menu-\\>Apps-\\>Google Workspace-\\>Drive and Docs**.\n3.  Select **Malware and Ransomware**.\n4.  Ensure **Drive automatically monitors unusual file changes to identify potential ransomware corruption** is set to ON.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/drive.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/drive.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md"
+    },
+    "gws.gemini.1.1v1": {
+      "id": "gws.gemini.1.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GEMINI.1.1v1",
+      "group": "Gemini App Access",
+      "groupNumber": 1,
+      "assertion": "Gemini app user access SHALL be set to OFF for everyone without a license.",
+      "obligation": "SHALL",
+      "rationale": "Only Gemini data for users with the appropriate license will be",
+      "lastModified": "July 2025",
+      "nist80053": [
+        "SC-7(10)(a)"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "details": "protected from use in generative AI training by the Google Workspace Terms of Service. Data for users without the\nappropriate license can be used to improve Google's generative AI models.\nAllowing user access to Gemini under any license creates the risk of data leakage but restricting it to licensed users will grant protection by the GWS Terms of Service.",
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Generative AI** -\\> **Gemini App**.\n3.  Select **User Access**.\n4.  Ensure **Allow all users to access the Gemini app, regardless of license** is **Unchecked**.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gemini.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gemini.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gemini.md"
+    },
+    "gws.gemini.2.1v1": {
+      "id": "gws.gemini.2.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GEMINI.2.1v1",
+      "group": "Gemini Alpha features",
+      "groupNumber": 2,
+      "assertion": "Gemini Alpha features SHALL be disabled.",
+      "obligation": "SHALL",
+      "rationale": "Allowing access to Gemini Alpha features may expose users to features that",
+      "lastModified": "July 2025",
+      "nist80053": [
+        "SC-7(10)(a)"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "details": "have not yet been fully vetted and may still need to undergo robust testing to verify\ncompliance with applicable security standards. Additionally, government customers are\nprohibited from using production data with pre-general availability offerings, per the Google Workspace\nService Specific Terms.",
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Generative AI** -\\> **Gemini for Workspace.**\n3.  Select **Alpha features.**\n4.  Ensure **Turn off access to Alpha features in Gemini for Google Workspace** is selected.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gemini.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gemini.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gemini.md"
+    },
+    "gws.gemini.3.1v1": {
+      "id": "gws.gemini.3.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GEMINI.3.1v1",
+      "group": "Gemini Conversation History",
+      "groupNumber": 3,
+      "assertion": "Gemini conversation history SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Users engaged in Gemini conversations may inadvertently share sensitive or private information. Enabling conversation history may mitigate this risk by providing a traceable record of Gemini conversations, enhancing information accountability and security. Additionally, this may help meet data retention requirements.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "AU-2",
+        "AU-11"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Generative AI** -\\> **Gemini App**.\n3.  Select **Gemini Conversation History**\n4.  Ensure **Gemini conversation history** is selected.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gemini.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gemini.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gemini.md"
+    },
+    "gws.gemini.3.2v1": {
+      "id": "gws.gemini.3.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GEMINI.3.2v1",
+      "group": "Gemini Conversation History",
+      "groupNumber": 3,
+      "assertion": "Gemini conversation retention SHALL be set to minimum of 18 months.",
+      "obligation": "SHALL",
+      "rationale": "Users engaged in Gemini conversations may inadvertently share sensitive or private information. Enabling conversation history may mitigate this risk by providing a traceable record of Gemini conversations, enhancing information accountability and security. Additionally, this may help meet data retention requirements.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "AU-2",
+        "AU-11"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Generative AI** -\\> **Gemini App**.\n3.  Select **Gemini Conversation History**\n4.  Ensure **Conversation retention** is set to at least 18 months.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gemini.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gemini.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gemini.md"
+    },
+    "gws.gemini.4.1v1": {
+      "id": "gws.gemini.4.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GEMINI.4.1v1",
+      "group": "Gemini Conversation Sharing",
+      "groupNumber": 4,
+      "assertion": "Conversation sharing SHALL be set to OFF.",
+      "obligation": "SHALL",
+      "rationale": "Users engaged in Gemini conversations may inadvertently share sensitive or private information. Disabling conversation sharing may prevent sensitive data from being shared with unauthorized individuals.",
+      "lastModified": "April 2026",
+      "nist80053": [
+        "SC-7(10)a"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Generative AI** -\\> **Gemini App**.\n3.  Select **Sharing**\n4.  Ensure **Allow conversation sharing via link** is set to OFF.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gemini.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gemini.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gemini.md"
+    },
+    "gws.gmail.1.1v1": {
+      "id": "gws.gmail.1.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.1.1v1",
+      "group": "Mail Delegation",
+      "groupNumber": 1,
+      "assertion": "Mail delegation SHOULD be disabled.",
+      "obligation": "SHOULD",
+      "rationale": "Granting mail delegation can inadvertently lead to disclosure of sensitive information, impersonation of delegated accounts, or malicious alteration or deletion of emails. By controlling mail delegation, these risks can be significantly reduced, improving the security and integrity of email communications.",
+      "lastModified": "October 2023",
+      "nist80053": [
+        "IA-2",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.002"
+      ],
+      "note": "Exceptions should be limited to individuals authorized by existing agency policy, such as Senior Executive Service (SES) or politically appointed staff. Other considerations include ensuring that delegated accounts require phishing-resistant multifactor authentication (MFA), limiting delegated account permissions (e.g. allowing view/reply, prohibiting delete), monitoring delegated accounts regularly, and disabling them if no longer required.",
+      "instructions": "To configure the settings for Mail Delegation:\n1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Gmail**.\n3.  Select **User Settings -\\> Mail delegation**.\n4.  Ensure that the **Let users delegate access to their mailbox to other users in the domain** checkbox is unchecked.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.10.1v1": {
+      "id": "gws.gmail.10.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.10.1v1",
+      "group": "Google Workspace Sync",
+      "groupNumber": 10,
+      "assertion": "Google Workspace Sync SHOULD be disabled.",
+      "obligation": "SHOULD",
+      "rationale": "Enabling Google Workspace Sync could potentially expose sensitive agency or organization data to unauthorized access or loss, posing a security risk. This risk can be reduced by disabling Google Workspace Sync, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "April 2025",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1048",
+        "T1048.001",
+        "T1048.002",
+        "T1048.003",
+        "T1530",
+        "T1199"
+      ],
+      "note": "Google Workspace Sync MAY be enabled on a per-user basis as needed.",
+      "instructions": "1.  Sign in to the [Google Admin console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Gmail**.\n3.  Select **End User Access -\\> Google Workspace Sync**.\n4.  Uncheck the **Enable Google Workspace Sync for Microsoft Outlook for my users** checkbox.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.11.1v1": {
+      "id": "gws.gmail.11.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.11.1v1",
+      "group": "Automatic Forwarding",
+      "groupNumber": 11,
+      "assertion": "Automatic forwarding SHOULD be disabled, especially to external domains.",
+      "obligation": "SHOULD",
+      "rationale": "By enabling automatic forwarding, especially to external domains, threat actors could gain persistent access to a victim's email, potentially exposing sensitive agency or organization emails to unauthorized access or loss. This risk can be reduced by disabling automatic forwarding, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-4"
+      ],
+      "mitreAttack": [
+        "T1114",
+        "T1114.003"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Gmail**.\n3.  Select **End User Access -\\> Automatic forwarding**.\n4.  Uncheck the **Allow users to automatically forward incoming email to another address** checkbox.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.12.1v1": {
+      "id": "gws.gmail.12.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.12.1v1",
+      "group": "Per-user Outbound Gateways",
+      "groupNumber": 12,
+      "assertion": "The option to use a per-user outbound gateway that is a mail server other than the Google Workspace (GWS) mail servers SHALL be disabled.",
+      "obligation": "SHALL",
+      "rationale": "Using a per-user outbound gateway that is a mail server other than the GWS mail servers could potentially expose sensitive agency or organization emails to unauthorized access or loss, posing a security risk. Disabling this feature can reduce the risk, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-4"
+      ],
+      "mitreAttack": [
+        "T1114",
+        "T1114.002",
+        "T1048",
+        "T1204.001",
+        "T1204.002"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Gmail**.\n3.  Select **End User Access -\\> Allow per-user outbound gateways**.\n4.  Uncheck the **Allow users to send mail through an external SMTP server when configuring a \"from\" address hosted outside your email domain** checkbox.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.13.1v1": {
+      "id": "gws.gmail.13.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.13.1v1",
+      "group": "Unintended External Reply Warning",
+      "groupNumber": 13,
+      "assertion": "Unintended external reply warnings SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Unintended external reply warnings can help reduce the risk of exposing sensitive information in replies to external messages. Enabling these warnings reminds users to treat external messages with caution, reducing this risk and enhancing the safety and integrity of user data and systems.",
+      "lastModified": "June 2024",
+      "nist80053": [
+        "AT-2b"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1566.003"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Gmail**.\n3.  Select **End User Access -\\> Warn for external recipients**.\n4.  Check the **Highlight any external recipients in a conversation. Warn users before they reply to email with external recipients who aren't in their contacts** checkbox.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.14.1v1": {
+      "id": "gws.gmail.14.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.14.1v1",
+      "group": "Email Allowlist",
+      "groupNumber": 14,
+      "assertion": "An email allowlist SHOULD NOT be implemented.",
+      "obligation": "SHOULD NOT",
+      "rationale": "Implementing an email allowlist could potentially expose users to security risks as allowlisted senders bypass important security mechanisms, including spam filtering and sender authentication checks. This risk can be reduced by not implementing an allowlist, enhancing the safety and integrity of the user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-4"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.001",
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1566.003"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Gmail**.\n3.  Select **Spam, phishing, and malware -\\> Email allowlist**.\n4.  Under the **Enter the IP addresses for your email allowlist** field, ensure **no IP addresses** are listed.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.15.1v1": {
+      "id": "gws.gmail.15.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.15.1v1",
+      "group": "Enhanced Pre-Delivery Message Scanning",
+      "groupNumber": 15,
+      "assertion": "Enhanced pre-delivery message scanning SHALL be enabled to prevent phishing.",
+      "obligation": "SHALL",
+      "rationale": "Without enhanced pre-delivery message scanning, users may be exposed to phishing attempts, posing a security risk. By enabling this feature, potential phishing emails can be identified and blocked before reaching the user, reducing the risk and enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-3",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1566.003"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Gmail**.\n3.  Select **Spam, phishing, and malware -\\> Enhanced pre-delivery message scanning**.\n4.  Check the **Enables improved detection of suspicious content prior to delivery** checkbox.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.16.1v1": {
+      "id": "gws.gmail.16.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.16.1v1",
+      "group": "Security Sandbox",
+      "groupNumber": 16,
+      "assertion": "Security sandbox SHOULD be enabled to provide additional email protections.",
+      "obligation": "SHOULD",
+      "rationale": "Without a security sandbox, emails with malicious content could potentially interact directly with the users' systems, posing a security risk. By enabling the security sandbox, additional protections are provided for email messages, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-3",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Gmail**.\n3.  Select **Spam, phishing, and malware -\\> Security sandbox**.\n4.  Check the **Enable virtual execution of attachments in a sandbox environment for all the users of the Organizational Unit for protection against malware, ransomware, and zero-day threats** checkbox.\n5.  Either **Security sandbox** or **Security sandbox rules** may be enabled but enabling **Security sandbox** takes precedence.\n6.  If **Security sandbox** rules are enabled, then the configuration needs to be completed and consists of the following fields **:**\n    1. A short description.\n    2. Email messages to affect.\n    3. Expressions to describe the content to search for in each message.\n    4. Action to take if expressions match.\n7. Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.17.1v1": {
+      "id": "gws.gmail.17.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.17.1v1",
+      "group": "Comprehensive Mail Storage",
+      "groupNumber": 17,
+      "assertion": "Comprehensive mail storage SHOULD be enabled to allow information traceability across applications.",
+      "obligation": "SHOULD",
+      "rationale": "The absence of comprehensive mail storage could compromise the ability for information traceability across applications, posing a security risk. Enabling comprehensive mail storage can reduce this risk, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "November 2023",
+      "nist80053": [
+        "SI-12",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Gmail**.\n3.  Select **Compliance -\\> Comprehensive mail storage**.\n4.  Check the **Ensure that a copy of all sent and received mail is stored in associated users' mailboxes** checkbox.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.18.1v1": {
+      "id": "gws.gmail.18.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.18.1v1",
+      "group": "Spam Filtering",
+      "groupNumber": 18,
+      "assertion": "Domains SHALL NOT be added to lists that bypass spam filters.",
+      "obligation": "SHALL NOT",
+      "rationale": "Spam protections may incorrectly filter legitimate emails. Adding allowed senders is an acceptable method of combating these false positives. Allowing an entire domain, especially a common domain like office.com, could enable numerous unknown users to bypass spam protections.",
+      "lastModified": "April 2024",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1534"
+      ],
+      "note": "Allowed senders MAY be added.",
+      "instructions": "For each rule listed under **Spam**:\n1. Ensure that either:\n    * **Bypass spam filters for messages from senders or domains in selected lists** is not selected, or\n    * None of the lists shown under **Bypass spam filters for messages from senders or domains in selected lists** contain an entire domain. For example, the entire domain \"example.com\" is not acceptable, but the specific address, john.doe@example.com, would be.\n2. Modify the rule or lists associated with the rule as needed, then select **Save.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.18.2v1": {
+      "id": "gws.gmail.18.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.18.2v1",
+      "group": "Spam Filtering",
+      "groupNumber": 18,
+      "assertion": "Domains SHALL NOT be added to lists that bypass spam filters and hide warnings.",
+      "obligation": "SHALL NOT",
+      "rationale": "Spam protections may incorrectly filter legitimate emails. Adding allowed senders is an acceptable method of combating these false positives. Allowing an entire domain, especially a common domain like office.com, could enable numerous unknown users to bypass spam protections.",
+      "lastModified": "April 2024",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1534"
+      ],
+      "instructions": "For each rule listed under **Spam**:\n1. Ensure that either:\n    * **Bypass spam filters and hide warnings for messages from senders or domains in selected lists** is not selected, or\n    * None of the lists shown under **Bypass spam filters and hide warnings for messages from senders or domains in selected lists** contain an entire domain. For example, the entire domain \"example.com\" is not acceptable, but the specific address, john.doe@example.com, would be.\n2. Modify the rule or lists associated with the rule as needed, then select **Save.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.18.3v1": {
+      "id": "gws.gmail.18.3v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.18.3v1",
+      "group": "Spam Filtering",
+      "groupNumber": 18,
+      "assertion": "\"Bypass spam filters\" and \"hide warnings for all messages from internal and external senders\" SHALL NOT be enabled.",
+      "obligation": "SHALL NOT",
+      "rationale": "Bypassing spam filters and hiding warnings for all messages from internal and external senders creates a security risk by allowing all messages to bypass filters. Disabling this feature mitigates the risk.",
+      "lastModified": "April 2024",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1534"
+      ],
+      "instructions": "For each rule listed under **Spam**:\n1. Ensure that **Bypass spam filters and hide warnings for all messages from internal and external sender** is not selected.\n2. Select **Save.**",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.2.1v1": {
+      "id": "gws.gmail.2.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.2.1v1",
+      "group": "DomainKeys Identified Mail",
+      "groupNumber": 2,
+      "assertion": "DKIM SHOULD be enabled for all domains.",
+      "obligation": "SHOULD",
+      "rationale": "Enabling DKIM for all domains can help prevent email spoofing and phishing attacks. Without DKIM, threat actors could manipulate email headers to appear as if they are from a legitimate source, potentially leading to the disclosure of sensitive information. By enabling DKIM, the authenticity of emails can be verified, reducing this risk.",
+      "lastModified": "November 2023",
+      "nist80053": [
+        "SC-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1434",
+        "T1672"
+      ],
+      "note": "This policy is not applicable to user alias domains. Emails sent from user alias domains will be signed by a Google-managed DKIM signing domain (gappssmtp.com) even if DKIM is disabled.",
+      "instructions": "To configure the settings for DKIM:\n1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Gmail**.\n3.  Select **Authenticate email -\\> DKIM authentication**.\n4.  Select a domain listed in the **Selected** domain drop-down menu.\n5.  Select **START AUTHENTICATION**.\n6.  Select **Save**.\n7.  Add the DNS TXT record listed in Admin Console to the domain, via the domain provider's DNS settings page. Note that it can take up to 48 hours for DNS changes to fully propagate.\n\nNote that step 7 requires action taken outside of the Google Admin Console, dependent on the agency's domain provider. Thus, the exact final step needed to set up DKIM varies from agency to agency. See [Turn on DKIM for your domain](https://support.google.com/a/answer/180504) for more details.\n\nTo test your DKIM configuration, consider using a web-based tool, such as the [Google Admin Toolbox](https://toolbox.googleapps.com/apps/checkmx/).",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.3.1v1": {
+      "id": "gws.gmail.3.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.3.1v1",
+      "group": "Sender Policy Framework",
+      "groupNumber": 3,
+      "assertion": "An SPF policy SHALL be published for each domain that fails all non-approved senders.",
+      "obligation": "SHALL",
+      "rationale": "Threat actors could potentially manipulate an email \"from\" field to appear as a legitimate sender, increasing the risk of phishing attacks. By publishing an SPF policy that fails all non-approved senders for each domain, this risk can be reduced as it helps to detect and block deceptive emails. Additionally, an SPF policy is required for FCEB agencies by BOD 18-01.",
+      "lastModified": "February 2024",
+      "nist80053": [
+        "AC-2d"
+      ],
+      "mitreAttack": [
+        "T1078",
+        "T1078.004",
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1566.003",
+        "T1672",
+        "T1598",
+        "T1598.003"
+      ],
+      "note": "- SPF defines two different \"fail\" mechanisms: fail (indicated by `-`, sometimes referred to as hardfail) and softfail (indicated by `~`). Either hard or soft fail may be used to comply with this baseline policy. - This policy is not applicable to user alias domains. Gmail uses the primary domain as the `envelope-from` domain and the alias domain as the `header-from` domain. SPF only verifies the `envelope-from` domain.",
+      "instructions": "First, identify any approved senders specific to your agency (see [Identify all email senders for your organization](https://support.google.com/a/answer/10686639#senders) for tips). SPF allows you to indicate approved senders by IP address or CIDR range. However, note that SPF allows you to [include](https://www.rfc-editor.org/rfc/rfc7208#section-5.2) the IP addresses indicated by a separate SPF policy, refered to by domain name. See [Define your SPF record—Basic setup](https://support.google.com/a/answer/10685031) for inclusions required for Google to send email on behalf of your domain.\n\nSPF is not configured through the Google Workspace admin center, but rather via DNS records hosted by the agency's domain. Thus, the exact steps needed to set up SPF varies from agency to agency. See [Add your SPF record at your domain provider](https://support.google.com/a/answer/10684623) for more details.\n\nTo test your SPF configuration, consider using a web-based tool, such as the [Google Admin Toolbox](https://toolbox.googleapps.com/apps/checkmx/).  Additionally, SPF records can be requested using the command line tool `dig`. For example:\n```\ndig example.com txt\n```\nIf SPF is configured, a response resembling `v=spf1 include:_spf.google.com -all` will be returned; though by necessity, the contents of the SPF policy may vary by agency. In this example, the SPF policy indicates the IP addresses listed by the policy for \"_spf.google.com\" are the only approved senders for \"example.com.\" These IPs can be determined via additional SPF lookups, starting with \"_spf.google.com.\"\n\nEnsure the IP addresses listed as approved senders for your domains are correct. Additionally, ensure that each policy either ends in `-all` or [redirects](https://www.rfc-editor.org/rfc/rfc7208#section-6.1) to one that does; this directive indicates that all IPs that don't match the policy should fail. See [Define your SPF record—Advanced setup](https://support.google.com/a/answer/10683907) for a more in-depth discussion of SPF record syntax.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.4.1v1": {
+      "id": "gws.gmail.4.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.4.1v1",
+      "group": "Domain-based Message Authentication, Reporting, and Conformance",
+      "groupNumber": 4,
+      "assertion": "A DMARC policy SHALL be published at the full domain or the second-level domain for all Google Workspace domains, including user alias domains.",
+      "obligation": "SHALL",
+      "rationale": "Without proper authentication and a DMARC policy available for each domain, recipients may improperly handle SPF and DKIM failures, possibly enabling threat actors to send deceptive emails that appear to be from your domain. Publishing a DMARC policy for every domain further reduces the risk posed by authentication failures.",
+      "lastModified": "September 2025",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1672",
+        "T1598",
+        "T1598.003"
+      ],
+      "note": "- A DMARC record published at the second-level domain applies to all subdomains by default. In other words, a DMARC record published for `example.com` will protect both `a.example.com` and `b.example.com`, but a separate record would need to be published for `c.example.gov`. In this example `a.example.com` is the full domain, or fully qualified domain name (FQDN), whereas `example.com` is the second-level domain. - User alias domains provide an alternative email address to send or receive email and therefore must have a DMARC policy in place.",
+      "instructions": "DMARC is not configured through the Google Admin Console, but rather via DNS records hosted by the agency's domain(s). As such, implementation varies depending on how an agency manages its DNS records. See [Add your DMARC record](https://support.google.com/a/answer/2466563) for Google guidance.\n\nTo test your DMARC configuration, consider using one of many publicly available web-based tools, such as the [Google Admin Toolbox](https://toolbox.googleapps.com/apps/checkmx/). Additionally, DMARC records can be requested using the command line tool `dig`. For example:\n\n```\ndig _dmarc.example.com txt\n```\n\nIf DMARC is configured, a response resembling `v=DMARC1; p=reject; pct=100; rua=mailto:reports@dmarc.cyber.dhs.gov, mailto:reports@example.com; ruf=mailto:reports@example.com` will be returned, though by necessity, the contents of the record will vary by agency. In this example, the policy indicates all emails failing the SPF/DKIM checks are to be rejected and aggregate reports sent to reports@dmarc.cyber.dhs.gov and reports@example.com. Failure reports will be sent to reports@example.com.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.4.2v1": {
+      "id": "gws.gmail.4.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.4.2v1",
+      "group": "Domain-based Message Authentication, Reporting, and Conformance",
+      "groupNumber": 4,
+      "assertion": "The DMARC message rejection option SHALL be p=reject.",
+      "obligation": "SHALL",
+      "rationale": "Without stringent email authentication, threat actors could potentially send deceptive emails that appear to be from the organization's domain, increasing the risk of phishing attacks. This policy reduces risk as it automatically rejects emails that fail SPF or DKIM checks, preventing potentially harmful emails from reaching recipients. Additionally, \"reject\" is the level of protection required by BOD 18-01 for federal civilian executive branch (FCEB) agencies.",
+      "lastModified": "November 2023",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1566.003",
+        "T1586",
+        "T1586.002",
+        "T1672"
+      ],
+      "instructions": "See [GWS.GMAIL.4.1 instructions](#gmail41-instructions) for an overview of how to publish and check a DMARC record. Ensure the record published includes `p=reject`.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.4.3v1": {
+      "id": "gws.gmail.4.3v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.4.3v1",
+      "group": "Domain-based Message Authentication, Reporting, and Conformance",
+      "groupNumber": 4,
+      "assertion": "The DMARC point of contact for aggregate reports SHALL include `reports@dmarc.cyber.dhs.gov`.",
+      "obligation": "SHALL",
+      "rationale": "Without a centralized point of contact for DMARC aggregate reports, potential email security issues may go unnoticed, increasing the risk of phishing attacks. As required by BOD 18-01, FCEB users should set reports@dmarc.cyber.dhs.gov as the DMARC aggregate report recipient. This allows CISA to monitor and address email authentication issues.",
+      "lastModified": "November 2023",
+      "nist80053": [
+        "SI-4(5)"
+      ],
+      "mitreAttack": [],
+      "note": "Only FCEB agencies should include this email address in their DMARC record.",
+      "instructions": "See [GWS.GMAIL.4.1 instructions](#gmail41-instructions) for an overview of how to publish and check a DMARC record. Ensure the record published includes reports@dmarc.cyber.dhs.gov as one of the emails for the `rua` field.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.4.4v1": {
+      "id": "gws.gmail.4.4v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.4.4v1",
+      "group": "Domain-based Message Authentication, Reporting, and Conformance",
+      "groupNumber": 4,
+      "assertion": "An agency point of contact SHOULD be included for aggregate and failure reports.",
+      "obligation": "SHOULD",
+      "rationale": "Without a designated agency point of contact for DMARC aggregate and failure reports, potential email security issues may not be promptly addressed, increasing the risk of phishing attacks. This risk can be reduced by including an agency point of contact, facilitating timely response to email authentication issues and enhancing overall email security.",
+      "lastModified": "November 2023",
+      "nist80053": [
+        "SI-4(5)"
+      ],
+      "mitreAttack": [],
+      "instructions": "See [GWS.GMAIL.4.1 instructions](#gmail41-instructions) for an overview of how to publish and check a DMARC record. Ensure the record published includes a point of contact specific to your agency, in addition to reports@dmarc.cyber.dhs.gov, as one of the emails for the `rua` field and one or more agency-defined points of contact for the `ruf` field.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.5.1v1": {
+      "id": "gws.gmail.5.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.5.1v1",
+      "group": "Attachment Protections",
+      "groupNumber": 5,
+      "assertion": "\"Protect against encrypted attachments from untrusted senders\" SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Attachments from untrusted senders, especially encrypted ones, may contain malicious content that poses a security risk. By enabling protection against encrypted attachments from untrusted senders, this risk can be reduced, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-3",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1566.003",
+        "T1204",
+        "T1204.001",
+        "T1204.002",
+        "T1204.003"
+      ],
+      "instructions": "1.  Check the **Protect against encrypted attachments from untrusted senders** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.5.2v1": {
+      "id": "gws.gmail.5.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.5.2v1",
+      "group": "Attachment Protections",
+      "groupNumber": 5,
+      "assertion": "\"Protect against attachments with scripts from untrusted senders\" SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Attachments with scripts from untrusted senders may contain malicious content that poses a security risk. By enabling protection against such attachments, this risk can be reduced, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-3",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1566.003",
+        "T1204",
+        "T1204.001",
+        "T1204.002",
+        "T1204.003"
+      ],
+      "instructions": "1.  Check the **Protect against attachments with scripts from untrusted senders** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.5.3v1": {
+      "id": "gws.gmail.5.3v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.5.3v1",
+      "group": "Attachment Protections",
+      "groupNumber": 5,
+      "assertion": "\"Protect against anomalous attachment types in emails\" SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Anomalous attachment types in emails may contain malicious content that poses a security risk. By enabling protection against such attachments, this risk can be reduced, enhancing the safety and integrity of the user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-3",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1566.003",
+        "T1204",
+        "T1204.001",
+        "T1204.002",
+        "T1204.003"
+      ],
+      "instructions": "1.  Check the **Protect against anomalous attachment types in emails** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.5.4v1": {
+      "id": "gws.gmail.5.4v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.5.4v1",
+      "group": "Attachment Protections",
+      "groupNumber": 5,
+      "assertion": "Google SHOULD be allowed to automatically apply future recommended settings for attachments.",
+      "obligation": "SHOULD",
+      "rationale": "By enabling this feature, the system can automatically stay updated with the latest security measures recommended by Google, reducing the risk of security breaches.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-3",
+        "SI-8"
+      ],
+      "mitreAttack": [],
+      "instructions": "1.  Check the **Apply future recommended settings automatically** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.5.5v1": {
+      "id": "gws.gmail.5.5v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.5.5v1",
+      "group": "Attachment Protections",
+      "groupNumber": 5,
+      "assertion": "Emails flagged by SCuBA policies GWS.GMAIL.5.1 through GWS.GMAIL.5.3 SHALL NOT be kept in inbox.",
+      "obligation": "SHALL NOT",
+      "rationale": "Keeping emails flagged by attachment protection controls in the inbox could potentially expose users to malicious content. Removing these emails from the inbox enhances the safety and integrity of user data and systems.",
+      "lastModified": "September 2023",
+      "nist80053": [
+        "SI-3",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1566.003",
+        "T1204",
+        "T1204.001",
+        "T1204.002",
+        "T1204.003"
+      ],
+      "note": "Agencies/organizations can choose whether to send these emails to spam or quarantine.",
+      "instructions": "1.  Under the setting for Policy 5.1 through Policy 5.3, ensure either \"Move email to spam\" or \"Quarantine\" is selected.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.6.1v1": {
+      "id": "gws.gmail.6.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.6.1v1",
+      "group": "Links and External Images Protection",
+      "groupNumber": 6,
+      "assertion": "\"Identify links behind shortened URLs\" SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Shortened URLs can hide malicious links, posing a security risk. This risk can be reduced by identifying links behind shortened URLs, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-3",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1434",
+        "T1566",
+        "T1566.002",
+        "T1204",
+        "T1204.001"
+      ],
+      "instructions": "1.  Check the **Identify links behind shortened URLs** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.6.2v1": {
+      "id": "gws.gmail.6.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.6.2v1",
+      "group": "Links and External Images Protection",
+      "groupNumber": 6,
+      "assertion": "\"Scan linked images\" SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Linked images in emails can contain malicious content, posing a security risk. By enabling the scanning of linked images, this risk can be reduced, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-3",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1434",
+        "T1566",
+        "T1566.002",
+        "T1204",
+        "T1204.002"
+      ],
+      "instructions": "1.  Check the **Scan linked images** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.6.3v1": {
+      "id": "gws.gmail.6.3v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.6.3v1",
+      "group": "Links and External Images Protection",
+      "groupNumber": 6,
+      "assertion": "\"Show warning prompt for any click on links to untrusted domains\" SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Clicking on links to unfamiliar domains can expose users to malicious content, posing a security risk. This risk can be reduced by enabling a warning prompt for any click on such links, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-4",
+        "SI-8",
+        "AT-2b"
+      ],
+      "mitreAttack": [
+        "T1434",
+        "T1566",
+        "T1566.002",
+        "T1204",
+        "T1204.001"
+      ],
+      "instructions": "1.  Check the **Show warning prompt for any click on links to untrusted domains** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.6.4v1": {
+      "id": "gws.gmail.6.4v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.6.4v1",
+      "group": "Links and External Images Protection",
+      "groupNumber": 6,
+      "assertion": "Google SHALL be allowed to automatically apply future recommended settings for links and external images.",
+      "obligation": "SHALL",
+      "rationale": "By enabling this feature, the system can automatically stay updated with the latest recommended security measures from Google, reducing the risk of security breaches and enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-3",
+        "SI-8"
+      ],
+      "mitreAttack": [],
+      "instructions": "1.  Check the **Apply future recommended settings automatically** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.7.1v1": {
+      "id": "gws.gmail.7.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.7.1v1",
+      "group": "Spoofing and Authentication Protection",
+      "groupNumber": 7,
+      "assertion": "\"Protect against domain spoofing based on similar domain names\" SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Emails sent from domains that look similar to the user's domain can deceive users into interacting with malicious content, posing a security risk. Enabling protection against such spoofing can reduce this risk, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1434",
+        "T1566",
+        "T1566.001",
+        "T1566.002"
+      ],
+      "instructions": "1.  Check the **Protect against domain spoofing based on similar domain names** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.7.2v1": {
+      "id": "gws.gmail.7.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.7.2v1",
+      "group": "Spoofing and Authentication Protection",
+      "groupNumber": 7,
+      "assertion": "\"Protect against spoofing of employee names\" SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Spoofing of employee identities (e.g., CEO and IT staff) can deceive users into interacting with malicious content, posing a security risk. Enabling protection against such spoofing can reduce this risk, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1434",
+        "T1566",
+        "T1566.001",
+        "T1566.002"
+      ],
+      "instructions": "1.  Check the **Protect against spoofing of employee names** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.7.3v1": {
+      "id": "gws.gmail.7.3v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.7.3v1",
+      "group": "Spoofing and Authentication Protection",
+      "groupNumber": 7,
+      "assertion": "\"Protect against inbound emails spoofing your domain\" SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Inbound emails appearing to come from the user's domain can deceive users into interacting with malicious content, posing a security risk. This risk can be reduced by enabling protection against such spoofing, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1434",
+        "T1566",
+        "T1566.001",
+        "T1566.002"
+      ],
+      "instructions": "1.  Check the **Protect against inbound emails spoofing your domain** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.7.4v1": {
+      "id": "gws.gmail.7.4v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.7.4v1",
+      "group": "Spoofing and Authentication Protection",
+      "groupNumber": 7,
+      "assertion": "\"Protect against any unauthenticated emails\" SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Unauthenticated emails can contain malicious content, posing a security risk. This risk can be reduced by enabling protection against such emails, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1434",
+        "T1566",
+        "T1566.001",
+        "T1566.002"
+      ],
+      "instructions": "1.  Check the **Protect against any unauthenticated emails** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.7.5v1": {
+      "id": "gws.gmail.7.5v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.7.5v1",
+      "group": "Spoofing and Authentication Protection",
+      "groupNumber": 7,
+      "assertion": "\"Protect your Groups from inbound emails spoofing your domain\" SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Inbound emails spoofing the user's domain can deceive users into interacting with malicious content, posing a security risk. This risk can be reduced by enabling protection against such spoofing, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1434",
+        "T1566",
+        "T1566.001",
+        "T1566.002"
+      ],
+      "instructions": "1.  Check the **Protect your groups from inbound emails spoofing your domain** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.7.6v1": {
+      "id": "gws.gmail.7.6v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.7.6v1",
+      "group": "Spoofing and Authentication Protection",
+      "groupNumber": 7,
+      "assertion": "Emails flagged by SCuBA policies GWS.GMAIL.7.1 through GWS.GMAIL.7.5 SHALL NOT be kept in inbox.",
+      "obligation": "SHALL NOT",
+      "rationale": "Retaining emails flagged by spoofing and authentication controls in the inbox could potentially expose users to malicious content. Moving emails out of the main inbox, to either spam or quarantine, can reduce this risk, enhancing the safety and integrity of the user's data and systems.",
+      "lastModified": "September 2023",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1434",
+        "T1566",
+        "T1566.001",
+        "T1566.002"
+      ],
+      "note": "Agencies/organizations can choose whether to send the emails to spam or quarantine.",
+      "instructions": "1.  Under each setting from Policy 7.1 through Policy 7.5, make sure either \"Move email to spam\" or \"Quarantine\" is selected.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.7.7v1": {
+      "id": "gws.gmail.7.7v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.7.7v1",
+      "group": "Spoofing and Authentication Protection",
+      "groupNumber": 7,
+      "assertion": "Google SHALL be allowed to automatically apply future recommended settings for spoofing and authentication.",
+      "obligation": "SHALL",
+      "rationale": "By enabling this feature, the system can automatically stay updated with the latest Google recommended security measures, reducing the risk of security breaches and enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1434",
+        "T1566",
+        "T1566.001",
+        "T1566.002"
+      ],
+      "instructions": "1.  Check the **Apply future recommended settings automatically** checkbox.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.8.1v1": {
+      "id": "gws.gmail.8.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.8.1v1",
+      "group": "User Email Uploads",
+      "groupNumber": 8,
+      "assertion": "User email uploads SHALL be disabled to protect against unauthorized files being introduced into the secured environment.",
+      "obligation": "SHALL",
+      "rationale": "Allowing user email uploads could potentially introduce unauthorized or malicious files into the secured environment, posing a security risk. By disabling user email uploads, this risk can be reduced, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "CM-7",
+        "SI-3",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1199",
+        "T1204",
+        "T1204.001",
+        "T1204.002",
+        "T1204.003"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Gmail**.\n3.  Select **Setup -\\> User email uploads**.\n4.  Uncheck the **Show users the option to import mail and contacts from Yahoo!, Hotmail, AOL, or other webmail or POP3 accounts from the Gmail settings page** checkbox.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.gmail.9.1v1": {
+      "id": "gws.gmail.9.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GMAIL.9.1v1",
+      "group": "POP and IMAP Access for Users",
+      "groupNumber": 9,
+      "assertion": "POP and IMAP access SHALL be disabled to protect sensitive agency or organization emails from being accessed through legacy applications or other third-party mail clients.",
+      "obligation": "SHALL",
+      "rationale": "Enabling POP and IMAP access could potentially expose sensitive agency or organization emails to unauthorized access through legacy applications or third-party mail clients, posing a security risk. This risk can be reduced by disabling POP and IMAP access, enhancing the safety and integrity of user data and systems.",
+      "lastModified": "October 2025",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1048",
+        "T1048.002"
+      ],
+      "note": "IMAP access MAY be enabled on a per-OU or per-group basis when there is a specific need, e.g., to support users that require specialized software for accessibility purposes.",
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps -\\> Google Workspace -\\> Gmail**.\n3.  Select **End User Access -\\> POP and IMAP access**.\n4.  Uncheck the **Enable IMAP access for all users** checkbox.\n5.  Uncheck the **Enable POP access for all users** checkbox.\n6.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/gmail.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/gmail.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md"
+    },
+    "gws.groups.1.1v1": {
+      "id": "gws.groups.1.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GROUPS.1.1v1",
+      "group": "External Group Access",
+      "groupNumber": 1,
+      "assertion": "Group access from outside the organization SHALL be disabled unless explicitly granted by the group owner.",
+      "obligation": "SHALL",
+      "rationale": "Groups may contain private or sensitive information. Restricting group access reduces the risk of data loss.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-3"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "instructions": "To configure the settings for sharing options:\n1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Groups for Business**.\n3.  Select **Sharing settings** -\\> **Sharing options**.\n4.  Select **Accessing groups from outside this organization** -\\> **Private**.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/groups.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/groups.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/groups.md"
+    },
+    "gws.groups.1.2v1": {
+      "id": "gws.groups.1.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GROUPS.1.2v1",
+      "group": "External Group Access",
+      "groupNumber": 1,
+      "assertion": "Group owners' ability to add external members to groups SHOULD be disabled unless necessary for agency mission fulfillment.",
+      "obligation": "SHOULD",
+      "rationale": "Groups may contain private or sensitive information. Restricting group access reduces the risk of data loss.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "CM-7",
+        "AC-6(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1048",
+        "T1048.001",
+        "T1048.002"
+      ],
+      "instructions": "To configure the settings for sharing options:\n1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Groups for Business**.\n3.  Select **Sharing settings** -\\> **Sharing options**.\n4.  **Uncheck** the **Group owners can allow external members** checkbox.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/groups.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/groups.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/groups.md"
+    },
+    "gws.groups.1.3v1": {
+      "id": "gws.groups.1.3v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GROUPS.1.3v1",
+      "group": "External Group Access",
+      "groupNumber": 1,
+      "assertion": "Group owners' ability to allow external, non-group members to post in the group SHOULD be disabled unless necessary for agency mission fulfillment.",
+      "obligation": "SHOULD",
+      "rationale": "Allowing external users to post in a group allows for potential phishing or other malicious activity to be shared via groups. Restricting posting by external, non-group members reduces this risk.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "CM-7",
+        "AC-6(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1048",
+        "T1048.001",
+        "T1048.002",
+        "T1566",
+        "T1566.001",
+        "T1566.002"
+      ],
+      "instructions": "To configure the settings for sharing options:\n1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Groups for Business**.\n3.  Select **Sharing settings** -\\> **Sharing options**.\n4.  **Uncheck** the **Group owners can allow incoming mail from outside the organization** checkbox.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/groups.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/groups.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/groups.md"
+    },
+    "gws.groups.2.1v1": {
+      "id": "gws.groups.2.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GROUPS.2.1v1",
+      "group": "Group Creation",
+      "groupNumber": 2,
+      "assertion": "Group creation SHOULD be restricted to administrators within the organization unless alternative creators are necessary for agency mission fulfillment.",
+      "obligation": "SHOULD",
+      "rationale": "Many Google Workspace product settings can be set at the \"Group\" level. However, allowing unrestricted group creation can complicate setting management and open channels of unmanaged communication. Restricting group creation to organization administrators helps reduce this risk.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-6(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1069",
+        "T1069.003"
+      ],
+      "instructions": "To configure the settings for Sharing options:\n\n1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Groups for Business**.\n3.  Select **Sharing settings** -\\> **Sharing options**.\n4.  Select **Creating groups** -\\> **Only organization admins can create groups**.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/groups.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/groups.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/groups.md"
+    },
+    "gws.groups.3.1v1": {
+      "id": "gws.groups.3.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GROUPS.3.1v1",
+      "group": "Default Permissions for Viewing Conversations",
+      "groupNumber": 3,
+      "assertion": "The default permission to view conversations SHOULD be set to \"All group members.\"",
+      "obligation": "SHOULD",
+      "rationale": "Groups may contain private or sensitive information not appropriate for the entire Google Workspace (GWS) organization. Restricting access to group members reduces the risk of data loss.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-6"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1048",
+        "T1048.001",
+        "T1048.002"
+      ],
+      "note": "This setting can be changed by group owners and group managers.",
+      "instructions": "To configure the settings for Sharing options:\n\n1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Groups for Business**.\n3.  Select **Sharing settings** -\\> **Sharing options**.\n4.  Select **Default for permission to view conversations** -\\> **All group members**.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/groups.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/groups.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/groups.md"
+    },
+    "gws.groups.4.1v1": {
+      "id": "gws.groups.4.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.GROUPS.4.1v1",
+      "group": "Ability to Hide Groups from the Directory",
+      "groupNumber": 4,
+      "assertion": "The ability for groups to be hidden from the directory SHALL be disabled.",
+      "obligation": "SHALL",
+      "rationale": "Hidden groups are not visible, even to administrators, in the list of groups found at groups.google.com, though they are still visible on the directory page at admin.google.com. Allowing for hidden groups increases the risk of groups being created without administrator oversight.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1048",
+        "T1048.001",
+        "T1048.002"
+      ],
+      "instructions": "To configure the settings for Sharing options:\n\n1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Groups for Business**.\n3.  Select **Sharing settings** -\\> **Sharing options**.\n4.  **Uncheck** the **Group owners can hide groups from the directory** checkbox.\n5.  **Ensure** that the **hide newly created groups from the directory** checkbox is not selected.\n6.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/groups.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/groups.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/groups.md"
+    },
+    "gws.meet.1.1v1": {
+      "id": "gws.meet.1.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.MEET.1.1v1",
+      "group": "Meeting Access",
+      "groupNumber": 1,
+      "assertion": "External users who were not explicitly invited to a Google Meet meeting SHALL be required to ask to join.",
+      "obligation": "SHALL",
+      "rationale": "Allowing users external to an organization or not on the invite list to join meetings without asking permission diminishes host control of meeting participation, reduces user accountability, and invites potential data leaks. This policy reduces that risk by requiring users external to the organization or without an invitation to request organizer permission prior to joining meetings.",
+      "lastModified": "November 2025",
+      "nist80053": [
+        "IA-2",
+        "IA-8"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1123",
+        "T1113",
+        "T1125"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Google Meet**.\n3.  Select **Meet safety settings** -\\> **Access Type**.\n4.  In **Meeting access type (subject to restrictions set in Domain)**, select **Trusted** or **Restricted**.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/meet.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/meet.md"
+    },
+    "gws.meet.2.1v1": {
+      "id": "gws.meet.2.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.MEET.2.1v1",
+      "group": "Internal Access to External Meetings",
+      "groupNumber": 2,
+      "assertion": "Meeting access SHALL be disabled for meetings created by users who are not members of any Google Workspace (GWS) tenant or organization.",
+      "obligation": "SHALL",
+      "rationale": "Contact with unmanaged users can pose the risk of data leakage and other security threats. This policy reduces such contact by not allowing agency users to join meetings created by users' personal accounts.",
+      "lastModified": "September 2023",
+      "nist80053": [
+        "IA-8",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1078",
+        "T1123",
+        "T1113",
+        "T1125"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Google Meet**.\n3.  Select **Meet safety settings** -\\> **Access**.\n4.  Select **Meetings created in your organization only** or **Meetings created in any Workspace organization**.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/meet.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/meet.md"
+    },
+    "gws.meet.3.1v1": {
+      "id": "gws.meet.3.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.MEET.3.1v1",
+      "group": "Host Management Meeting Features",
+      "groupNumber": 3,
+      "assertion": "Host management meeting features SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "When host management features are disabled, any internal participant can take control of meetings, performing actions such as recording the meeting, disabling or enabling the chat, and ending the meeting. When host management features are enabled, these options are only available to meeting hosts.",
+      "lastModified": "January 2024",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.001",
+        "T1123",
+        "T1113",
+        "T1125"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Google Meet**.\n3.  Select **Meet safety settings** -\\> **Host management**.\n4.  Check the **Start video calls with host management turned on** checkbox.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/meet.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/meet.md"
+    },
+    "gws.meet.4.1v1": {
+      "id": "gws.meet.4.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.MEET.4.1v1",
+      "group": "External Participants",
+      "groupNumber": 4,
+      "assertion": "\"Warn for external participants\" SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Users may inadvertently include external users in meetings or not be aware that external users are present. When enabled, external or unidentified participants in a meeting are given a visible label. This increases situational awareness amongst meeting participants and can help prevent inadvertent data leaks.",
+      "lastModified": "September 2023",
+      "nist80053": [
+        "SC-15"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1566",
+        "T1566.004",
+        "T1598",
+        "T1598.004",
+        "T1123",
+        "T1113",
+        "T1125"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Google Meet**.\n3.  Select **Meet safety settings** -\\> **Warn for external participants**.\n4.  Check the **External or unidentified participants in a meeting are given a label** checkbox.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/meet.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/meet.md"
+    },
+    "gws.meet.5.1v1": {
+      "id": "gws.meet.5.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.MEET.5.1v1",
+      "group": "Video Meeting Settings",
+      "groupNumber": 5,
+      "assertion": "Automatic recordings for Google Meet SHALL be disabled.",
+      "obligation": "SHALL",
+      "rationale": "Automatic recordings could record sensitive information. By selecting this setting, it potentially mitigates unauthorized data leakage.",
+      "lastModified": "April 2026",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1123",
+        "T1048",
+        "T1565"
+      ],
+      "note": "The meeting owner retains the ability to modify this setting for their own meetings.",
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Meet**.\n3.  Click **Meet video settings**.\n4.  Click **Automatic recording**.\n5.  Ensure **Meetings are recorded by default** is unselected.\n6.  Click **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/meet.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/meet.md"
+    },
+    "gws.meet.5.2v1": {
+      "id": "gws.meet.5.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.MEET.5.2v1",
+      "group": "Video Meeting Settings",
+      "groupNumber": 5,
+      "assertion": "Automatic transcripts for Google Meet SHALL be disabled.",
+      "obligation": "SHALL",
+      "rationale": "Automatic transcripts could record sensitive information. By selecting this setting, it potentially mitigates unauthorized data leakage.",
+      "lastModified": "April 2026",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1113",
+        "T1048",
+        "T1565"
+      ],
+      "note": "The meeting owner retains the ability to modify this setting for their own meetings.",
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Meet**.\n3.  Click **Meet video settings**.\n4.  Click **Automatic transcription**.\n5.  Ensure **Meetings are transcribed by default** is unselected.\n6.  Click **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/meet.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/meet.md"
+    },
+    "gws.meet.6.1v1": {
+      "id": "gws.meet.6.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.MEET.6.1v1",
+      "group": "Gemini Settings",
+      "groupNumber": 6,
+      "assertion": "Administrators SHOULD NOT be allowed to override the default sharing level for meeting notes set by the organization.",
+      "obligation": "SHOULD NOT",
+      "rationale": "Meeting notes may contain sensitive information that should not be shared outside of the organization. Preventing administrators from overriding the default sharing level reduces the risk of inadvertent meeting note sharing.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "AC-3",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1567.002"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Meet**.\n3.  Click **Gemini Settings**.\n4.  Click **Google AI notes sharing**.\n5.  Ensure **Allow hosts to change who notes are shared to** is unselected.\n6.  Click **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/meet.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/meet.md"
+    },
+    "gws.meet.6.2v1": {
+      "id": "gws.meet.6.2v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.MEET.6.2v1",
+      "group": "Gemini Settings",
+      "groupNumber": 6,
+      "assertion": "Default sharing setting for Google AI notes SHALL be restricted to \"Guests in your organization.\"",
+      "obligation": "SHALL",
+      "rationale": "Meeting notes may contain sensitive information that should not be shared outside of the organization. Setting a secure default sharing level reduces the risk of inadvertent meeting note sharing.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1530",
+        "T1567.002"
+      ],
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Meet**.\n3.  Click **Gemini Settings**.\n4.  Click **Google AI notes sharing**.\n5.  Ensure **Default sharing setting for Google AI notes** is set to \"The hosts and co-hosts\" or \"Invited Guests in your Organization\".\n6.  Click **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/meet.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/meet.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/meet.md"
+    },
+    "gws.sites.1.1v1": {
+      "id": "gws.sites.1.1v1",
+      "platform": "google-workspace",
+      "policyId": "GWS.SITES.1.1v1",
+      "group": "Sites Service Status",
+      "groupNumber": 1,
+      "assertion": "Sites Service SHOULD be disabled for all users.",
+      "obligation": "SHOULD",
+      "rationale": "Google Sites can increase the attack surface of Google Workspace (GWS). Disabling the \"Sites Service\" feature, unless it is needed, conforms to the principle of least functionality.",
+      "lastModified": "December 2025",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1526",
+        "T1530"
+      ],
+      "note": "Google Sites MAY be enabled on a per-group and per-Organizational Unit (OU) basis.",
+      "instructions": "1.  Sign in to the [Google Admin Console](https://admin.google.com).\n2.  Select **Apps** -\\> **Google Workspace** -\\> **Sites**.\n3.  Select **Service Status**\n4.  Select **OFF for everyone**.\n5.  Select **Save**.",
+      "license": "CC0-1.0",
+      "licenseObligations": {
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Derived from the CISA Secure Configuration Baselines (SCuBA), released under CC0 1.0 Universal.",
+        "sourceUrl": "https://github.com/cisagov/ScubaGoggles/blob/95d80462699e469b569e5b5caf921c4b8c6c884a/scubagoggles/baselines/sites.md",
+        "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGoggles",
+          "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+          "path": "scubagoggles/baselines/sites.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/sites.md"
+    },
+    "ms.aad.1.1v1": {
+      "id": "ms.aad.1.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.1.1v1",
+      "group": "Legacy Authentication",
+      "groupNumber": 1,
+      "assertion": "Legacy authentication SHALL be blocked.",
+      "obligation": "SHALL",
+      "rationale": "The security risk of allowing legacy authentication protocols is they do not support MFA. Blocking legacy protocols reduces the impact of user credential theft.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003",
+        "T1078",
+        "T1078.004"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. [Determine if an agency’s existing applications use legacy authentication](https://learn.microsoft.com/en-us/entra/identity/conditional-access/block-legacy-authentication#identify-legacy-authentication-use) before blocking legacy authentication across the entire application base.\n\n2. Create a Conditional Access policy to block legacy authentication\n\n```\n  Users > Include > All users\n\n  Target resources > Include > All resources (formerly 'All cloud apps')\n\n  Conditions > Client apps > Configure > Yes > Legacy authentication clients > Select only Exchange ActiveSync clients and Other clients\n\n  Access controls > Grant > Block Access\n```",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.2.1v1": {
+      "id": "ms.aad.2.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.2.1v1",
+      "group": "Risk Based Policies",
+      "groupNumber": 2,
+      "assertion": "Users detected as high risk SHALL be blocked.",
+      "obligation": "SHALL",
+      "rationale": "Blocking high-risk users may prevent compromised accounts from accessing the tenant.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-2(12)",
+        "AC-2(13)"
+      ],
+      "mitreAttack": [
+        "T1078",
+        "T1078.004"
+      ],
+      "note": "Users identified as high risk by Microsoft Entra ID Identity Protection can be blocked from accessing the system via a Microsoft Entra ID Conditional Access policy. A high-risk user will be blocked until an administrator remediates their account.",
+      "productLicenseNotes": "- Requires a Microsoft Entra ID P2 license",
+      "instructions": "1.  Create a conditional access policy blocking users categorized as high risk by the Identity Protection service. Configure the following policy settings in the new conditional access policy as per the values below:\n\n```\n  Users > Include > All users\n\n  Target resources > Include > All resources (formerly 'All cloud apps')\n\n  Conditions > User risk > High\n\n  Access controls > Grant > Block Access\n```",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.2.2v1": {
+      "id": "ms.aad.2.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.2.2v1",
+      "group": "Risk Based Policies",
+      "groupNumber": 2,
+      "assertion": "A notification SHOULD be sent to the administrator when high-risk users are detected.",
+      "obligation": "SHOULD",
+      "rationale": "Notification enables the admin to monitor the event and remediate the risk. This helps the organization proactively respond to cyber intrusions as they occur.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-2(12)"
+      ],
+      "mitreAttack": [
+        "T1078",
+        "T1078.004"
+      ],
+      "productLicenseNotes": "- Requires a Microsoft Entra ID P2 license",
+      "instructions": "1.  [Configure Microsoft Entra ID Protection to send a regularly monitored security mailbox email notification](https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-notifications#configure-users-at-risk-detected-alerts) when user accounts are determined to be high risk.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.2.3v1": {
+      "id": "ms.aad.2.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.2.3v1",
+      "group": "Risk Based Policies",
+      "groupNumber": 2,
+      "assertion": "Sign-ins detected as high risk SHALL be blocked.",
+      "obligation": "SHALL",
+      "rationale": "This prevents compromised accounts from accessing the tenant.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-2(12)",
+        "AC-2(13)"
+      ],
+      "mitreAttack": [
+        "T1078",
+        "T1078.004"
+      ],
+      "productLicenseNotes": "- Requires a Microsoft Entra ID P2 license",
+      "instructions": "1.  Create a Conditional Access policy blocking sign-ins determined high risk by the Identity Protection service. Configure the following policy settings in the new Conditional Access policy as per the values below:\n\n```\n  Users > Include > All users\n\n  Target resources > Include > All resources (formerly 'All cloud apps')\n\n  Conditions > Sign-in risk > High\n\n  Access controls > Grant > Block Access\n```",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.3.1v1": {
+      "id": "ms.aad.3.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.3.1v1",
+      "group": "Strong Authentication and a Secure Registration Process",
+      "groupNumber": 3,
+      "assertion": "Phishing-resistant MFA SHALL be enforced for all users.",
+      "obligation": "SHALL",
+      "rationale": "Weaker forms of MFA do not protect against sophisticated phishing attacks. By enforcing methods resistant to phishing, those risks are minimized.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "IA-2(1)",
+        "IA-2(2)",
+        "IA-5c",
+        "IA-5g",
+        "IA-2(8)"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002"
+      ],
+      "details": "The phishing-resistant methods **Microsoft Entra ID certificate-based authentication (CBA)**, **FIDO2 Security Key**, **Windows Hello for Business**, and **device-bound passkeys** are the recommended authentication options since they offer forms of MFA with the least weaknesses. For federal agencies, Microsoft Entra ID CBA supports federal PIV card authentication directly to Microsoft Entra ID.\nIf on-premises PIV authentication and federation to Microsoft Entra ID is used, [enforce PIV logon via Microsoft Active Directory group policy](https://www.idmanagement.gov/implement/scl-windows/).",
+      "productLicenseNotes": "- Policies related to managed devices require Microsoft Intune.",
+      "instructions": "1. Create a conditional access policy enforcing phishing-resistant MFA for all users. Configure the following policy settings in the new conditional access policy, per the values below:\n\n```\n  Users > Include > All users\n\n  Target resources > Include > All resources (formerly 'All cloud apps')\n\n  Access controls > Grant > Grant Access > Require authentication strength > Phishing-resistant MFA\n```",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.3.2v2": {
+      "id": "ms.aad.3.2v2",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.3.2v2",
+      "group": "Strong Authentication and a Secure Registration Process",
+      "groupNumber": 3,
+      "assertion": "MFA SHALL be enforced for all users.",
+      "obligation": "SHALL",
+      "rationale": "This policy helps protect the tenant for guest users or any other group with multifactor authentication where phishing-resistant MFA is not enforceable due to technical limitations. It protects against the weaknesses inherent in singlefactor authentication.",
+      "lastModified": "February 2026",
+      "nist80053": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003"
+      ],
+      "productLicenseNotes": "- Policies related to managed devices require Microsoft Intune.",
+      "instructions": "There are a few different options to implement a conditional access policy that enforces MFA. Each option is described below, followed by our recommendation and the respective instructions for each option.\n\n- **Option 1** - Create a custom authentication strength that includes the specific multifactor authentication methods supported by your organization and then create a policy that enforces your custom authentication strength.\n- **Option 2** - Create a policy that enforces multifactor authentication (no specific MFA method).\n- **Option 3** - Create a policy that enforces the built-in authentication strength named \"Multifactor authentication\" (no specific MFA method).\n\nWe recommend using a custom authentication strength because you can enforce the specific methods that offer the highest security. We recommend that you require the passwordless authentication strength Microsoft Authenticator (Phone Sign-in) in lieu of alternative MFA methods, since it removes passwords from the sign-in flow, reducing the exposure to credential compromise.\n\n**Option 1**. [Follow the instructions at this link](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-strength-advanced-options#create-a-custom-authentication-strength) to create a custom authentication strength. Create a conditional access policy that enforces your custom authentication. Configure the following policy settings in the new conditional access policy, per the values below:\n\n```\n  Users > Include > All users\n\n  Target resources > Include > All resources (formerly 'All cloud apps')\n\n  Access controls > Grant > Grant Access > Require authentication strength > YOUR_CUSTOM_AUTHENTICATION_STRENGTH\n```\n\n**Option 2**. Create a conditional access policy that enforces MFA but does not dictate a specific MFA method. Configure the following policy settings in the new conditional access policy, per the values below:\n\n```\n  Users > Include > All users\n\n  Target resources > Include > All resources (formerly 'All cloud apps')\n\n  Access controls > Grant > Grant Access > Require multifactor authentication\n```\n\n**Option 3**. Create a conditional access policy that enforces the built-in authentication strength named \"Multifactor authentication\" and does not dictate a specific MFA method. Configure the following policy settings in the new conditional access policy, per the values below:\n\n```\n  Users > Include > All users\n\n  Target resources > Include > All resources (formerly 'All cloud apps')\n\n  Access controls > Grant > Grant Access > Require authentication strength > Multifactor authentication\n```",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.3.3v2": {
+      "id": "ms.aad.3.3v2",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.3.3v2",
+      "group": "Strong Authentication and a Secure Registration Process",
+      "groupNumber": 3,
+      "assertion": "If Microsoft Authenticator is enabled, it SHALL be configured to show login context information.",
+      "obligation": "SHALL",
+      "rationale": "This policy helps protect the tenant when Microsoft Authenticator is used by showing user context information, which helps reduce MFA phishing compromises.",
+      "lastModified": "March 2025",
+      "nist80053": [
+        "IA-2(1)",
+        "IA-2(2)",
+        "IA-5c",
+        "IA-5g",
+        "IA-2(8)",
+        "IA-2(13)"
+      ],
+      "mitreAttack": [
+        "T1110",
+        "T1110.001",
+        "T1110.002",
+        "T1110.003"
+      ],
+      "productLicenseNotes": "- Policies related to managed devices require Microsoft Intune.",
+      "instructions": "If Microsoft Authenticator is in use, configure Authenticator to display context information to users when they log in.\n\n1. In **Microsoft Entra admin center**, click **Protection > Authentication methods > Microsoft Authenticator**.\n2. Click the **Configure** tab.\n3. For **Allow use of Microsoft Authenticator OTP** select *No*.\n4. Under **Show application name in push and passwordless notifications** select **Status > Enabled** and **Target > Include > All users**.\n5. Under **Show geographic location in push and passwordless notifications** select **Status > Enabled** and **Target > Include > All users**.\n6. Select **Save**",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.3.4v1": {
+      "id": "ms.aad.3.4v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.3.4v1",
+      "group": "Strong Authentication and a Secure Registration Process",
+      "groupNumber": 3,
+      "assertion": "The Authentication Methods Manage Migration feature SHALL be set to Migration Complete.",
+      "obligation": "SHALL",
+      "rationale": "To disable the legacy authentication methods screen for the tenant, configure the Manage Migration feature to Migration Complete. The MFA and Self-Service Password Reset (SSPR) authentication methods are both managed from a central admin page, thereby reducing administrative complexity and potential security misconfigurations.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [],
+      "productLicenseNotes": "- Policies related to managed devices require Microsoft Intune.",
+      "instructions": "1. Go through the process of [How to migrate MFA and SSPR policy settings to the Authentication methods policy for Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/authentication/how-to-authentication-methods-manage).\n2. Once ready to finish the migration, [set the **Manage Migration** option to **Migration Complete**](https://learn.microsoft.com/en-us/entra/identity/authentication/how-to-authentication-methods-manage#finish-the-migration).",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.3.5v2": {
+      "id": "ms.aad.3.5v2",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.3.5v2",
+      "group": "Strong Authentication and a Secure Registration Process",
+      "groupNumber": 3,
+      "assertion": "The authentication methods SMS, Voice Call, and Email One-Time Passcode (OTP) SHALL be disabled.",
+      "obligation": "SHALL",
+      "rationale": "SMS, voice call, and email OTP are the weakest authenticators. This policy forces users to use stronger MFA methods.",
+      "lastModified": "February 2026",
+      "nist80053": [
+        "CM-7b",
+        "IA-5c"
+      ],
+      "mitreAttack": [
+        "T1621",
+        "T1566",
+        "T1566.002"
+      ],
+      "productLicenseNotes": "- Policies related to managed devices require Microsoft Intune.",
+      "instructions": "1. In **Microsoft Entra admin center** , click **Protection > Authentication methods**\n2. Click on the **SMS**, **Voice Call**, and **Email OTP** authentication methods and disable each of them. Their statuses should be **Enabled > No** on the **Authentication methods > Policies** page.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.3.6v1": {
+      "id": "ms.aad.3.6v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.3.6v1",
+      "group": "Strong Authentication and a Secure Registration Process",
+      "groupNumber": 3,
+      "assertion": "Phishing-resistant MFA SHALL be required for highly privileged roles.",
+      "obligation": "SHALL",
+      "rationale": "This is a backup security policy to help protect privileged access to the tenant if the conditional access policy, which requires MFA for all users, is disabled or misconfigured.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "IA-2(1)",
+        "IA-5c",
+        "IA-5g",
+        "IA-2(8)"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1078",
+        "T1078.004"
+      ],
+      "note": "Refer to the Highly Privileged Roles section at the top of this document for a reference list of roles considered highly privileged.",
+      "productLicenseNotes": "- Policies related to managed devices require Microsoft Intune.",
+      "instructions": "1. Create a conditional access policy enforcing phishing-resistant MFA for highly privileged roles.  Configure the following policy settings in the new conditional access policy, per the values below:\n\n```\n  Users > Include > Select users and groups > Directory roles > select each of the roles listed in the Highly Privileged Roles section at the top of this document\n\n  Target resources > Include > All resources (formerly 'All cloud apps')\n\n  Access controls > Grant > Grant Access > Require authentication strength > Phishing-resistant MFA\n```",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.3.7v1": {
+      "id": "ms.aad.3.7v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.3.7v1",
+      "group": "Strong Authentication and a Secure Registration Process",
+      "groupNumber": 3,
+      "assertion": "Managed devices SHOULD be required for authentication.",
+      "obligation": "SHOULD",
+      "rationale": "The security risk of an adversary authenticating to the tenant from their own device is reduced by requiring a managed device to authenticate. Managed devices are under the provisioning and control of the agency. [OMB-22-09](https://www.whitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf) states, \"When authorizing users to access resources, agencies must consider at least one device-level signal alongside identity information about the authenticated user.\"",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-20b",
+        "IA-3"
+      ],
+      "mitreAttack": [
+        "T1078",
+        "T1078.004"
+      ],
+      "productLicenseNotes": "- Policies related to managed devices require Microsoft Intune.",
+      "instructions": "1. Create a conditional access policy requiring a user's device to be either Microsoft Entra ID hybrid joined or compliant during authentication. Configure the following policy settings in the new conditional access policy, per the values below:\n\n```\n  Users > Include > All users\n\n  Target resources > Include > All resources (formerly 'All cloud apps')\n\n  Access controls > Grant > Grant Access > Require device to be marked as compliant and Require Microsoft Entra ID hybrid joined device > For multiple controls > Require one of the selected controls\n```",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.3.8v1": {
+      "id": "ms.aad.3.8v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.3.8v1",
+      "group": "Strong Authentication and a Secure Registration Process",
+      "groupNumber": 3,
+      "assertion": "Managed Devices SHOULD be required to register MFA.",
+      "obligation": "SHOULD",
+      "rationale": "Reduce risk of an adversary using stolen user credentials and then registering their own MFA device to access the tenant by requiring a managed device provisioned and controlled by the agency to perform registration actions. This prevents the adversary from using their own unmanaged device to perform the registration.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-20b",
+        "IA-3"
+      ],
+      "mitreAttack": [
+        "T1078",
+        "T1078.004",
+        "T1098",
+        "T1098.005"
+      ],
+      "productLicenseNotes": "- Policies related to managed devices require Microsoft Intune.",
+      "instructions": "1. Create a conditional access policy requiring a user to be on a managed device when registering for MFA. Configure the following policy settings in the new conditional access policy, per the values below:\n\n```\n  Users > Include > All users\n\n  Target resources > User actions > Register security information\n\n  Access controls > Grant > Grant Access > Require device to be marked as compliant and Require Microsoft Entra ID hybrid joined device > For multiple controls > Require one of the selected controls\n```",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.3.9v1": {
+      "id": "ms.aad.3.9v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.3.9v1",
+      "group": "Strong Authentication and a Secure Registration Process",
+      "groupNumber": 3,
+      "assertion": "Device code authentication SHOULD be blocked.",
+      "obligation": "SHOULD",
+      "rationale": "The device code authentication flow has been abused to compromise user accounts via phishing. Since most organizations using M365 don't need device code authentication, blocking it mitigates the risk.",
+      "lastModified": "February 2025",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [
+        "T1528",
+        "T1078",
+        "T1078.004"
+      ],
+      "productLicenseNotes": "- Policies related to managed devices require Microsoft Intune.",
+      "instructions": "1. Create a Conditional Access policy to block device code flow\n\n```\n  Users > Include > All users\n\n  Target resources > Include > All resources (formerly 'All cloud apps')\n\n  Conditions > Authentication Flows > Configure > Yes > Select Device code flow\n\n  Access controls > Grant > Block Access\n```",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.4.1v1": {
+      "id": "ms.aad.4.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.4.1v1",
+      "group": "Centralized Log Collection",
+      "groupNumber": 4,
+      "assertion": "Security logs SHALL be sent to the agency's security operations center for monitoring.",
+      "obligation": "SHALL",
+      "rationale": "The security risk of not having visibility into cyber attacks is reduced by collecting logs in the agency’s centralized security detection infrastructure. This makes security events available for auditing, query, and incident response.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AU-4"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.008"
+      ],
+      "note": "The following Microsoft Entra ID logs (configured in diagnostic settings), are required: `AuditLogs, SignInLogs, RiskyUsers, UserRiskEvents, NonInteractiveUserSignInLogs, ServicePrincipalSignInLogs, ADFSSignInLogs, RiskyServicePrincipals, ServicePrincipalRiskEvents, EnrichedOffice365AuditLogs, MicrosoftGraphActivityLogs`. If managed identities are used for Azure resources, also send the `ManagedIdentitySignInLogs` log type. If the Microsoft Entra ID Provisioning Service is used to provision users to software-as-a-service (SaaS) apps or other systems, also send the `ProvisioningLogs` log type.\n\nAgencies can benefit from security detection capabilities offered by the CISA Cloud Log Aggregation Warehouse (CLAW) system. Agencies are urged to send the logs to CLAW. Contact CISA at cyberliason@cisa.dhs.gov to request integration instructions.",
+      "productLicenseNotes": "- An Azure subscription may be required to send logs to an external system, such as the agency's Security Information and Event Management (SIEM).",
+      "instructions": "Follow the configuration instructions unique to the products and integration patterns at your organization to send the security logs to the security operations center for monitoring.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.5.1v1": {
+      "id": "ms.aad.5.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.5.1v1",
+      "group": "Application Registration and Consent",
+      "groupNumber": 5,
+      "assertion": "Only administrators SHALL be allowed to register applications.",
+      "obligation": "SHALL",
+      "rationale": "Application access for the tenant presents a heightened security risk compared to interactive user access because applications are typically not subject to critical security protections, such as MFA policies. Reduce risk of unauthorized users installing malicious applications into the tenant by ensuring that only specific privileged users can register applications.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-6(10)",
+        "CM-5"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.001",
+        "T1098.003"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  In **Microsoft Entra admin center**, select **Users**.\n\n2. Select **User settings**.\n\n3. For **Users can register applications**, select **No**.\n\n4. Click **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.5.2v1": {
+      "id": "ms.aad.5.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.5.2v1",
+      "group": "Application Registration and Consent",
+      "groupNumber": 5,
+      "assertion": "User consent to applications SHALL be restricted.",
+      "obligation": "SHALL",
+      "rationale": "Restricting user consent for applications reduces risk of users giving insecure applications access to their data via [consent grant attacks](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/detect-and-remediate-illicit-consent-grants?view=o365-worldwide).",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-6(10)",
+        "CM-5"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.001",
+        "T1098.003"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "There are a couple of configuration options to restrict user consent. Each option is described below, followed by its respective instructions.\n\n- **Option 1** - Most restrictive - Do not allow user consent for applications. An administrator is required to consent for all applications. Users can submit requests to use an application via the admin consent workflow but they cannot perform the consent themselves.\n- **Option 2** - More flexible - Allow users to consent to applications from Microsoft verified publishers that use low-risk permissions. When selecting this option, an administrator must configure a set of permissions considered low risk in the **Consent and permissions** > **Permission classifications** page in the Microsoft Entra admin center.\n\n**Option 1**. Do not allow user consent.\n\n1.  In **Microsoft Entra admin center** select **Enterprise Applications**.\n\n2. Under **Security**, select **Consent and permissions**. Then select **User Consent Settings**.\n\n3. Under **User consent for applications**, select **Do not allow user consent**.\n\n4. Click **Save**.\n\n**Option 2**. Allow restricted user consent.\n\n1.  In **Microsoft Entra admin center** select **Enterprise apps**.\n\n2. Under **Security**, select **Consent and permissions**. Then select **User Consent Settings**.\n\n3. Under **User consent for applications**, select **Allow user consent for apps from verified publishers, for selected permissions**.\n\n4. Click **Save**.\n\n5. In the page navigation menu, select **Permission classifications**.\n\n6. Click on the **Low** tab.\n\n7. [Add a list of low risk application permissions that users will be able to consent to](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-permission-classifications). We recommend only including permissions that provide minimal access to a user's data. For a reference of permissions that are considered risky and should be avoided [go to this JSON file and examine the permissions listed](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/schemas/RiskyAppPermissions.json) in the **Delegated** sections under Microsoft Graph and other apps.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.5.3v1": {
+      "id": "ms.aad.5.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.5.3v1",
+      "group": "Application Registration and Consent",
+      "groupNumber": 5,
+      "assertion": "An admin consent workflow SHALL be configured for applications.",
+      "obligation": "SHALL",
+      "rationale": "Configuring an admin consent workflow reduces the risk of the previous policy by setting up a process for users to securely request access to applications necessary for business purposes. Administrators have the opportunity to review the permissions requested by new applications and approve or deny access based on a risk assessment.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "CM-4"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.001",
+        "T1098.003"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  In **Microsoft Entra admin center**  create a new Microsoft Entra ID Group that contains admin users responsible for reviewing and adjudicating application consent requests. Group members will be notified when users request consent for new applications.\n\n2. Then in **Microsoft Entra admin center**  under **Applications**, select **Enterprise Applications**.\n\n3. Under **Security**, select **Consent and permissions**. Then select **Admin consent settings**.\n\n4. Under **Admin consent requests** navigate to **Users can request admin consent to apps they are unable to consent to** and select **Yes**.\n\n5. Under **Who can review admin consent requests**, select **+ Add groups** and select the group responsible for reviewing and adjudicating app requests (created in step one above).\n\n6. Click **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.5.5v1": {
+      "id": "ms.aad.5.5v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.5.5v1",
+      "group": "Application Registration and Consent",
+      "groupNumber": 5,
+      "assertion": "Application Password Addition SHOULD be blocked.",
+      "obligation": "SHOULD",
+      "rationale": "Applications that use client secrets might store them in configuration files, hardcode them in scripts, or risk exposure in other ways. The complexities of secret management make client secrets susceptible to leaks and attractive to attackers. Blocking password addition forces the use of more secure certificate-based authentication.",
+      "lastModified": "April 2026",
+      "nist80053": [
+        "IA-5"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.001",
+        "T1528"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. In **Microsoft Entra admin center**, select **Enterprise apps**.\n\n2. Under **Security**, select **Application policies**.\n\n3. Select **Block password addition**.\n\n4. Set status to **On**. Ensure **Applies to** is set to **All applications**.\n\n5. Leave **Only apply to apps created after** blank. Setting a date allows apps created before that date to bypass this restriction.\n\n6. Click **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.5.6v1": {
+      "id": "ms.aad.5.6v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.5.6v1",
+      "group": "Application Registration and Consent",
+      "groupNumber": 5,
+      "assertion": "Application password lifetime SHOULD be restricted to 180 days or less.",
+      "obligation": "SHOULD",
+      "rationale": "Long-lived credentials increase the window of opportunity for attackers to exploit compromised secrets. Enforcing a maximum password lifetime of 180 days ensures regular credential rotation, reducing the impact of credential theft and improving overall security hygiene.",
+      "lastModified": "April 2026",
+      "nist80053": [
+        "IA-5",
+        "SC-12"
+      ],
+      "mitreAttack": [
+        "T1552",
+        "T1552.001"
+      ],
+      "note": "Due to how Microsoft Entra ID evaluates the MaxLifetime restriction using \"less than\" (not \"less than or equal to\"), the portal setting must be configured to **181 days** to enforce the requirement of \"180 days or less.\"\n\nThis policy applies only if password credentials are permitted. Microsoft and CISA recommend blocking password addition entirely (MS.AAD.5.5v1) as the preferred approach.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. In **Microsoft Entra admin center**, select **Enterprise apps**.\n\n2. Under **Security**, select **Application policies**.\n\n3. Select **Restrict max password lifetime**.\n\n4. Set status to **On**. Set maximum lifetime to **181 days**. Ensure **Applies to** is set to **All applications**.\n\n5. Leave **Only apply to apps created after** blank. Setting a date allows apps created before that date to bypass this restriction.\n\n6. Click **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.5.7v1": {
+      "id": "ms.aad.5.7v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.5.7v1",
+      "group": "Application Registration and Consent",
+      "groupNumber": 5,
+      "assertion": "Application certificate lifetime SHOULD be restricted to 365 days or less.",
+      "obligation": "SHOULD",
+      "rationale": "While certificates provide more secure authentication than passwords, long-lived certificates can still be compromised. Limiting certificate lifetime to 365 days reduces the risk of exploitation while balancing operational overhead. Regular certificate rotation is a security best practice that minimizes exposure from compromised keys.",
+      "lastModified": "April 2026",
+      "nist80053": [
+        "SC-12",
+        "IA-5"
+      ],
+      "mitreAttack": [
+        "T1649"
+      ],
+      "note": "Due to how Microsoft Entra ID evaluates the MaxLifetime restriction using \"less than\" (not \"less than or equal to\"), the portal setting must be configured to **366 days** to enforce the requirement of \"365 days or less.\"",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. In **Microsoft Entra admin center**, select **Enterprise apps**.\n\n2. Under **Security**, select **Application policies**.\n\n3. Select **Restrict max certificate lifetime**.\n\n4. Set status to **On**. Set maximum lifetime to **366 days**. Ensure **Applies to** is set to **All applications**.\n\n5. Leave **Only apply to apps created after** blank. Setting a date allows apps created before that date to bypass this restriction.\n\n6. Click **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.6.1v1": {
+      "id": "ms.aad.6.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.6.1v1",
+      "group": "Passwords",
+      "groupNumber": 6,
+      "assertion": "User passwords SHALL NOT expire.",
+      "obligation": "SHALL NOT",
+      "rationale": "The National Institute of Standards and Technology (NIST), OMB, and Microsoft have published guidance indicating mandated periodic password changes make user accounts less secure. For example, OMB-22-09 states, \"Password policies must not require use of special characters or regular rotation.\"",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "IA-5(1)"
+      ],
+      "mitreAttack": [],
+      "productLicenseNotes": "- N/A",
+      "instructions": "> **Note:** Tenants created after October 2021 have password expiration disabled by default (`passwordValidityPeriodInDays = null`), which Microsoft treats as equivalent to \"never expire.\" Tenants created before October 2021, or any tenant where the policy was explicitly configured and then reverted, will show `2147483647` (INT_MAX). ScubaGear treats both values as compliant. The M365 admin center password expiration checkbox applies to all managed domains in the tenant. If a tenant has **multiple root domains**, use the PowerShell in Step 2 to audit all of them and remediate any that have a finite expiration period set.\n\n1. Sign in to the [Microsoft 365 admin center](https://admin.microsoft.com) and [configure the **Password expiration policy** to **Set passwords to never expire**](https://learn.microsoft.com/en-us/microsoft-365/admin/manage/set-password-expiration-policy?view=o365-worldwide#set-password-expiration-policy).\n\n2. Optionally, verify and remediate all root domains via PowerShell. This is useful if any domain had a finite expiration configured explicitly. This uses `Invoke-MgGraphRequest`, which is included with the `Microsoft.Graph.Authentication` module already required by ScubaGear. To audit only, connect with `Domain.Read.All`; to also remediate, use `Domain.ReadWrite.All`.\n\n  ```powershell\n  Connect-MgGraph -Scopes \"Domain.ReadWrite.All\" # or alternatively \"Domain.Read.All\" for determining which domains are in a non-compliant state.\n\n  $NonCompliantDomains = (Invoke-MgGraphRequest -Method GET -Uri \"https://graph.microsoft.com/v1.0/domains\").value | Where-Object {\n    $_.isRoot -and $_.isVerified -and\n    $null -ne $_.passwordValidityPeriodInDays -and\n    $_.passwordValidityPeriodInDays -ne [int32]::MaxValue\n  }\n\n  Write-Host $NonCompliantDomains | Format-List\n\n  # Remediate each non-compliant domain\n  Invoke-MgGraphRequest -Method PATCH -Uri \"https://graph.microsoft.com/v1.0/domains/example.com\" `\n    -Body @{ passwordValidityPeriodInDays = [int32]::MaxValue }\n\n  # Verify domain configurations\n  $AllDomains = (Invoke-MgGraphRequest -Method GET -Uri \"https://graph.microsoft.com/v1.0/domains\").value | Where-Object {\n    $_.isRoot -and $_.isVerified\n  }\n\n  Write-Host \"All current domain password expiration policies\"\n  foreach ($Domain in $AllDomains) {\n    Write-Host \"Domain passwordValidityPeriodInDays: $($Domain.id) $($Domain.passwordValidityPeriodInDays)\"\n  }\n  ```",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.7.1v1": {
+      "id": "ms.aad.7.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.7.1v1",
+      "group": "Highly Privileged User Access",
+      "groupNumber": 7,
+      "assertion": "A minimum of two users and a maximum of eight users SHALL be provisioned with the Global Administrator role.",
+      "obligation": "SHALL",
+      "rationale": "The Global Administrator role provides unfettered access to the tenant. Limiting the number of users with this level of access makes tenant compromise more challenging. Microsoft recommends fewer than five users in the Global Administrator role. However, additional user accounts, up to eight, may be necessary to support emergency access and some operational scenarios.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-6(5)"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.003"
+      ],
+      "productLicenseNotes": "- Policies [MS.AAD.7.4v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad74v1), [MS.AAD.7.5v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad75v1), [MS.AAD.7.6v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad76v1), [MS.AAD.7.7v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad77v1), [MS.AAD.7.8v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad78v1), and [MS.AAD.7.9v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad79v1) require a Microsoft Entra ID P2 license; however, a third-party Privileged Access Management (PAM) solution may also be used to satisfy the requirements. If a third-party solution is used, then a P2 license is not required for the respective policies.",
+      "instructions": "When counting the number of users assigned to the Global Administrator role, count each user only once.\n\n1. In **Microsoft Entra admin center**  count the number of users assigned to the **Global Administrator** role. Count users that are assigned directly to the role and users assigned via group membership. If you have Microsoft Entra ID PIM, count both the **Eligible assignments** and **Active assignments**. If any of the groups assigned to Global Administrator are enrolled in PIM for Groups, also count the number of group members from the PIM for Groups portal **Eligible** assignments.\n\n2. Validate that there are a total of two to eight users assigned to the Global Administrator role.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.7.2v1": {
+      "id": "ms.aad.7.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.7.2v1",
+      "group": "Highly Privileged User Access",
+      "groupNumber": 7,
+      "assertion": "Privileged users SHALL be provisioned with finer-grained roles instead of Global Administrator.",
+      "obligation": "SHALL",
+      "rationale": "Many privileged administrative users do not need unfettered access to the tenant to perform their duties. By assigning them to roles based on least privilege, the risks associated with having their accounts compromised are reduced.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-5"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.003",
+        "T1651",
+        "T1136",
+        "T1136.003"
+      ],
+      "productLicenseNotes": "- Policies [MS.AAD.7.4v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad74v1), [MS.AAD.7.5v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad75v1), [MS.AAD.7.6v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad76v1), [MS.AAD.7.7v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad77v1), [MS.AAD.7.8v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad78v1), and [MS.AAD.7.9v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad79v1) require a Microsoft Entra ID P2 license; however, a third-party Privileged Access Management (PAM) solution may also be used to satisfy the requirements. If a third-party solution is used, then a P2 license is not required for the respective policies.",
+      "instructions": "This policy is based on the ratio below:\n\n`X = (Number of users assigned to the Global Administrator role) / (Number of users assigned to other highly privileged roles)`\n\n1. Follow the instructions for policy MS.AAD.7.1v1 above to get a count of users assigned to the Global Administrator role.\n\n2. Follow the instructions for policy MS.AAD.7.1v1 above but get a count of users assigned to the other highly privileged roles (not Global Administrator). If a user is assigned to both Global Administrator and other roles, only count that user for the Global Administrator assignment.\n\n3. Divide the value from step 2 from the value from step 1 to calculate X. If X is less than or equal to 1 then the tenant is compliant with the policy.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.7.3v1": {
+      "id": "ms.aad.7.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.7.3v1",
+      "group": "Highly Privileged User Access",
+      "groupNumber": 7,
+      "assertion": "Privileged users SHALL be provisioned cloud-only accounts separate from an on-premises directory or other federated identity providers.",
+      "obligation": "SHALL",
+      "rationale": "By provisioning cloud-only Microsoft Entra ID user accounts to privileged users, the risks associated with a compromise of on-premises federation infrastructure are reduced. It is more challenging for the adversary to pivot from the compromised environment to the cloud with privileged access.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-6(5)"
+      ],
+      "mitreAttack": [
+        "T1556",
+        "T1556.007"
+      ],
+      "productLicenseNotes": "- Policies [MS.AAD.7.4v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad74v1), [MS.AAD.7.5v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad75v1), [MS.AAD.7.6v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad76v1), [MS.AAD.7.7v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad77v1), [MS.AAD.7.8v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad78v1), and [MS.AAD.7.9v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad79v1) require a Microsoft Entra ID P2 license; however, a third-party Privileged Access Management (PAM) solution may also be used to satisfy the requirements. If a third-party solution is used, then a P2 license is not required for the respective policies.",
+      "instructions": "1. Perform the steps below for each highly privileged role. We reference the Global Administrator role as an example.\n\n2. Create a list of all the users assigned to the **Global Administrator** role. Include users that are assigned directly to the role and users assigned via group membership. If you have Microsoft Entra ID PIM, include both the **Eligible assignments** and **Active assignments**. If any of the groups assigned to Global Administrator are enrolled in PIM for Groups, also include group members from the PIM for Groups portal **Eligible** assignments.\n\n3. For each highly privileged user in the list, execute the Powershell code below but replace the `username@somedomain.com` with the principal name of the user who is specific to your environment. You can get the data value from the **Principal name** field displayed in the Microsoft Entra ID portal.\n\n    ```\n    Connect-MgGraph\n    Get-MgBetaUser -Filter \"userPrincipalName eq 'username@somedomain.com'\" | FL\n    ```\n\n6. Review the output field named **OnPremisesImmutableId**. If this field contains a data value, it means that the  user is not cloud-only. If the user is not cloud-only, create a cloud-only account for that user, assign the user to their respective roles and then remove the account that is not cloud-only from Microsoft Entra ID.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.7.4v1": {
+      "id": "ms.aad.7.4v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.7.4v1",
+      "group": "Highly Privileged User Access",
+      "groupNumber": 7,
+      "assertion": "Permanent active role assignments SHALL NOT be allowed for highly privileged roles.",
+      "obligation": "SHALL NOT",
+      "rationale": "Instead of giving users permanent assignments to privileged roles, provisioning access just in time lessens exposure if those accounts become compromised. In Microsoft Entra ID PIM or an alternative PAM system, just in time access can be provisioned by assigning users to roles as eligible instead of perpetually active.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-2"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.003"
+      ],
+      "note": "Exceptions to this policy are: - Emergency access accounts that need perpetual access to the tenant in the rare event of system degradation or other scenarios. - Some types of service accounts that require a user account with privileged roles; since these accounts are used by software programs, they cannot perform role activation.",
+      "productLicenseNotes": "- Policies [MS.AAD.7.4v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad74v1), [MS.AAD.7.5v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad75v1), [MS.AAD.7.6v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad76v1), [MS.AAD.7.7v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad77v1), [MS.AAD.7.8v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad78v1), and [MS.AAD.7.9v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad79v1) require a Microsoft Entra ID P2 license; however, a third-party Privileged Access Management (PAM) solution may also be used to satisfy the requirements. If a third-party solution is used, then a P2 license is not required for the respective policies.",
+      "instructions": "1. In **Microsoft Entra admin center**  select **Roles and admins**. Perform the steps below for each highly privileged role. We reference the Global Administrator role as an example.\n\n2. Select the **Global Administrator** role.\n\n3. Under **Manage**, select **Assignments** and click the **Active assignments** tab.\n\n4. Verify there are no users or groups with a value of **Permanent** in the **End time** column. If there are any, recreate those assignments to have an expiration date using Microsoft Entra ID PIM or an alternative PAM system. If a group is identified and it is enrolled in PIM for Groups, see the exception cases below for details.\n\nException cases:\n- Emergency access accounts that require perpetual active assignment.\n- Service accounts that require perpetual active assignment.\n- If using PIM for Groups, a group that is enrolled in PIM is allowed to have a perpetual active assignment to a role because activation is handled by PIM for Groups.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.7.5v1": {
+      "id": "ms.aad.7.5v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.7.5v1",
+      "group": "Highly Privileged User Access",
+      "groupNumber": 7,
+      "assertion": "Provisioning users to highly privileged roles SHALL NOT occur outside of a PAM system.",
+      "obligation": "SHALL NOT",
+      "rationale": "Provisioning users to privileged roles within a PAM system enables enforcement of numerous privileged access policies and monitoring. If privileged users are assigned directly to roles in the M365 admin center or via PowerShell outside of the context of a PAM system, a significant set of critical security capabilities are bypassed.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-2"
+      ],
+      "mitreAttack": [
+        "T1651"
+      ],
+      "productLicenseNotes": "- Policies [MS.AAD.7.4v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad74v1), [MS.AAD.7.5v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad75v1), [MS.AAD.7.6v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad76v1), [MS.AAD.7.7v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad77v1), [MS.AAD.7.8v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad78v1), and [MS.AAD.7.9v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad79v1) require a Microsoft Entra ID P2 license; however, a third-party Privileged Access Management (PAM) solution may also be used to satisfy the requirements. If a third-party solution is used, then a P2 license is not required for the respective policies.",
+      "instructions": "1. Perform the steps below for each highly privileged role. We reference the Global Administrator role as an example.\n\n2. In **Microsoft Entra admin center**  select **Roles and Admins**.\n\n3. Select the **Global Administrator** role.\n\n4. Under **Manage**, select **Assignments** and click the **Active assignments** tab.\n\n5. For each user or group listed, examine the value in the **Start time** column. If it contains a value of **-**, this indicates the respective user/group was assigned to that role outside of Microsoft Entra ID PIM. If the role was assigned outside of Microsoft Entra ID PIM, delete the assignment and recreate it using Microsoft Entra ID PIM.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.7.6v1": {
+      "id": "ms.aad.7.6v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.7.6v1",
+      "group": "Highly Privileged User Access",
+      "groupNumber": 7,
+      "assertion": "Activation of the Global Administrator role SHALL require approval.",
+      "obligation": "SHALL",
+      "rationale": "Requiring approval for a user to activate Global Administrator, which provides unfettered access, makes it more challenging for an attacker to compromise the tenant with stolen credentials, and it provides visibility of activities indicating a compromise is taking place.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-6(1)"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.003"
+      ],
+      "productLicenseNotes": "- Policies [MS.AAD.7.4v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad74v1), [MS.AAD.7.5v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad75v1), [MS.AAD.7.6v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad76v1), [MS.AAD.7.7v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad77v1), [MS.AAD.7.8v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad78v1), and [MS.AAD.7.9v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad79v1) require a Microsoft Entra ID P2 license; however, a third-party Privileged Access Management (PAM) solution may also be used to satisfy the requirements. If a third-party solution is used, then a P2 license is not required for the respective policies.",
+      "instructions": "1. In the **Microsoft Entra Portal**, under **Identity Governance**, select **Privileged Identity Management (PIM)**, and then under **Manage**, select **Microsoft Entra roles**.\n\n2. Under **Manage**, select **Roles**.\n\n  1.  Select the **Global Administrator** role in the list.\n  2.  Click **Settings**.\n  3.  Click **Edit**.\n  4.  Select the **Require approval to activate** option.\n  5.  Click **Update**.\n\n3. Review the list of groups that are actively assigned to the **Global Administrator** role. If any of the groups are enrolled in PIM for Groups, also apply the same configurations as steps 2-7 above to each PIM group's **Member** settings.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.7.7v1": {
+      "id": "ms.aad.7.7v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.7.7v1",
+      "group": "Highly Privileged User Access",
+      "groupNumber": 7,
+      "assertion": "Eligible and active highly privileged role assignments SHALL trigger an alert.",
+      "obligation": "SHALL",
+      "rationale": "Closely monitor assignment of the highest privileged roles for signs of compromise. Send assignment alerts to enable the security monitoring team to detect compromise attempts.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-2(1)"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.003"
+      ],
+      "productLicenseNotes": "- Policies [MS.AAD.7.4v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad74v1), [MS.AAD.7.5v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad75v1), [MS.AAD.7.6v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad76v1), [MS.AAD.7.7v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad77v1), [MS.AAD.7.8v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad78v1), and [MS.AAD.7.9v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad79v1) require a Microsoft Entra ID P2 license; however, a third-party Privileged Access Management (PAM) solution may also be used to satisfy the requirements. If a third-party solution is used, then a P2 license is not required for the respective policies.",
+      "instructions": "1.  In the **Microsoft Entra Portal**, under **Identity Governance**, select **Privileged Identity Management (PIM)**, and then under **Manage**, select **Microsoft Entra roles**.\n\n2. Under **Manage**, select **Roles**. Perform the steps below for each highly privileged role. We reference the Global Administrator role as an example:\n\n  1. Click the **Global Administrator** role.\n  2. Click **Settings** and then click **Edit**.\n  3. Click the **Notification** tab.\n  4. Under **Send notifications when members are assigned as eligible to this role**, in the **Role assignment alert > Additional recipients** textbox, enter the email address of the security monitoring mailbox configured to receive privileged role assignment alerts.\n  5. Under **Send notifications when members are assigned as active to this role**, in the **Role assignment alert > Additional recipients** textbox, enter the email address of the security monitoring mailbox configured to receive privileged role assignment alerts.\n  6. Click **Update**.\n\n3. For each of the highly privileged roles, if they have any PIM groups actively assigned to them, apply the same configurations as steps 2-8 above to each PIM group's **Member** settings.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.7.8v1": {
+      "id": "ms.aad.7.8v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.7.8v1",
+      "group": "Highly Privileged User Access",
+      "groupNumber": 7,
+      "assertion": "User activation of the Global Administrator role SHALL trigger an alert.",
+      "obligation": "SHALL",
+      "rationale": "Closely monitor activation of the Global Administrator role for signs of compromise. Send activation alerts to enable the security monitoring team to detect compromise attempts.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-6(9)"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.003"
+      ],
+      "note": "It is recommended to prioritize user activation of Global Administrator as one of the most important events to monitor and respond to.",
+      "productLicenseNotes": "- Policies [MS.AAD.7.4v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad74v1), [MS.AAD.7.5v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad75v1), [MS.AAD.7.6v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad76v1), [MS.AAD.7.7v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad77v1), [MS.AAD.7.8v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad78v1), and [MS.AAD.7.9v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad79v1) require a Microsoft Entra ID P2 license; however, a third-party Privileged Access Management (PAM) solution may also be used to satisfy the requirements. If a third-party solution is used, then a P2 license is not required for the respective policies.",
+      "instructions": "1. In the **Microsoft Entra Portal**, under **Identity Governance**, select **Privileged Identity Management (PIM)**. Under **Manage**, select **Microsoft Entra roles**.\n\n2. Click the **Global Administrator** role.\n\n3. Click **Settings** then click **Edit**.\n\n4. Click the **Notification** tab.\n\n5. Under **Send notifications when eligible members activate this role**, in the **Role activation alert** select the  **Additional recipients** textbox and enter the email address of the security monitoring mailbox configured to receive Global Administrator activation alerts.\n\n6. Click **Update**.\n\n7. If the Global Administrator role has any PIM groups actively assigned to it, then also apply the same configurations per the steps above to each PIM group's **Member** settings.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.7.9v1": {
+      "id": "ms.aad.7.9v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.7.9v1",
+      "group": "Highly Privileged User Access",
+      "groupNumber": 7,
+      "assertion": "User activation of other highly privileged roles SHOULD trigger an alert.",
+      "obligation": "SHOULD",
+      "rationale": "Closely monitor activation of high-risk roles for signs of compromise. Send activation alerts to enable the security monitoring team to detect compromise attempts. In some environments, activating privileged roles can generate a significant number of alerts.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-6(9)"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.003",
+        "T1136",
+        "T1136.003"
+      ],
+      "productLicenseNotes": "- Policies [MS.AAD.7.4v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad74v1), [MS.AAD.7.5v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad75v1), [MS.AAD.7.6v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad76v1), [MS.AAD.7.7v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad77v1), [MS.AAD.7.8v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad78v1), and [MS.AAD.7.9v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad79v1) require a Microsoft Entra ID P2 license; however, a third-party Privileged Access Management (PAM) solution may also be used to satisfy the requirements. If a third-party solution is used, then a P2 license is not required for the respective policies.",
+      "instructions": "1. Follow the same instructions as MS.AAD.7.8v1 for each of the highly privileged roles (other than Global Administrator) but enter a security monitoring mailbox different from the one used to monitor Global Administrator activations.\n\n 2. For each of the highly privileged roles, if they have any PIM groups actively assigned to them, then also apply the same configurations per step 1 to each PIM group's **Member** settings.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.8.1v1": {
+      "id": "ms.aad.8.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.8.1v1",
+      "group": "Guest User Access",
+      "groupNumber": 8,
+      "assertion": "Guest users SHOULD have limited or restricted access to Microsoft Entra ID directory objects.",
+      "obligation": "SHOULD",
+      "rationale": "Limiting the amount of object information available to guest users in the tenant, reduces malicious reconnaissance exposure if a guest account is compromised or created by an adversary.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-6"
+      ],
+      "mitreAttack": [
+        "T1087",
+        "T1087.003",
+        "T1087.004",
+        "T1526"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. In **Microsoft Entra admin center**  select **External Identities > External collaboration settings**.\n\n2. Under **Guest user access**, select either **Guest users have limited access to properties and memberships of directory objects** or **Guest user access is restricted to properties and memberships of their own directory objects (most restrictive)**.\n\n3. Click **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.8.2v1": {
+      "id": "ms.aad.8.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.8.2v1",
+      "group": "Guest User Access",
+      "groupNumber": 8,
+      "assertion": "Only users with the Guest Inviter role SHOULD be able to invite guest users.",
+      "obligation": "SHOULD",
+      "rationale": "By only allowing an authorized group of individuals to invite external users to create accounts in the tenant, an agency can enforce a guest user account approval process, reducing the risk of unauthorized account creation.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-6(10)"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.003"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. In **Microsoft Entra admin center**  select **External Identities > External collaboration settings**.\n\n2.  Under **Guest invite settings**, select **Only users assigned to specific admin roles can invite guest users**.\n\n3. Click **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.8.3v1": {
+      "id": "ms.aad.8.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.8.3v1",
+      "group": "Guest User Access",
+      "groupNumber": 8,
+      "assertion": "Guest invites SHOULD only be allowed to specific external domains that have been authorized by the agency for legitimate business purposes.",
+      "obligation": "SHOULD",
+      "rationale": "Limiting which domains can be invited to create guest accounts in the tenant helps reduce the risk of users from unauthorized external organizations getting access.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-3"
+      ],
+      "mitreAttack": [
+        "T1078",
+        "T1078.001"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. In **Microsoft Entra admin center**  select **External Identities > External collaboration settings**.\n\n2. Under **Collaboration restrictions**, select **Allow invitations\n    only to the specified domains (most restrictive)**.\n\n3. Select **Target domains** and enter the names of the external domains authorized by the agency for guest user access.\n\n4. Click **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.aad.9.1v1": {
+      "id": "ms.aad.9.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.AAD.9.1v1",
+      "group": "AI Security",
+      "groupNumber": 9,
+      "assertion": "Risky AI agents SHALL be blocked.",
+      "obligation": "SHALL",
+      "rationale": "AI agents may access tenant resources using application permissiona and can perform actions autonomously. Blocking high-risk AI agents reduces the risk of unauthorized access and automated misuse of resources.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "AC-3",
+        "AC-6",
+        "CM-7(4)"
+      ],
+      "mitreAttack": [
+        "T1078",
+        "T1078.004"
+      ],
+      "note": "This policy is not applicable to Government Community Cloud (GCC) High, and Department of Defense (DoD) tenants.",
+      "productLicenseNotes": "- Requires a Microsoft Entra ID P2 license",
+      "instructions": "1. Create a conditional access policy blocking High Risk AI Agents. Configure the following policy settings in the new conditional access policy, per the values below:\n\n```\n  Assignments > Users, agents (Preview) or workload identities > What does this policy apply to? > Agents (Preview) > Include > All agent identities (Preview)\n\n  Target resources > Include > All resources (formerly 'All cloud apps')\n\n  Conditions > Agent risk (Preview) > Configure > Yes > Configure agent risk levels needed for policy to be enforced > High\n```\n\n# Appendix A: Microsoft Entra ID hybrid Guidance\n\nMost of this document does not focus on securing Microsoft Entra ID hybrid environments. CISA released a separate [Hybrid Identity Solutions Architecture](https://www.cisa.gov/sites/default/files/2023-03/csso-scuba-guidance_document-hybrid_identity_solutions_architecture-2023.03.22-final.pdf) document addressing the unique implementation requirements of Microsoft Entra ID hybrid infrastructure.\n\n# Appendix B: Cross-tenant Access Guidance\n\nSome of the conditional access policies contained in this security baseline, if implemented as described, will impact guest user access to a tenant. For example, the policies require users to perform MFA and originate from a managed device to gain access. These requirements are also enforced for guest users. For these policies to work effectively with guest users, both the home tenant (the one the guest user belongs to) and the resource tenant (the target tenant) may need to configure their Microsoft Entra ID cross-tenant access settings.\n\nMicrosoft’s [Authentication and Conditional Access for External ID](https://learn.microsoft.com/en-us/entra/external-id/authentication-conditional-access) provides an understanding of how MFA and device claims are passed from the home tenant to the resource tenant. To configure the inbound and outbound cross-tenant access settings in Microsoft Entra External ID, refer to Microsoft’s [Overview: Cross-tenant access with Microsoft Entra External ID](https://learn.microsoft.com/en-us/entra/external-id/cross-tenant-access-overview).\n\n**`TLP:CLEAR`**",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/aad.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/aad.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md"
+    },
+    "ms.defender.1.1v1": {
+      "id": "ms.defender.1.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.1.1v1",
+      "group": "Preset Security Profiles",
+      "groupNumber": 1,
+      "assertion": "The standard and strict preset security policies SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Defender includes a large number of features and settings to protect users against threats. Using the preset security policies, administrators can help ensure all new and existing users automatically have secure defaults applied.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "CM-6a",
+        "SI-3a",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1566.003"
+      ],
+      "productLicenseNotes": "- Defender for Office 365 capabilities require Defender for Office 365 Plan 1 or 2. These are included with E5 and G5 and are available as add-ons for E3 and G3. However, third-party solutions can be used to meet this requirement. If a third-party solution is used, then a Defender for Office 365 Plan 1 or 2, E5, and G5 license is not required for the respective policies.",
+      "instructions": "1. Sign in to **Microsoft 365 Defender**.\n2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.\n3. Select **Threat Policies**.\n4. From the **Templated policies** section, select **Preset Security Policies**.\n5. Under **Standard protection**, slide the toggle switch to the right so the text next to the toggle reads **Standard protection is on**.\n6. Under **Strict protection**, slide the toggle switch to the right so the text next to the toggle reads **Strict protection is on**.\n\nNote: If the toggle slider in step 5 is grayed out, click on **Manage protection settings**\ninstead and configure the policy settings according to [Use the Microsoft 365 Defender portal to assign Standard and Strict preset security policies to users \\| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/preset-security-policies?view=o365-worldwide#use-the-microsoft-365-defender-portal-to-assign-standard-and-strict-preset-security-policies-to-users).",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.1.2v1": {
+      "id": "ms.defender.1.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.1.2v1",
+      "group": "Preset Security Profiles",
+      "groupNumber": 1,
+      "assertion": "All users SHALL be added to Exchange Online Protection (EOP) in either the standard or strict preset security policy.",
+      "obligation": "SHALL",
+      "rationale": "Important user protections are provided by EOP, including anti-spam, anti-malware, and anti-phishing protections. By using the preset policies, administrators can help ensure all new and existing users have secure defaults applied automatically.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "CM-6a",
+        "SI-3a",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1566.003"
+      ],
+      "note": "- The standard and strict preset security policies must be enabled as directed by [MS.DEFENDER.1.1v1](#msdefender11v1) for protections to be applied. - Specific user accounts, except for sensitive accounts, MAY be exempt from the preset policies, provided they are added to one or more custom policies offering comparable protection. These users might need flexibility not offered by the preset policies. Their accounts should be added to a custom policy conforming, as closely as possible to the settings used by the preset policies. See the **Resources** section for more details on configuring policies.",
+      "productLicenseNotes": "- Defender for Office 365 capabilities require Defender for Office 365 Plan 1 or 2. These are included with E5 and G5 and are available as add-ons for E3 and G3. However, third-party solutions can be used to meet this requirement. If a third-party solution is used, then a Defender for Office 365 Plan 1 or 2, E5, and G5 license is not required for the respective policies.",
+      "instructions": "1. Sign in to **Microsoft 365 Defender**.\n2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.\n3. Select **Threat Policies**.\n4. From the **Templated policies** section, select **Preset Security Policies**.\n5. Select **Manage protection settings** under either **Standard protection**\n   or **Strict protection**.\n6. On the **Apply Exchange Online Protection** page, select **All recipients**.\n7. (Optional) Under **Exclude these recipients**, add **Users** and **Groups**\n   to be exempted from the preset policies.\n8. Select **Next** on each page until the **Review and confirm your changes** page.\n9. On the **Review and confirm your changes** page, select **Confirm**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.1.3v1": {
+      "id": "ms.defender.1.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.1.3v1",
+      "group": "Preset Security Profiles",
+      "groupNumber": 1,
+      "assertion": "All users SHALL be added to Defender for Office 365 protection in either the standard or strict preset security policy.",
+      "obligation": "SHALL",
+      "rationale": "Important user protections are provided by Defender for Office 365 protection, including safe attachments and safe links. By using the preset policies, administrators can help ensure all new and existing users have secure defaults applied automatically.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "CM-6a",
+        "SI-3a",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1566.003"
+      ],
+      "note": "- The standard and strict preset security policies must be enabled as directed by [MS.DEFENDER.1.1v1](#msdefender11v1) for protections to be applied. - Specific user accounts, except for sensitive accounts, MAY be exempt from the preset policies, provided they are added to one or more custom policies offering comparable protection. These users might need flexibility not offered by the preset policies. Their accounts should be added to a custom policy conforming as closely as possible to the settings used by the preset policies. See the **Resources** section for more details on configuring policies.",
+      "productLicenseNotes": "- Defender for Office 365 capabilities require Defender for Office 365 Plan 1 or 2. These are included with E5 and G5 and are available as add-ons for E3 and G3. However, third-party solutions can be used to meet this requirement. If a third-party solution is used, then a Defender for Office 365 Plan 1 or 2, E5, and G5 license is not required for the respective policies.",
+      "instructions": "1. Sign in to **Microsoft 365 Defender**.\n2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.\n3. Select **Threat Policies**.\n4. From the **Templated policies** section, select **Preset Security Policies**.\n5. Under either **Standard protection** or **Strict protection**, select **Manage\n   protection settings**.\n6. Select **Next** until you reach the **Apply Defender for Office 365 protection** page.\n7. On the **Apply Defender for Office 365 protection** page, select **All recipients**.\n8. (Optional) Under **Exclude these recipients**, add **Users** and **Groups**\n   to be exempted from the preset policies.\n9. Select **Next** on each page until the **Review and confirm your changes** page.\n10. On the **Review and confirm your changes** page, select **Confirm**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.1.4v1": {
+      "id": "ms.defender.1.4v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.1.4v1",
+      "group": "Preset Security Profiles",
+      "groupNumber": 1,
+      "assertion": "Sensitive accounts SHALL be added to Exchange Online Protection in the strict preset security policy.",
+      "obligation": "SHALL",
+      "rationale": "Unauthorized access to a sensitive account may result in greater harm than a standard user account. Adding sensitive accounts to the strict preset security policy, with its increased protections, better mitigates their elevated risk to email threats.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "CM-6a",
+        "SI-3a",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002"
+      ],
+      "note": "The strict preset security policy must be enabled to protect sensitive accounts.",
+      "productLicenseNotes": "- Defender for Office 365 capabilities require Defender for Office 365 Plan 1 or 2. These are included with E5 and G5 and are available as add-ons for E3 and G3. However, third-party solutions can be used to meet this requirement. If a third-party solution is used, then a Defender for Office 365 Plan 1 or 2, E5, and G5 license is not required for the respective policies.",
+      "instructions": "1. Sign in to **Microsoft 365 Defender**.\n2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.\n3. Select **Threat Policies**.\n4. From the **Templated policies** section, select **Preset Security Policies**.\n5. Under **Strict protection**, select **Manage protection settings**.\n6. On the **Apply Exchange Online Protection** page, select **Specific recipients**.\n7. Add all sensitive accounts via the **User** and **Group** boxes using the\n   names of mailboxes, users, contacts, M365 groups, and distribution groups.\n8. Select **Next** on each page until the **Review and confirm your changes** page.\n9. On the **Review and confirm your changes** page, select **Confirm**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.1.5v1": {
+      "id": "ms.defender.1.5v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.1.5v1",
+      "group": "Preset Security Profiles",
+      "groupNumber": 1,
+      "assertion": "Sensitive accounts SHALL be added to Defender for Office 365 protection in the strict preset security policy.",
+      "obligation": "SHALL",
+      "rationale": "Unauthorized access to a sensitive account may result in greater harm than to a standard user account. Adding sensitive accounts to the strict preset security policy, with its increased protections, better mitigates their elevated risk.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "CM-6a",
+        "SI-3a",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002"
+      ],
+      "note": "The strict preset security policy must be enabled to protect sensitive accounts.",
+      "productLicenseNotes": "- Defender for Office 365 capabilities require Defender for Office 365 Plan 1 or 2. These are included with E5 and G5 and are available as add-ons for E3 and G3. However, third-party solutions can be used to meet this requirement. If a third-party solution is used, then a Defender for Office 365 Plan 1 or 2, E5, and G5 license is not required for the respective policies.",
+      "instructions": "1. Sign in to **Microsoft 365 Defender**.\n2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.\n3. Select **Threat Policies**.\n4. From the **Templated policies** section, select **Preset Security Policies**.\n5. Under **Strict protection**, select **Manage protection settings**.\n6. Select **Next** until you reach the **Apply Defender for Office 365 protection** page.\n7. On the **Apply Defender for Office 365 protection** page, select\n   **Specific recipients** or **Previously selected recipients** if sensitive\n   accounts were already set on the EOP page.\n8. If adding sensitive accounts separately via **Specific recipients**, add all\n   sensitive accounts via the **User** and **Group** boxes using the names of\n   mailboxes, users, contacts, M365 groups, and distribution groups.\n9. (Optional) Under **Exclude these recipients**, add **Users** and **Groups**\n   to be exempted from the preset policies.\n10. Select **Next** on each page until the **Review and confirm your changes** page.\n11. On the **Review and confirm your changes** page, select **Confirm**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.2.1v1": {
+      "id": "ms.defender.2.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.2.1v1",
+      "group": "Impersonation Protection",
+      "groupNumber": 2,
+      "assertion": "User impersonation protection SHOULD be enabled for sensitive accounts in both the standard and strict preset policies.",
+      "obligation": "SHOULD",
+      "rationale": "User impersonation, especially of users with access to sensitive or high-value information and resources, has the potential to result in serious harm. Impersonation protection mitigates this risk. By configuring impersonation protection in both preset policies, administrators can help protect email recipients from impersonated emails, regardless of whether they are added to the standard or strict policy.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1656"
+      ],
+      "note": "The standard and strict preset security policies must be enabled to protect accounts.",
+      "productLicenseNotes": "- Impersonation protection and advanced phishing thresholds require\n  Defender for Office 365 Plan 1 or 2. These are included with E5 and G5\n  and are available as add-ons for E3 and G3. As of April 25, 2023,\n  anti-phishing for user and domain impersonation and spoof intelligence\n  are not yet available in M365 Government Community Cloud (GCC High) and Department of Defense (DoD) environments. See [Platform features \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/office-365-platform-service-description/office-365-us-government/office-365-us-government#platform-features)\n  for current offerings.",
+      "instructions": "1. Sign in to **Microsoft 365 Defender**.\n2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.\n3. Select **Threat Policies**.\n4. From the **Templated policies** section, select **Preset Security Policies**.\n5. Under either **Standard protection** or **Strict protection**, select **Manage\n   protection settings**.\n6. Select **Next** until you reach the **Impersonation Protection** page, then\n   select **Next** once more.\n7. On the **Protected custom users** page, add a name and valid email address for each\n   sensitive account and click **Add** after each.\n8. Select **Next** until you reach the **Trusted senders and domains** page.\n9. (Optional) Add specific email addresses here to not flag as impersonation\n   when sending messages and prevent false positives. Click **Add** after each.\n10. Select **Next** on each page until the **Review and confirm your changes** page.\n11. On the **Review and confirm your changes** page, select **Confirm**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.2.2v1": {
+      "id": "ms.defender.2.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.2.2v1",
+      "group": "Impersonation Protection",
+      "groupNumber": 2,
+      "assertion": "Domain impersonation protection SHOULD be enabled for domains owned by the agency in both the standard and strict preset policies.",
+      "obligation": "SHOULD",
+      "rationale": "Configuring domain impersonation protection for all agency domains reduces the risk of a user being deceived by a look-alike domain. By configuring impersonation protection in both preset policies, administrators can help protect email recipients from impersonated emails, regardless of whether they are added to the standard or strict policy.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1656"
+      ],
+      "note": "The standard and strict preset security policies must be enabled to protect agency domains.",
+      "productLicenseNotes": "- Impersonation protection and advanced phishing thresholds require\n  Defender for Office 365 Plan 1 or 2. These are included with E5 and G5\n  and are available as add-ons for E3 and G3. As of April 25, 2023,\n  anti-phishing for user and domain impersonation and spoof intelligence\n  are not yet available in M365 Government Community Cloud (GCC High) and Department of Defense (DoD) environments. See [Platform features \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/office-365-platform-service-description/office-365-us-government/office-365-us-government#platform-features)\n  for current offerings.",
+      "instructions": "1. Sign in to **Microsoft 365 Defender**.\n2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.\n3. Select **Threat Policies**.\n4. From the **Templated policies** section, select **Preset Security Policies**.\n5. Under either **Standard protection** or **Strict protection**, select **Manage\n   protection settings**.\n6. Select **Next** until you reach the **Impersonation Protection** page, then\n   select **Next** once more.\n7. On the **Protected custom domains** page, add each agency domain\n   and click **Add** after each.\n8. Select **Next** until you reach the **Trusted senders and domains** page.\n9. (Optional) Add specific domains here to not flag as impersonation when\n   sending messages and prevent false positives. Click **Add** after each.\n10. Select **Next** on each page until the **Review and confirm your changes** page.\n11. On the **Review and confirm your changes** page, select **Confirm**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.2.3v1": {
+      "id": "ms.defender.2.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.2.3v1",
+      "group": "Impersonation Protection",
+      "groupNumber": 2,
+      "assertion": "Domain impersonation protection SHOULD be added for key suppliers and partners in both the standard and strict preset policies.",
+      "obligation": "SHOULD",
+      "rationale": "Configuring domain impersonation protection for domains owned by important partners reduces the risk of a user being deceived by a look-alike domain. By configuring impersonation protection in both preset policies, administrators can help protect email recipients from impersonated emails, regardless of whether they are added to the standard or strict policy.",
+      "lastModified": "November 2025",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1656"
+      ],
+      "note": "The standard and strict preset security policies must be enabled to protect partner domains.",
+      "productLicenseNotes": "- Impersonation protection and advanced phishing thresholds require\n  Defender for Office 365 Plan 1 or 2. These are included with E5 and G5\n  and are available as add-ons for E3 and G3. As of April 25, 2023,\n  anti-phishing for user and domain impersonation and spoof intelligence\n  are not yet available in M365 Government Community Cloud (GCC High) and Department of Defense (DoD) environments. See [Platform features \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/office-365-platform-service-description/office-365-us-government/office-365-us-government#platform-features)\n  for current offerings.",
+      "instructions": "1. Sign in to **Microsoft 365 Defender**.\n2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.\n3. Select **Threat Policies**.\n4. From the **Templated policies** section, select **Preset Security Policies**.\n5. Under either **Standard protection** or **Strict protection**, select **Manage\n   protection settings**.\n6. Select **Next** until you reach the **Impersonation Protection** page, then\n   select **Next** once more.\n7. On the **Protected custom domains** page, add each partner domain\n   and click **Add** after each.\n8. Select **Next** on each page until the **Review and confirm your changes** page.\n9. On the **Review and confirm your changes** page, select **Confirm**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.3.1v1": {
+      "id": "ms.defender.3.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.3.1v1",
+      "group": "Safe Attachments",
+      "groupNumber": 3,
+      "assertion": "Safe attachments SHOULD be enabled for SharePoint, OneDrive, and Microsoft Teams.",
+      "obligation": "SHOULD",
+      "rationale": "Clicking malicious links makes users vulnerable to attacks, and this danger is not limited to links in emails. Other Microsoft products, such as Microsoft Teams, can be used to present users with malicious links. As such, it is important to protect users on these other Microsoft products as well.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SI-3a"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1204",
+        "T1204.001",
+        "T1204.002"
+      ],
+      "productLicenseNotes": "- Safe attachments require Defender for Office 365 Plan 1 or 2. These are included with\n  E5 and G5 and are available as add-ons for E3 and G3.",
+      "instructions": "To enable Safe Attachments for SharePoint, OneDrive, and Microsoft\nTeams, follow the instructions listed at [Turn on Safe Attachments for\nSharePoint, OneDrive, and Microsoft Teams \\| Microsoft\nLearn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/safe-attachments-for-spo-odfb-teams-configure?view=o365-worldwide).\n\n1.  Sign in to **Microsoft 365 Defender**.\n\n2.  Under **Email & collaboration**, select **Policies & rules**.\n\n3.  Select **Threat policies**.\n\n4.  Under **Policies**, select **Safe Attachments**.\n\n5.  Select **Global settings**.\n\n6.  Toggle the **Turn on Defender for Office 365 for SharePoint, OneDrive, and\n    Microsoft Teams** slider to **On**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.4.1v2": {
+      "id": "ms.defender.4.1v2",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.4.1v2",
+      "group": "Data Loss Prevention",
+      "groupNumber": 4,
+      "assertion": "A custom policy SHALL be configured to protect PII and sensitive information, as defined by the agency, blocking at a minimum: credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN).",
+      "obligation": "SHALL",
+      "rationale": "Users may inadvertently share sensitive information with others who should not have access to it. DLP policies provide a way for agencies to detect and prevent unauthorized disclosures.",
+      "lastModified": "November 2024",
+      "nist80053": [
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1567",
+        "T1530",
+        "T1213"
+      ],
+      "productLicenseNotes": "- DLP for Teams requires an E5 or G5 license. See [Microsoft Purview Data Loss Prevention: Data Loss Prevention for Teams \\| Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#microsoft-purview-data-loss-prevention-data-loss-prevention-dlp-for-teams)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.\n\n- DLP for Endpoint requires an E5 or G5 license. See [Get started with\n  Endpoint data loss prevention - Microsoft Purview (compliance) \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.",
+      "instructions": "1. Sign in to the **Microsoft Purview portal**.\n\n2. Under the **Solutions** section on the left-hand menu, select **Data loss\n   prevention**.\n\n3. Select **Policies** from the top of the page.\n\n4. Select **Create policy**.\n\n5. From the **Categories** list, select **Custom**.\n\n6. From the **Regulations** list, select **Custom policy** and then click\n   **Next**.\n\n7. Edit the name and description of the policy if desired, then click\n   **Next**.\n\n8. Under **Assign admin units**,  ensure **Admin units** is set to **Full directory** by default, then click **Next**.\n\n9. Under **Choose where to apply the policy**, set **Status** to **On**\n   for at least the Exchange email, OneDrive accounts, SharePoint\n   sites, Teams chat and channel messages, and Devices locations, then\n   click **Next**.\n\n10. Under **Define policy settings**, select **Create or customize advanced\n   DLP rules**, and then click **Next**.\n\n11. Click **Create rule**. Assign the rule an appropriate name and\n   description.\n\n12. Click **Add condition**, then **Content contains**.\n\n13. Click **Add**, then **Sensitive info types**.\n\n14. Add information types that protect information sensitive to the agency.\n    At a minimum, the agency should protect:\n\n    - Credit card numbers\n    - U.S. Individual Taxpayer Identification Numbers (ITIN)\n    - U.S. Social Security Numbers (SSN)\n    - All agency-defined PII and sensitive information\n\n15. Click **Add**.\n\n16. Under **Actions**, click **Add an action**.\n\n17. Check **Restrict Access or encrypt the content in Microsoft 365\n    locations**.\n\n18. Under this action, select **Block Everyone**.\n\n19. Under **User notifications**, turn on **Use notifications to inform your users and help educate them on the proper use of sensitive info**.\n\n20. Under **Microsoft 365 services** if using a GCC environment or under **Microsoft 365 files and Microsoft Fabric items** if using a Commercial environment, a section that appears after user notifications are turned on, check the box next to **Notify users in Office 365 service with a policy tip or email notifications**.\n\n21. Click **Save**, then **Next**.\n\n22. Select **Turn the policy on immediately**, then click **Next**.\n\n23. Click **Submit**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.4.2v1": {
+      "id": "ms.defender.4.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.4.2v1",
+      "group": "Data Loss Prevention",
+      "groupNumber": 4,
+      "assertion": "The custom policy SHOULD be applied to Exchange, OneDrive, SharePoint, Teams chat, and Devices.",
+      "obligation": "SHOULD",
+      "rationale": "Unauthorized disclosures may happen through M365 services or endpoint devices. DLP policies should cover all affected locations to be effective.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1567",
+        "T1530",
+        "T1213",
+        "T1213.002"
+      ],
+      "note": "The custom policy referenced here is the same policy configured in [MS.DEFENDER.4.1v2](#msdefender41v2).",
+      "productLicenseNotes": "- DLP for Teams requires an E5 or G5 license. See [Microsoft Purview Data Loss Prevention: Data Loss Prevention for Teams \\| Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#microsoft-purview-data-loss-prevention-data-loss-prevention-dlp-for-teams)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.\n\n- DLP for Endpoint requires an E5 or G5 license. See [Get started with\n  Endpoint data loss prevention - Microsoft Purview (compliance) \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.",
+      "instructions": "See [MS.DEFENDER.4.1v2 Instructions](#msdefender41v2-instructions) step 8\n   for details on enforcing DLP policy in specific M365 service locations.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.4.3v1": {
+      "id": "ms.defender.4.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.4.3v1",
+      "group": "Data Loss Prevention",
+      "groupNumber": 4,
+      "assertion": "The action for the custom policy SHOULD be set to block sharing sensitive information with everyone.",
+      "obligation": "SHOULD",
+      "rationale": "Access to sensitive information should be prohibited unless explicitly allowed. Specific exemptions can be made based on agency policies and valid business justifications.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-3",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1567",
+        "T1530",
+        "T1213"
+      ],
+      "note": "The custom policy referenced here is the same policy configured in [MS.DEFENDER.4.1v2](#msdefender41v2).",
+      "productLicenseNotes": "- DLP for Teams requires an E5 or G5 license. See [Microsoft Purview Data Loss Prevention: Data Loss Prevention for Teams \\| Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#microsoft-purview-data-loss-prevention-data-loss-prevention-dlp-for-teams)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.\n\n- DLP for Endpoint requires an E5 or G5 license. See [Get started with\n  Endpoint data loss prevention - Microsoft Purview (compliance) \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.",
+      "instructions": "See [MS.DEFENDER.4.1v2 Instructions](#msdefender41v2-instructions) steps\n   15-17 for details on configuring DLP policy to block sharing sensitive\n   information with everyone.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.4.4v1": {
+      "id": "ms.defender.4.4v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.4.4v1",
+      "group": "Data Loss Prevention",
+      "groupNumber": 4,
+      "assertion": "Notifications to inform users and help educate them on the proper use of sensitive information SHOULD be enabled in the custom policy.",
+      "obligation": "SHOULD",
+      "rationale": "Some users may not be aware of agency policies on proper use of sensitive information. Enabling notifications provides positive feedback to users when accessing sensitive information.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AT-2b"
+      ],
+      "mitreAttack": [],
+      "note": "The custom policy referenced here is the same policy configured in [MS.DEFENDER.4.1v2](#msdefender41v2).",
+      "productLicenseNotes": "- DLP for Teams requires an E5 or G5 license. See [Microsoft Purview Data Loss Prevention: Data Loss Prevention for Teams \\| Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#microsoft-purview-data-loss-prevention-data-loss-prevention-dlp-for-teams)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.\n\n- DLP for Endpoint requires an E5 or G5 license. See [Get started with\n  Endpoint data loss prevention - Microsoft Purview (compliance) \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.",
+      "instructions": "See [MS.DEFENDER.4.1v2 Instructions](#msdefender41v2-instructions) steps\n   18-19 for details on configuring DLP policy to notify users when accessing\n   sensitive information.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.4.5v1": {
+      "id": "ms.defender.4.5v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.4.5v1",
+      "group": "Data Loss Prevention",
+      "groupNumber": 4,
+      "assertion": "A list of apps that are restricted from accessing files protected by DLP policy SHOULD be defined.",
+      "obligation": "SHOULD",
+      "rationale": "Some apps may inappropriately share accessed files or not conform to agency policies for access to sensitive information. Defining a list of those apps makes it possible to use DLP policies to restrict those apps' access to sensitive information on endpoints using Defender.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1565",
+        "T1485",
+        "T1530"
+      ],
+      "productLicenseNotes": "- DLP for Teams requires an E5 or G5 license. See [Microsoft Purview Data Loss Prevention: Data Loss Prevention for Teams \\| Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#microsoft-purview-data-loss-prevention-data-loss-prevention-dlp-for-teams)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.\n\n- DLP for Endpoint requires an E5 or G5 license. See [Get started with\n  Endpoint data loss prevention - Microsoft Purview (compliance) \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.",
+      "instructions": "1. Sign in to the **Microsoft Purview portal**.\n\n2. Go to **Settings**, under **Solution Settings** select **Data loss prevention**.\n\n3. Go to **Endpoint DLP Settings**.\n\n4. Go to **Restricted apps and app groups**.\n\n5. Click **Add or edit Restricted Apps**.\n\n6. Enter an app and executable name to disallow said app from\n   accessing protected files, and log the incident.\n\n7. Return and click **Unallowed Bluetooth apps**.\n\n8. Click **Add or edit unallowed Bluetooth apps**.\n\n9. Enter an app and executable name to disallow said app from\n   accessing protected files, and log the incident.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.4.6v1": {
+      "id": "ms.defender.4.6v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.4.6v1",
+      "group": "Data Loss Prevention",
+      "groupNumber": 4,
+      "assertion": "The custom policy SHOULD include an action to block access to sensitive information by restricted apps and unwanted Bluetooth applications.",
+      "obligation": "SHOULD",
+      "rationale": "Some apps may inappropriately share accessed files or not conform to agency policies for access to sensitive information. Defining a DLP policy with an action to block access from restricted apps and unwanted Bluetooth applications prevents unauthorized disclosure by those programs.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-19a"
+      ],
+      "mitreAttack": [
+        "T1565",
+        "T1485",
+        "T1530",
+        "T1486"
+      ],
+      "note": "- The custom policy referenced here is the same policy configured in [MS.DEFENDER.4.1v2](#msdefender41v2). - This action can only be included if at least one device is onboarded to the agency tenant. Otherwise, the option to block restricted apps will not be available.",
+      "productLicenseNotes": "- DLP for Teams requires an E5 or G5 license. See [Microsoft Purview Data Loss Prevention: Data Loss Prevention for Teams \\| Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#microsoft-purview-data-loss-prevention-data-loss-prevention-dlp-for-teams)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.\n\n- DLP for Endpoint requires an E5 or G5 license. See [Get started with\n  Endpoint data loss prevention - Microsoft Purview (compliance) \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.",
+      "instructions": "If restricted app and unwanted Bluetooth app restrictions are desired,\nassociated devices must be onboarded with Defender for Endpoint\nbefore the instructions below can be completed.\n\n1. Sign in to the **Microsoft Purview portal**.\n\n2. Under **Solutions**, select **Data loss prevention**.\n\n3. Select **Policies** from the top of the page.\n\n4. Find the custom DLP policy configured under\n   [MS.DEFENDER.4.1v2 Instructions](#msdefender41v2-instructions) in the list\n   and click the Policy name to select.\n\n5. Select **Edit Policy**.\n\n6. Click **Next** on each page in the policy wizard until you reach the\n   Advanced DLP rules page.\n\n7. Select the relevant rule and click the pencil icon to edit it.\n\n8. Under **Actions**, click **Add an action**.\n\n9. Choose **Audit or restrict activities on device**\n\n10. Under **File activities for all apps**, select\n    **Apply restrictions to specific activity**.\n\n11. Check the box next to **Copy or move using unallowed Bluetooth app**\n    and set its action to **Block**.\n\n12. Under **Restricted app activities**, check the **Access by restricted apps** box\n   and set the action drop-down to **Block**.\n\n13. Click **Save** to save the changes.\n\n14. Click **Next** on each page until reaching the\n    **Review your policy and create it** page.\n\n15. Review the policy and click **Submit** to complete the policy changes.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.5.1v1": {
+      "id": "ms.defender.5.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.5.1v1",
+      "group": "Alerts",
+      "groupNumber": 5,
+      "assertion": "At a minimum, the alerts required by the CISA M365 Secure Configuration Baseline for Exchange Online SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Potentially malicious or service-impacting events may go undetected without a means of detecting these events. Administrators are alerted to these events when they occur, minimizing potential user or agency impact.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SI-4(5)"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.006"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. Sign in to **Microsoft 365 Defender**.\n\n2. Under **Email & collaboration**, select **Policies & rules**.\n\n3. Select **Alert Policy**.\n\n4. Select the checkbox next to each alert to enable as determined by the\n   agency and at a minimum those referenced in the\n   [_CISA M365 Secure Configuration Baseline for Exchange Online_](./exo.md#msexo161v1) which are:\n\n   a. **Suspicious email sending patterns detected.**\n\n   b. **Suspicious connector activity.**\n\n   c. **Suspicious Email Forwarding Activity.**\n\n   d. **Messages have been delayed.**\n\n   e. **Tenant restricted from sending unprovisioned email.**\n\n   f. **Tenant restricted from sending email.**\n\n   g. **A potentially malicious URL click was detected.**\n\n5. Click the pencil icon from the top menu.\n\n6. Select the **Enable selected policies** action from the **Bulk actions**\n   menu.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.5.2v1": {
+      "id": "ms.defender.5.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.5.2v1",
+      "group": "Alerts",
+      "groupNumber": 5,
+      "assertion": "The alerts SHOULD be sent to a monitored address or incorporated into a Security Information and Event Management (SIEM).",
+      "obligation": "SHOULD",
+      "rationale": "Suspicious or malicious events, if not resolved promptly, may have a greater impact to users and the agency. Sending alerts to a monitored email address or SIEM system helps ensure events are acted upon in a timely manner to limit overall impact.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SI-4(5)"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.006"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "For each enabled alert, to add one or more email recipients:\n\n1. Sign in to **Microsoft 365 Defender**.\n\n2. Under **Email & collaboration**, select **Policies & rules**.\n\n3. Select **Alert Policy**.\n\n4. Click the alert policy to modify.\n\n5. Click the pencil icon next to **Set your recipients**.\n\n6. Check the **Opt-In for email notifications** box.\n\n7. Add one or more email addresses to the **Email recipients** text box.\n\n8. Click **Next**.\n\n9. On the **Review** page, click **Submit** to save the notification settings.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.6.1v1": {
+      "id": "ms.defender.6.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.6.1v1",
+      "group": "Audit Logging",
+      "groupNumber": 6,
+      "assertion": "Unified Audit logging SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Responding to incidents without detailed information about activities that took place slows response actions. Enabling Unified Audit logging helps ensure agencies have visibility into user actions. Furthermore, enabling the Unified Audit log is required for government agencies by OMB M-21-31.",
+      "lastModified": "March 2025",
+      "nist80053": [
+        "AU-12"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.008"
+      ],
+      "productLicenseNotes": "- Microsoft Purview Audit (Premium) logging capabilities, including the creation of a custom audit\n  log retention policy, requires E5/G5 licenses or E3/G3 licenses with\n  add-on compliance licenses.\n\n- Additionally, maintaining logs in the M365 environment for longer than\n  one year requires an add-on license. For more information, see\n  [Manage audit log retention policies | Microsoft Learn](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies?tabs=microsoft-purview-portal#before-you-create-an-audit-log-retention-policy). However, this requirement can also be met by exporting the logs from M365 and storing them with your solution of choice, in which case audit log retention policies are not necessary.",
+      "instructions": "To enable auditing via the **Microsoft Purview portal**:\n\n1. Sign in to the **Microsoft Purview portal**.\n\n2. Under **Solutions**, select **Audit**.\n\n3. If auditing is not enabled, a banner is displayed to notify the\nadministrator to start recording user and admin activity.\n\n4. Click the **Start recording user and admin activity**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.defender.6.3v1": {
+      "id": "ms.defender.6.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.DEFENDER.6.3v1",
+      "group": "Audit Logging",
+      "groupNumber": 6,
+      "assertion": "Audit logs SHALL be maintained for at least the minimum duration dictated by OMB M-21-31.",
+      "obligation": "SHALL",
+      "rationale": "Audit logs may no longer be available when needed if they are not retained for a sufficient time. Increased log retention time gives an agency the necessary visibility to investigate incidents that occurred some time ago.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AU-11"
+      ],
+      "mitreAttack": [
+        "T1070"
+      ],
+      "note": "Purview Audit (Premium) provides a default audit log retention policy, retaining Exchange Online, SharePoint Online, OneDrive for Business, and Microsoft Entra ID audit records for one year. Additional record types require custom audit retention policies. Agencies may also consider alternate storage locations and services to meet audit log retention needs.",
+      "productLicenseNotes": "- Microsoft Purview Audit (Premium) logging capabilities, including the creation of a custom audit\n  log retention policy, requires E5/G5 licenses or E3/G3 licenses with\n  add-on compliance licenses.\n\n- Additionally, maintaining logs in the M365 environment for longer than\n  one year requires an add-on license. For more information, see\n  [Manage audit log retention policies | Microsoft Learn](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies?tabs=microsoft-purview-portal#before-you-create-an-audit-log-retention-policy). However, this requirement can also be met by exporting the logs from M365 and storing them with your solution of choice, in which case audit log retention policies are not necessary.",
+      "instructions": "To create one or more custom audit retention policies, if the default retention policy is not sufficient for agency needs, follow [Create an audit log retention policy](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies?view=o365-worldwide#create-an-audit-log-retention-policy) instructions.\nEnsure the duration selected in the retention policies is at least one year, in accordance with OMB M-21-31.\n\nAs noted in the [License Requirements](https://github.com/cisagov/ScubaGear/baselines/defender.md#license-requirements-1) section above, the creation of a custom audit log retention policy and its retention in the M365 environment requires E5/G5 licenses or E3/G3 licenses with add-on compliance licenses. No additional license is required to view and export logs. To view and export audit logs follow [Export, configure, and view audit log records | Microsoft Learn](https://learn.microsoft.com/en-us/purview/audit-log-export-records) and/or [Untitled Goose Tool Fact Sheet | CISA.](https://www.cisa.gov/resources-tools/resources/untitled-goose-tool-fact-sheet)\n\n**`TLP:CLEAR`**",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/defender.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/defender.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md"
+    },
+    "ms.exo.1.1v2": {
+      "id": "ms.exo.1.1v2",
+      "platform": "microsoft-365",
+      "policyId": "MS.EXO.1.1v2",
+      "group": "Automatic Forwarding to External Domains",
+      "groupNumber": 1,
+      "assertion": "Automatic forwarding to external domains SHALL be disabled.",
+      "obligation": "SHALL",
+      "rationale": "Adversaries can use automatic forwarding to gain",
+      "lastModified": "March 2025",
+      "nist80053": [
+        "AC-4"
+      ],
+      "mitreAttack": [
+        "T1567",
+        "T1048",
+        "T1566",
+        "T1566.001"
+      ],
+      "note": "Automatic forwarding MAY be enabled with specific, agency-approved domains.",
+      "details": "persistent access to a victim's email. Disabling forwarding to\nexternal domains prevents this technique when the adversary is\nexternal to the organization but does not impede legitimate\ninternal forwarding.\nThere may be cases where an external domain is operationally needed and has an acceptable\ndegree of risk, e.g., a domain controlled by the same agency that hasn't been added\nas an accepted domain in M365.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "To disallow automatic forwarding to external domains:\n\n1.  Sign in to the **Exchange admin center**.\n\n2.  Select **Mail flow**, then **Remote domains**.\n\n3.  Select **Default**.\n\n4.  Under **Email reply types**, select **Edit reply types**.\n\n5.  Clear the checkbox next to **Allow automatic forwarding**, then\n    click **Save**.\n\n6.  Return to **Remote domains** and review each\n    additional remote domain in the list, ensuring that automatic forwarding\n    is only allowed for approved domains.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/exo.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md"
+    },
+    "ms.exo.13.1v1": {
+      "id": "ms.exo.13.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.EXO.13.1v1",
+      "group": "Mailbox Auditing",
+      "groupNumber": 13,
+      "assertion": "Mailbox auditing SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Exchange Online user accounts can be compromised or misused. Enabling mailbox auditing provides a valuable source of information to detect and respond to mailbox misuse.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AU-12c"
+      ],
+      "mitreAttack": [
+        "T1070",
+        "T1070.008",
+        "T1098",
+        "T1098.002",
+        "T1562",
+        "T1562.008",
+        "T1586",
+        "T1586.002",
+        "T1564",
+        "T1564.008"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "Mailbox auditing can be managed from the Exchange Online PowerShell.\nFollow the instructions listed on [Manage mailbox auditing in Office\n365](https://learn.microsoft.com/en-us/microsoft-365/compliance/audit-mailboxes?view=o365-worldwide).\n\nTo check the current mailbox auditing status for your organization via PowerShell:\n\n1.  Connect to the Exchange Online PowerShell.\n\n2.  Run the following command:\n\n    `Get-OrganizationConfig | Format-List AuditDisabled`\n\n3.  An `AuditDisabled : False` result indicates mailbox auditing is enabled.\n\nTo enable mailbox auditing by default for your organization via PowerShell:\n\n1.  Connect to the Exchange Online PowerShell.\n\n2.  Run the following command:\n\n    `Set-OrganizationConfig –AuditDisabled $false`\n\n**`TLP:CLEAR`**",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/exo.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md"
+    },
+    "ms.exo.2.2v3": {
+      "id": "ms.exo.2.2v3",
+      "platform": "microsoft-365",
+      "policyId": "MS.EXO.2.2v3",
+      "group": "Sender Policy Framework",
+      "groupNumber": 2,
+      "assertion": "An SPF policy SHALL be published for each domain that fails all non-approved senders.",
+      "obligation": "SHALL",
+      "rationale": "An adversary may modify the `FROM` field",
+      "lastModified": "October 2025",
+      "nist80053": [
+        "AC-2d"
+      ],
+      "mitreAttack": [
+        "T1656",
+        "T1566"
+      ],
+      "note": "SPF defines two different \"fail\" mechanisms: fail (indicated by `-`, sometimes referred to as hardfail) and softfail (indicated by `~`). Either hard or soft fail may be used to comply with this baseline policy.",
+      "details": "of an email such that it appears to be a legitimate email sent by an\nagency, facilitating phishing attacks. Publishing an SPF policy for each agency domain mitigates forged `FROM` fields by providing a means for recipients to detect emails spoofed in this way.  SPF is required for FCEB departments and agencies by Binding Operational Directive (BOD) 18-01, \"Enhance Email and Web Security\".",
+      "productLicenseNotes": "- N/A",
+      "instructions": "First, identify any approved senders specific to your agency, e.g., any on-premises mail servers. SPF allows you to indicate approved senders by IP address or CIDR range. However, note that SPF allows you to [include](https://www.rfc-editor.org/rfc/rfc7208#section-5.2) the IP addresses indicated by a separate SPF policy, referred to by domain name. See [External DNS records required for SPF](https://learn.microsoft.com/en-us/microsoft-365/enterprise/external-domain-name-system-records?view=o365-worldwide#external-dns-records-required-for-spf) for inclusions required for M365 to send email on behalf of your domain.\n\nSPF is not configured through the Exchange admin center, but rather via\nDNS records hosted by the agency's domain. Thus, the exact steps needed\nto set up SPF varies from agency to agency. See [Add or edit an SPF TXT record to help prevent email spam (Outlook, Exchange Online) \\| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/admin/get-help-with-domains/create-dns-records-at-any-dns-hosting-provider?view=o365-worldwide#add-or-edit-an-spf-txt-record-to-help-prevent-email-spam-outlook-exchange-online) for more details.\n\nTo test your SPF configuration, consider using a web-based tool, such as\nthose listed under [How can I validate SPF records for my domain? \\| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/admin/setup/domains-faq?view=o365-worldwide#how-can-i-validate-spf-records-for-my-domain).\nAdditionally, SPF records can be requested using the\nPowerShell tool `Resolve-DnsName`. For example:\n\n```\nResolve-DnsName example.onmicrosoft.com txt\n```\n\nIf SPF is configured, you will see a response resembling `v=spf1 include:spf.protection.outlook.com -all`\nreturned; though by necessity, the contents of the SPF\npolicy may vary by agency. In this example, the SPF policy indicates\nthe IP addresses listed by the policy for \"spf.protection.outlook.com\" are\nthe only approved senders for \"example.onmicrosoft.com.\" These IPs can be determined\nvia an additional SPF lookup, this time for \"spf.protection.outlook.com.\" Ensure the IP addresses listed as approved senders for your domains are correct. Additionally, ensure that each policy either ends in `-all` or `~all` or [redirects](https://www.rfc-editor.org/rfc/rfc7208#section-6.1) to one that does; these directives indicates that all IPs that don't match the policy should fail. See [SPF TXT record syntax for Microsoft 365 \\| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-anti-spoofing?view=o365-worldwide#spf-txt-record-syntax-for-microsoft-365) for a more in-depth discussion\nof SPF record syntax.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/exo.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md"
+    },
+    "ms.exo.3.1v1": {
+      "id": "ms.exo.3.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.EXO.3.1v1",
+      "group": "DomainKeys Identified Mail",
+      "groupNumber": 3,
+      "assertion": "DKIM SHOULD be enabled for all domains.",
+      "obligation": "SHOULD",
+      "rationale": "An adversary may modify the `FROM` field",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SC-8"
+      ],
+      "mitreAttack": [
+        "T1598",
+        "T1656",
+        "T1566"
+      ],
+      "details": "of an email such that it appears to be a legitimate email sent by an\nagency, facilitating phishing attacks. Enabling DKIM is another means for\nrecipients to detect spoofed emails and verify the integrity of email content.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. To enable DKIM, follow the instructions listed on [Steps to Create,\nenable and disable DKIM from Microsoft 365 Defender portal \\| Microsoft\nLearn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-dkim-configure?view=o365-worldwide#steps-to-create-enable-and-disable-dkim-from-microsoft-365-defender-portal).",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/exo.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md"
+    },
+    "ms.exo.4.1v1": {
+      "id": "ms.exo.4.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.EXO.4.1v1",
+      "group": "Domain-Based Message Authentication, Reporting, and Conformance (DMARC)",
+      "groupNumber": 4,
+      "assertion": "A DMARC policy SHALL be published for every second-level domain.",
+      "obligation": "SHALL",
+      "rationale": "Without a DMARC policy available for each domain, recipients",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1598",
+        "T1656",
+        "T1566"
+      ],
+      "details": "may improperly handle SPF and DKIM failures, possibly enabling spoofed\nemails to reach end users' mailboxes. Publishing DMARC records at the\nsecond-level domain protects the second-level domains and all subdomains.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "DMARC is not configured through the Exchange admin center, but rather via\nDNS records hosted by the agency's domain. As such, implementation varies\ndepending on how an agency manages its DNS records. See [Form the DMARC TXT record for your domain \\| Microsoft\nLearn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-dmarc-configure?view=o365-worldwide#step-4-form-the-dmarc-txt-record-for-your-domain)\nfor Microsoft guidance.\n\nA DMARC record published at the second-level domain will protect all subdomains.\nIn other words, a DMARC record published for `example.com` will protect both\n`a.example.com` and `b.example.com`, but a separate record would need to be\npublished for `c.example.gov`.\n\nTo test your DMARC configuration, consider using one of many publicly available\nweb-based tools. Additionally, DMARC records can be requested using the\nPowerShell tool `Resolve-DnsName`. For example:\n\n```\nResolve-DnsName _dmarc.example.com txt\n```\n\nIf DMARC is configured, a response resembling `v=DMARC1; p=reject; pct=100; rua=mailto:reports@dmarc.cyber.dhs.gov, mailto:reports@example.com; ruf=mailto:reports@example.com`\nwill be returned, though by necessity, the contents of the record will vary\nby agency. In this example, the policy indicates all emails failing the\nSPF/DKIM checks are to be rejected and aggregate reports sent to\nreports@dmarc.cyber.dhs.gov and reports@example.com. Failure reports will be\nsent to reports@example.com.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/exo.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md"
+    },
+    "ms.exo.4.2v1": {
+      "id": "ms.exo.4.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.EXO.4.2v1",
+      "group": "Domain-Based Message Authentication, Reporting, and Conformance (DMARC)",
+      "groupNumber": 4,
+      "assertion": "The DMARC message rejection option SHALL be p=reject.",
+      "obligation": "SHALL",
+      "rationale": "Of the three policy options (i.e., none, quarantine, and reject),",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1598",
+        "T1656",
+        "T1566"
+      ],
+      "details": "reject provides the strongest protection. Reject is the level of protection\nrequired by BOD 18-01 for FCEB departments and agencies.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "See [MS.EXO.4.1v1 Instructions](#msexo41v1-instructions) for an overview of how to publish and check a DMARC record. Ensure the record published includes `p=reject`.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/exo.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md"
+    },
+    "ms.exo.4.3v1": {
+      "id": "ms.exo.4.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.EXO.4.3v1",
+      "group": "Domain-Based Message Authentication, Reporting, and Conformance (DMARC)",
+      "groupNumber": 4,
+      "assertion": "The DMARC point of contact for aggregate reports SHALL include `reports@dmarc.cyber.dhs.gov`.",
+      "obligation": "SHALL",
+      "rationale": "Email spoofing attempts are not inherently visible to domain",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SI-4(5)"
+      ],
+      "mitreAttack": [
+        "T1562"
+      ],
+      "note": "Only federal, executive branch, departments and agencies should include this email address in their DMARC record.",
+      "details": "owners. DMARC provides a mechanism to receive reports of spoofing attempts.\nIncluding reports@dmarc.cyber.dhs.gov as a point of contact for these reports gives CISA insight into spoofing attempts and is required by BOD 18-01 for FCEB departments and agencies.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "See [MS.EXO.4.1v1 Instructions](#msexo41v1-instructions) for an overview of how to publish and check a DMARC record. Ensure the record published includes reports@dmarc.cyber.dhs.gov\nas one of the emails for the RUA field.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/exo.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md"
+    },
+    "ms.exo.4.4v1": {
+      "id": "ms.exo.4.4v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.EXO.4.4v1",
+      "group": "Domain-Based Message Authentication, Reporting, and Conformance (DMARC)",
+      "groupNumber": 4,
+      "assertion": "An agency point of contact SHOULD be included for aggregate and failure reports.",
+      "obligation": "SHOULD",
+      "rationale": "Email spoofing attempts are not inherently visible to domain",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SI-4(5)"
+      ],
+      "mitreAttack": [
+        "T1562"
+      ],
+      "details": "owners. DMARC provides a mechanism to receive reports of spoofing attempts.\nIncluding an agency point of contact gives the agency insight into attempts\nto spoof their domains.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "See [MS.EXO.4.1v1 Instructions](#msexo41v1-instructions) for an overview of how to publish and check a DMARC record. Ensure the record published includes:\n- A point of contact specific to your agency in the RUA field.\n- reports@dmarc.cyber.dhs.gov as one of the emails in the RUA field.\n- One or more agency-defined points of contact in the RUF field.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/exo.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md"
+    },
+    "ms.exo.5.1v1": {
+      "id": "ms.exo.5.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.EXO.5.1v1",
+      "group": "Simple Mail Transfer Protocol Authentication",
+      "groupNumber": 5,
+      "assertion": "SMTP AUTH SHALL be disabled.",
+      "obligation": "SHALL",
+      "rationale": "SMTP AUTH is not used or needed by modern email clients.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [],
+      "details": "Therefore, disabling it as the global default conforms to the principle of\nleast functionality.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "To disable SMTP AUTH for the organization:\n\n1. Sign in to the **Exchange admin center**.\n\n2. On the left hand pane, select **Settings**; then from the settings list, select **Mail Flow**.\n\n3. Make sure the setting **Turn off SMTP AUTH protocol for your organization** is checked.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/exo.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md"
+    },
+    "ms.exo.6.1v1": {
+      "id": "ms.exo.6.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.EXO.6.1v1",
+      "group": "Calendar and Contact Sharing",
+      "groupNumber": 6,
+      "assertion": "Contact folders SHALL NOT be shared with all domains.",
+      "obligation": "SHALL NOT",
+      "rationale": "Contact folders may contain information that should not be shared by default with all domains. Disabling sharing with all domains closes an avenue for data exfiltration while still allowing",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-3",
+        "SC-7(10)(a)"
+      ],
+      "mitreAttack": [
+        "T1567",
+        "T1048"
+      ],
+      "note": "Contact folders MAY be shared with specific domains.",
+      "details": "for specific legitimate use as needed.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "To restrict sharing with all domains:\n\n1. Sign in to the **Exchange admin center**.\n\n2. On the left-hand pane under **Organization**, select **Sharing**.\n\n3. Select **Individual Sharing**.\n\n4. For all existing policies, select the policy, then select **Manage domains**.\n\n5. For all sharing rules under all existing policies, ensure **Sharing with all domains** is not selected.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/exo.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md"
+    },
+    "ms.exo.6.2v1": {
+      "id": "ms.exo.6.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.EXO.6.2v1",
+      "group": "Calendar and Contact Sharing",
+      "groupNumber": 6,
+      "assertion": "Calendar details SHALL NOT be shared with all domains.",
+      "obligation": "SHALL NOT",
+      "rationale": "Calendar details may contain information that should not be shared by default with all domains. Disabling sharing with all domains closes an avenue for data exfiltration while still allowing",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-3",
+        "SC-7(10)(a)"
+      ],
+      "mitreAttack": [
+        "T1567",
+        "T1048"
+      ],
+      "note": "Calendar details MAY be shared with specific domains.",
+      "details": "for legitimate use as needed.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "To restrict sharing calendar details with all domains:\n\n1. Refer to step 5 in [MS.EXO.6.1v1 Instructions](#msexo61v1-instructions) to implement\nthis policy.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/exo.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md"
+    },
+    "ms.exo.7.1v1": {
+      "id": "ms.exo.7.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.EXO.7.1v1",
+      "group": "External Sender Warnings",
+      "groupNumber": 7,
+      "assertion": "External sender warnings SHALL be implemented.",
+      "obligation": "SHALL",
+      "rationale": "Alerting users when email originates from outside their organization can encourage them to exercise increased caution, especially if an email is one they expected from an internal sender.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "To create a mail flow rule to produce external sender warnings:\n\n1.  Sign in to the **Exchange admin center**.\n\n2.  Under **Mail flow**, select **Rules**.\n\n3.  Click the plus (**+**) button to create a new rule.\n\n4.  Select **Modify messages…**.\n\n5.  Give the rule an appropriate name.\n\n6.  Under **Apply this rule if…,** select **The sender is external/internal**.\n\n7.  Under **select sender location**, select **Outside the organization**, then click **OK**.\n\n8.  Under **Do the following…,** select **Prepend the subject of the message with…**.\n\n9.  Under **specify subject prefix**, enter a message such as\n    \"\\[External\\]\" (without the quotation marks), then click **OK**.\n\n10. Click **Next**.\n\n11. Under **Choose a mode for this rule**, select **Enforce**.\n\n12. Leave the **Severity** as **Not Specified**.\n\n13. Leave the **Match sender address in message** as **Header** and click **Next**.\n\n14. Click **Finish** and then **Done**.\n\n15. The new rule will be disabled.  Re-select the new rule to show its\n    settings and slide the **Enable or disable rule** slider to the right\n    until it shows as **Enabled**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/exo.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/exo.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md"
+    },
+    "ms.powerbi.1.1v1": {
+      "id": "ms.powerbi.1.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERBI.1.1v1",
+      "group": "Publish to Web",
+      "groupNumber": 1,
+      "assertion": "The Publish to Web feature SHOULD be disabled unless the agency mission requires the capability.",
+      "obligation": "SHOULD",
+      "rationale": "A publicly accessible web URL can be accessed by everyone, including malicious actors. This policy limits information available on the public web that is not specifically allowed to be published.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "CM-7",
+        "SC-7(10)(a)"
+      ],
+      "mitreAttack": [
+        "T1530"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. Navigate to the **PowerBI Admin Portal**\n\n2. Click on **Tenant Settings**\n\n3. Scroll to **Export and sharing settings**\n\n4. Click **Publish to web** set to **Disabled**",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerbi.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerbi.md"
+    },
+    "ms.powerbi.2.1v1": {
+      "id": "ms.powerbi.2.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERBI.2.1v1",
+      "group": "Power BI Guest Access",
+      "groupNumber": 2,
+      "assertion": "Guest user access to the Power BI tenant SHOULD be disabled unless the agency mission requires the capability.",
+      "obligation": "SHOULD",
+      "rationale": "Disabling external access to Power BI helps keep guest users from accessing potentially risky data and application programming interfaces (APIs). If an agency needs to allow guest access, this can be limited to users in specific security groups to curb risk.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "CM-7",
+        "AC-6"
+      ],
+      "mitreAttack": [
+        "T1485",
+        "T1565",
+        "T1565.001",
+        "T1078",
+        "T1078.001"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "To Disable Completely:\n1. Navigate to the **PowerBI Admin Portal**\n\n2. Click on **Tenant Settings**\n\n3. Scroll to **Export and sharing settings**\n\n4. For **Commercial** tenants Click on **Guest users can access Microsoft Fabric** and set to **Disabled**\n\n5. For **GCC, GCC High and DoD** tenants Click on **Allow Azure Active Directory guest users to access Power BI** and set to **Disabled**\n\nTo Enable with Security Group(s):\n1. Navigate to the **PowerBI Admin Portal**\n\n2. Click on **Tenant Settings**\n\n3. Scroll to **Export and sharing settings**\n\n4. For **Commercial** tenants Click on **Guest users can access Microsoft Fabric** and set to **Enabled**\n\n5. For **GCC, GCC High and DoD** tenants Click on **Allow Azure Active Directory guest users to access Power BI** and set to **Enabled**\n\n6. Select the security group(s) you want to have access to the PowerBI tenant.\n> Note:\n> You may need to make a specific security group(s)",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerbi.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerbi.md"
+    },
+    "ms.powerbi.3.1v1": {
+      "id": "ms.powerbi.3.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERBI.3.1v1",
+      "group": "Power BI External Invitations",
+      "groupNumber": 3,
+      "assertion": "The Invite external users to your organization feature SHOULD be disabled unless agency mission requires the capability.",
+      "obligation": "SHOULD",
+      "rationale": "Disabling this feature keeps internal users from inviting guest users. Therefore guest users can be limited from accessing potentially risky data/APIs. If an agency needs to allow guest access, the agency can limit the invitation feature to users in specific security groups to help limit risk.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "CM-7",
+        "AC-6"
+      ],
+      "mitreAttack": [
+        "T1485",
+        "T1565",
+        "T1565.001",
+        "T1078",
+        "T1078.001",
+        "T1199"
+      ],
+      "details": "> Note:\n> If this feature is disabled, existing guest users in the tenant continue to have access to Power BI items they already had access to and continue to be listed in user picker experiences. After it is disabled, an external user who is not already a guest user cannot be added to the tenant through Power BI.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "To disable completely:\n1. Navigate to the **PowerBI Admin Portal**\n\n2. Click on **Tenant Settings**\n\n3. Scroll to **Export and sharing settings**\n\n4. Click on **Users can invite guest users to collaborate through item sharing and permissions** and set to **Disabled**\n\nTo enable with security groups:\n1. Navigate to the **PowerBI Admin Portal**\n\n2. Click on **Tenant Settings**\n\n3. Scroll to **Export and sharing settings**\n\n4. Click on **Users can invite guest users to collaborate through item sharing and permissions** and set to **Enabled**\n\n5. Select the security group(s) needed.\n> Note:\n> You may need to make a specific security group(s)",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerbi.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerbi.md"
+    },
+    "ms.powerbi.4.1v1": {
+      "id": "ms.powerbi.4.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERBI.4.1v1",
+      "group": "Power BI Service Principals",
+      "groupNumber": 4,
+      "assertion": "Service principals with access to APIs SHOULD be restricted to specific security groups.",
+      "obligation": "SHOULD",
+      "rationale": "With unrestricted service principals, unwanted access to APIs is possible. Allowing service principals through security groups, and only where necessary, mitigates this risk.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-4",
+        "AC-6(5)"
+      ],
+      "mitreAttack": [
+        "T1059",
+        "T1059.009"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "If your organization has service principals that need to access Power BI APIs, then you configure the setting per the instructions below.\nIf you don't have service principals that need access then for step 4, configure the setting to Disabled.\n\n1. Navigate to the **PowerBI Admin Portal**\n\n2. Click on **Tenant settings**\n\n3. Scroll to **Developer settings**\n\n4. Click on **Service Principals can call Fabric public APIs**\n\n5. If don't have service principals that need access to Power BI APIs, then configure the setting to **Disabled** and you are finished. Otherwise go to step 6.\n\n6. If you have service principals that need to access Power BI APIs, then configure the setting to **Enabled**.\n\n7. Select the specific security groups that contain the service principals authorized to call the APIs.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerbi.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerbi.md"
+    },
+    "ms.powerbi.4.2v1": {
+      "id": "ms.powerbi.4.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERBI.4.2v1",
+      "group": "Power BI Service Principals",
+      "groupNumber": 4,
+      "assertion": "Service principals creating and using profiles SHOULD be restricted to specific security groups.",
+      "obligation": "SHOULD",
+      "rationale": "With unrestricted service principals creating/using profiles, there is risk of an unauthorized user using a profile with more permissions than they have. Allowing service principals through security groups will mitigate that risk.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-4",
+        "AC-6(5)"
+      ],
+      "mitreAttack": [
+        "T1098",
+        "T1098.003"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. Navigate to the **PowerBI Admin Portal**\n\n2. Click on **Tenant settings**\n\n3. Scroll to **Developer settings**\n\n4. Then, click on **Allow service principals to create and use profiles**\n\n5. If don't have service principals that need to create and use profiles, then configure the setting to **Disabled** and you are finished. Otherwise go to step 6.\n\n6. If you have service principals that need to create and use profiles, then configure the setting to **Enabled**.\n\n7. Select the specific security groups that contain the service principals authorized to to create and use profiles.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerbi.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerbi.md"
+    },
+    "ms.powerbi.5.1v1": {
+      "id": "ms.powerbi.5.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERBI.5.1v1",
+      "group": "Power BI ResourceKey Authentication",
+      "groupNumber": 5,
+      "assertion": "ResourceKey-based authentication SHOULD be blocked unless a specific use case (e.g., streaming and/or PUSH datasets) merits its use.",
+      "obligation": "SHOULD",
+      "rationale": "If resource keys are allowed, someone can move data without Microsoft Entra ID OAuth bearer token, causing possibly malicious or junk data to be stored. Disabling resource keys reduces risk that an unauthorized individual will make changes.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "CM-7",
+        "IA-5g"
+      ],
+      "mitreAttack": [
+        "T1134",
+        "T1134.001",
+        "T1134.003"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. Navigate to the **PowerBI Admin Portal**\n\n2. Click on **Tenant settings**\n\n3. Scroll to **Developer settings**\n\n4. Click on **Block ResourceKey Authentication** and set to **Enabled**",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerbi.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerbi.md"
+    },
+    "ms.powerbi.6.1v1": {
+      "id": "ms.powerbi.6.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERBI.6.1v1",
+      "group": "Python and R Visual Sharing",
+      "groupNumber": 6,
+      "assertion": "Python and R interactions SHOULD be disabled.",
+      "obligation": "SHOULD",
+      "rationale": "External code poses a security and privacy risk as there is no good way to regulate use of  data or integrations. Disabling this feature reduces the risk of a data leak or malicious threat activity.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "CM-7",
+        "SI-3"
+      ],
+      "mitreAttack": [
+        "T1059",
+        "T1059.009",
+        "T1048",
+        "T1567"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. Navigate to the **PowerBI Admin Portal**\n\n2. Click on **Tenant settings**\n\n3. Scroll to **R and Python Visuals Settings**\n\n4. Click on **Interact with and share R and Python visuals** and set to **Disabled**",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerbi.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerbi.md"
+    },
+    "ms.powerbi.7.1v1": {
+      "id": "ms.powerbi.7.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERBI.7.1v1",
+      "group": "Power BI Sensitive Data",
+      "groupNumber": 7,
+      "assertion": "Sensitivity labels SHOULD be enabled for Power BI and employed for sensitive data per enterprise data protection policies.",
+      "obligation": "SHOULD",
+      "rationale": "A document without sensitivity labels may be opened unknowingly, potentially exposing data to someone who is not supposed to have access to it. This policy will help organize and classify data, making it easier to keep data out of the wrong hands.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-21b",
+        "SC-7(10)(a)"
+      ],
+      "mitreAttack": [
+        "T1048",
+        "T1213",
+        "T1213.002",
+        "T1530",
+        "T1567"
+      ],
+      "productLicenseNotes": "- Microsoft Purview Information Protection Premium P1 or Premium P2 license is required to apply or view\n  Microsoft Information Protection sensitivity labels in Power BI. Azure Information Protection can be purchased either standalone or through one of the Microsoft licensing suites. See [Microsoft Purview Information Protection\n  service description](https://azure.microsoft.com/services/information-protection/) for\n  details.\n\n- Microsoft Purview Information Protection sensitivity labels need to be migrated to\n  the Microsoft Information Protection Unified Labeling platform to be\n  used in Power BI.\n\n- To apply labels to Power BI content and files, a user must\n  have a Power BI Pro or Premium Per User (PPU) license, in addition to\n  one of the previously mentioned Azure Information Protection licenses.\n\n- Before enabling sensitivity labels on the agency's tenant, ensure sensitivity labels have been defined and published for relevant\n  users and groups. See [Create and configure sensitivity labels and\n  their\n  policies](https://learn.microsoft.com/en-us/purview/create-sensitivity-labels)\n  for detail.",
+      "instructions": "1. Navigate to the **PowerBI Admin Portal**\n\n2. Click on **Tenant settings**\n\n3. Scroll to **Information protection**\n\n4. Click on **Allow users to apply sensitivity labels for content** and set to **Enabled**. Define who can apply and change sensitivity labels in Power BI assets.\n\n# Appendix A: Implementation Considerations",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerbi.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerbi.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerbi.md"
+    },
+    "ms.powerplatform.1.1v1": {
+      "id": "ms.powerplatform.1.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERPLATFORM.1.1v1",
+      "group": "Creation of Power Platform Environments",
+      "groupNumber": 1,
+      "assertion": "The ability to create production and sandbox environments SHALL be restricted to admins.",
+      "obligation": "SHALL",
+      "rationale": "Users creating new Power Platform environments may inadvertently bypass data loss prevention (DLP) policy settings or misconfigure the security settings of their environment.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-6(10)"
+      ],
+      "mitreAttack": [
+        "T1567",
+        "T1048"
+      ],
+      "details": "- Note: This control restricts creating environments to users with Global admin, Dynamics 365 service admin, Power Platform service admins, or Delegated admin roles.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to your tenant environment's respective [Power Platform admin\n    center](https://learn.microsoft.com/en-us/power-platform/admin/powerapps-us-government#power-apps-us-government-service-urls).\n\n2.  In the upper-right corner of the Microsoft Power Platform site,\n    select the **Gear icon** (Settings icon).\n\n3.  Select **Power Platform settings**.\n\n4.  Under **Production environment assignments**, select\n    **Only specific admins.**",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerplatform.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerplatform.md"
+    },
+    "ms.powerplatform.1.2v1": {
+      "id": "ms.powerplatform.1.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERPLATFORM.1.2v1",
+      "group": "Creation of Power Platform Environments",
+      "groupNumber": 1,
+      "assertion": "The ability to create trial environments SHALL be restricted to admins.",
+      "obligation": "SHALL",
+      "rationale": "Users creating new Power Platform environments may inadvertently bypass DLP policy settings or misconfigure the security settings of their environment.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-6(10)"
+      ],
+      "mitreAttack": [],
+      "details": "- Note: This control restricts creating environments to users with Global admin, Dynamics 365 service admin, Power Platform service admins, or Delegated admin roles.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Follow the MS.POWERPLATFORM.1.1v1 instructions up to step **3**.\n\n2.  Under **Trial environment assignments**, select **Only specific admins.**",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerplatform.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerplatform.md"
+    },
+    "ms.powerplatform.2.1v1": {
+      "id": "ms.powerplatform.2.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERPLATFORM.2.1v1",
+      "group": "Power Platform Data Loss Prevention Policies",
+      "groupNumber": 2,
+      "assertion": "A DLP policy SHALL be created to restrict connector access in the default Power Platform environment.",
+      "obligation": "SHALL",
+      "rationale": "All users in the tenant have access to the default Power Platform environment. Those users may inadvertently use connectors that share sensitive information with others who should not have access to it. Users requiring Power Apps should be directed to conduct development in other Power Platform environments with DLP connector policies customized to suit the user's needs while also maintaining the agency's security posture.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1567",
+        "T1048"
+      ],
+      "note": "The following connectors drive core Power Platform functionality and enable core Office customization scenarios: Approvals, Dynamics 365 Customer Voice, Excel Online (Business), Microsoft Dataverse (legacy), Microsoft Teams, Microsoft To-Do (Business), Office 365 Groups, Office 365 Outlook, Office 365 Users, OneDrive for Business, OneNote (Business), Planner, Power Apps Notification, Power BI, SharePoint, Shifts for Microsoft Teams, and Yammer. As such these connectors remain non-blockable to maintain core user scenario functions.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to your tenant environment's respective [Power Platform admin\n    center](https://learn.microsoft.com/en-us/power-platform/admin/powerapps-us-government#power-apps-us-government-service-urls).\n\n2.  On the left pane, select **Security** -\\> **Data and privacy.**\n\n3.   Select **Data policy,** then select **+ New Policy** icon to create a new policy.\n\n4.  Give the policy a suitable agency name and click **Next.**\n\n5.  At the **Prebuilt connectors** section, search and select the connectors currently in the **Non-business | default** tab containing sensitive data that can be utilized to create flows and apps.\n\n6.  Click **Move to Business.** Connectors added to this group can not share data with connectors in other groups because connectors can reside in only one data group at a time.\n\n7.  If necessary (and possible) for the connector, click **Configure connector** at the top of the screen to change connector permissions. This allows greater flexibility for the agency to allow and block certain connector actions for additional customization.\n\n8.  For the default environment, move all other connectors to the **Blocked** category. For non-blockable connectors noted above, the Block action will be grayed out and a warning will appear.\n\n9.  At the bottom of the screen, select **Next** to move on.\n\n10.  Add a custom connector pattern. Custom connectors allow admins to specify an ordered list of Allow and Deny URL patterns for custom connectors.  View [DLP for custom connectors \\| Microsoft\n  Learn](https://learn.microsoft.com/en-us/power-platform/admin/dlp-custom-connector-parity?WT.mc_id=ppac_inproduct_datapol) for more information.\n\n11.  Click **Next**.\n\n12.  At the **Scope** section for the default environment, select **Add multiple environments** then click **Next**.\n\n13.  Select the default environment, then select the **+ Add to policy** button at the top of the screen, then select **Next**.\n\n14. Select **Next**-\\> **Create Policy** to finish.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerplatform.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerplatform.md"
+    },
+    "ms.powerplatform.2.2v1": {
+      "id": "ms.powerplatform.2.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERPLATFORM.2.2v1",
+      "group": "Power Platform Data Loss Prevention Policies",
+      "groupNumber": 2,
+      "assertion": "Non-default environments SHOULD have at least one DLP policy affecting them.",
+      "obligation": "SHOULD",
+      "rationale": "Users may inadvertently use connectors that share sensitive information with others who should not have access to it. DLP policies provide a way for agencies to detect and prevent unauthorized disclosures.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1567",
+        "T1048"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Repeat steps 1 to 11 in the MS.POWERPLATFORM.2.1v1 instructions.\n\n2.  At the **Scope** section for the default environment, select **Add multiple environments** and select the non-default environments where you wish to enforce a DLP policy upon. If you wish to apply the DLP policy for all environments including environments created in the future select **Add all environments**.\n\n4.  Select **Next**-\\> **Create Policy** to finish.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerplatform.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerplatform.md"
+    },
+    "ms.powerplatform.3.1v1": {
+      "id": "ms.powerplatform.3.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERPLATFORM.3.1v1",
+      "group": "Power Platform Tenant Isolation",
+      "groupNumber": 3,
+      "assertion": "Power Platform tenant isolation SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Provides an additional tenant isolation control on top of Microsoft Entra ID tenant isolation specifically for Power Platform applications to prevent accidental or malicious cross tenant information sharing.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-3",
+        "SC-7(5)"
+      ],
+      "mitreAttack": [
+        "T1078",
+        "T1078.004",
+        "T1190"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to your tenant environment's respective [Power Platform admin\n    center](https://learn.microsoft.com/en-us/power-platform/admin/powerapps-us-government#power-apps-us-government-service-urls).\n\n2.  On the left pane, select **Security -\\> Identity and access -\\> Tenant Isolation**.\n\n3.  Set the slider **Restrict cross-tenant connections** to **On,** then click **Save**\n    on the bottom of the screen.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerplatform.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerplatform.md"
+    },
+    "ms.powerplatform.3.2v1": {
+      "id": "ms.powerplatform.3.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERPLATFORM.3.2v1",
+      "group": "Power Platform Tenant Isolation",
+      "groupNumber": 3,
+      "assertion": "An inbound/outbound connection allowlist SHOULD be configured.",
+      "obligation": "SHOULD",
+      "rationale": "Depending on agency needs an allowlist can be configured to allow cross tenant collaboration via connectors.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-3",
+        "SC-7(5)"
+      ],
+      "mitreAttack": [],
+      "details": "- Note: The allowlist may be empty if the agency has no need for cross tenant collaboration.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Follow steps **1 and 2** in **MS.POWERPLATFORM.3.1v1 instructions** to\narrive at the same page.\n\n2.  The tenant isolation exceptions can be configured by clicking **+ Add exceptions**\non the Tenant Isolation page.\n\n3.  Select the **Direction** of the rule and add the **Tenant Domain or ID** this rule applies to.\n\n4.  If Tenant Isolation is switched **Off**, these rules will not be enforced until tenant\nisolation is turned **On**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerplatform.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerplatform.md"
+    },
+    "ms.powerplatform.4.1v1": {
+      "id": "ms.powerplatform.4.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERPLATFORM.4.1v1",
+      "group": "Power Apps Content Security Policy",
+      "groupNumber": 4,
+      "assertion": "Content Security Policy (CSP) SHALL be enforced for model-driven and canvas Power Apps.",
+      "obligation": "SHALL",
+      "rationale": "Adds CSP as a defense mechanism for Power Apps against common website attacks.",
+      "lastModified": "March 2025",
+      "nist80053": [
+        "SI-10"
+      ],
+      "mitreAttack": [
+        "T1190"
+      ],
+      "note": "This policy is only applicable to environments using Dataverse.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to your tenant environment's respective [Power Platform admin\ncenter](https://learn.microsoft.com/en-us/power-platform/admin/powerapps-us-government#power-apps-us-government-service-urls).\n\n2.  On the left-hand pane click on **Manage -\\> Environments** and then select an environment from the list.\n\n3.  Select the **Settings** icon at the top of the page.\n\n4.  Click on **Product** then click on **Privacy + Security** from the options that appear.\n\n5.  At the bottom of the page under the **Content security policy** section, set **Enforce content security policy** to **On** for **Model-driven** and **Canvas**.\n\n6.  At the same location, set **Enable reporting**  to **On** and add an appropriate endpoint for reporting CSP violations can be reported to.\n\n7.  Repeat steps 2 to 6 for all active Power Platform environments.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerplatform.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerplatform.md"
+    },
+    "ms.powerplatform.5.1v1": {
+      "id": "ms.powerplatform.5.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERPLATFORM.5.1v1",
+      "group": "Power Pages Creation",
+      "groupNumber": 5,
+      "assertion": "The ability to create Power Pages sites SHOULD be restricted to admins.",
+      "obligation": "SHOULD",
+      "rationale": "Users may unintentionally misconfigure their Power Pages to expose sensitive information or leave the website in a vulnerable state.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-6(10)"
+      ],
+      "mitreAttack": [
+        "T1190"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  This setting currently can only be enabled through the [Power Apps PowerShell modules](https://learn.microsoft.com/en-us/power-platform/admin/powerapps-powershell#installation).\n\n2. After installing the Power Apps PowerShell modules, run `Add-PowerAppsAccount -Endpoint $YourTenantsEndpoint`. To authenticate to your tenant's Power Platform.\nDiscover the valid endpoint parameter [here](https://learn.microsoft.com/en-us/powershell/module/microsoft.powerapps.administration.powershell/add-powerappsaccount?view=pa-ps-latest#-endpoint). Commercial tenants use `-Endpoint prod`, GCC tenants use `-Endpoint usgov` and so on.\n\n3. Then run the following PowerShell command to disable the creation of Power Pages sites by non-administrative users.\n\n    ```\n    Set-TenantSettings -RequestBody @{ “disablePortalsCreationByNonAdminUsers” = $true }\n    ```",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerplatform.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerplatform.md"
+    },
+    "ms.powerplatform.6.1v1": {
+      "id": "ms.powerplatform.6.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.POWERPLATFORM.6.1v1",
+      "group": "Power Apps Sharing Controls",
+      "groupNumber": 6,
+      "assertion": "The Share with Everyone feature SHOULD be disabled.",
+      "obligation": "SHOULD",
+      "rationale": "Prevents tenant-wide exposure of applications with unintended users. If enabled, this setting grants application access to the **Everyone** group for your organization. Its membership contains all users present in the directory, including B2B guest accounts and internal members. The **Everyone** group is not a standard Microsoft Entra ID security group and can't be edited or viewed, complicating auditing and access governance. The configuration setting is disabled by default; however, this is a defense-in-depth policy to protect against misconfigurations or malicious actors.",
+      "lastModified": "October 2025",
+      "nist80053": [
+        "AC-6(5)",
+        "AC-6(10)"
+      ],
+      "mitreAttack": [
+        "T1078",
+        "T1078.004",
+        "T1098",
+        "T1098.007"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  This setting currently can only be enabled through the [Power Apps PowerShell modules](https://learn.microsoft.com/en-us/power-platform/admin/powerapps-powershell#installation).\n\n2. After installing the Power Apps PowerShell modules, run `Add-PowerAppsAccount -Endpoint $YourTenantsEndpoint`. To authenticate to your tenant's Power Platform.\nDiscover the valid endpoint parameter [here](https://learn.microsoft.com/en-us/powershell/module/microsoft.powerapps.administration.powershell/add-powerappsaccount?view=pa-ps-latest#-endpoint). Commercial tenants use `-Endpoint prod`, GCC tenants use `-Endpoint usgov` and so on.\n\n3. Then run the following PowerShell commands to get the settings object and set the variable `disableShareWithEveryone` to `$true`.\n\n    ```\n    $tenantSettings = Get-TenantSettings\n    $tenantSettings.powerPlatform.powerApps.disableShareWithEveryone = $true\n    Set-TenantSettings $tenantSettings\n    ```\n\n**`TLP:CLEAR`**",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/powerplatform.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/powerplatform.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerplatform.md"
+    },
+    "ms.securitysuite.1.1v1": {
+      "id": "ms.securitysuite.1.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.1.1v1",
+      "group": "Malware Protection",
+      "groupNumber": 1,
+      "assertion": "Emails with click-to-run file attachments SHALL be blocked, including at a minimum .exe, .cmd, and .vbe files.",
+      "obligation": "SHALL",
+      "rationale": "Malicious attachments often take the form of click-to-run files.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SI-3"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001"
+      ],
+      "details": "Sharing high risk file types, when necessary, is better left to a means other\nthan email; the dangers of allowing them to be sent over email outweigh\nany potential benefits. Filtering email attachments based on file types can\nprevent spread of malware distributed via click-to-run email attachments.",
+      "productLicenseNotes": "Safe attachments require Defender for Office 365 Plan 1 or 2. These are included with\n  E5 and G5 and are available as add-ons for E3 and G3.",
+      "instructions": "Both the standard and strict preset policies meet this baseline policy requirement,\nso no further actions are needed for users added to those policies. See\n[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)\nfor instructions on adding users to these policies.\n\nAs the steps for MS.SECURITYSUITE.1.1v1 and MS.SECURITYSUITE.1.2v1 share many steps in common,\nsteps for both policies are included in this section. Steps that do not strictly apply to\nMS.SECURITYSUITE.1.1v1 are followed by the applicable SCuBA policy in parenthesis.\n\nFor users not added to the standard or strict preset policies:\n1.  Sign in to **Microsoft 365 Defender**.\n2.  Under **Email & collaboration**, select **Policies & rules**.\n3.  Select **Threat policies**.\n4.  Under **Policies**, select **Anti-malware**.\n5.  If modifying an existing policy:\n    1. Click the name of the policy from the policy list to open the policy summary.\n    2. Click **Edit user and domains**. _Note:_ the **Default (default)** policy applies to all users, so skip this step if modifying the default policy.\n        - Add users, groups, and domains as needed. To make the policy apply to all users, under\n          **Domains**, enter all the tenant domains.\n        - (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**\n          to be exempted from this policy.\n        - Click **Save**.\n    3. Click **Edit protection settings**\n    4. Check **Enable zero-hour auto purge for malware (Recommended)**. (_MS.SECURITYSUITE.1.2v1_)\n    5. Check **Enable the common attachments filter**.\n    6. Click **Customize file types** and ensure that at a minimum .exe, .cmd, and .vba are selected.\n    7. Click **Save**.\n6.  If creating a new policy:\n    1. Click **Create**.\n    2. After naming the policy, click **Next**.\n    3. Add users, groups, and domains as needed. To make the policy apply to all users, under\n       **Domains**, enter all the tenant domains.\n    4. (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**\n       to be exempted from this policy.\n    5. Click **Next**.\n    6. Check **Enable zero-hour auto purge for malware (Recommended)**. (_MS.SECURITYSUITE.1.2v1_)\n    7. Check **Enable the common attachments filter**.\n    8. Click **Select file types** and ensure that at a minimum .exe, .cmd, and .vba are selected, then click **Done**.\n    9. Click **Next** then **Submit**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.1.2v1": {
+      "id": "ms.securitysuite.1.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.1.2v1",
+      "group": "Malware Protection",
+      "groupNumber": 1,
+      "assertion": "Email scanning SHALL be capable of reviewing emails after delivery.",
+      "obligation": "SHALL",
+      "rationale": "As known malware signatures are updated, it is possible for an email to be retroactively identified as containing malware after delivery. By scanning emails, the number of malware-infected in users' mailboxes can be reduced.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SI-3"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001"
+      ],
+      "productLicenseNotes": "Safe attachments require Defender for Office 365 Plan 1 or 2. These are included with\n  E5 and G5 and are available as add-ons for E3 and G3.",
+      "instructions": "Both the standard and strict preset policies meet this baseline policy requirement,\nso no further actions are needed for users added to those policies. See\n[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)\nfor instructions on adding users to these policies.\n\nFor users not added to the standard or strict preset policies, see [MS.SECURITYSUITE.1.2v1 Instructions](#mssecuritysuite12v1-instructions).",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.1.3v1": {
+      "id": "ms.securitysuite.1.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.1.3v1",
+      "group": "Malware Protection",
+      "groupNumber": 1,
+      "assertion": "Emails identified as containing malware SHALL be quarantined or dropped.",
+      "obligation": "SHALL",
+      "rationale": "Email can be used as a mechanism for delivering malware.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SI-3"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001"
+      ],
+      "details": "Preventing emails with known malware from reaching user mailboxes helps ensure\nusers cannot interact with those emails.",
+      "productLicenseNotes": "Safe attachments require Defender for Office 365 Plan 1 or 2. These are included with\n  E5 and G5 and are available as add-ons for E3 and G3.",
+      "instructions": "Both the standard and strict preset policies meet this baseline policy requirement,\nso no further actions are needed for users added to those policies. See\n[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)\nfor instructions on adding users to these policies.\n\nFor users not added to the standard or strict preset policies:\n1.  Sign in to **Microsoft 365 Defender**.\n2.  Under **Email & collaboration**, select **Policies & rules**.\n3.  Select **Threat policies**.\n4.  Under **Policies**, select **Safe Attachments**.\n5.  If modifying an existing policy:\n    1. Click the name of the policy from the policy list to open the policy summary.\n    2. Click **Edit user and domains**. _Note:_ the **Default (default)** policy applies to all users, so skip this step if modifying the default policy.\n        - Add users, groups, and domains as needed. To make the policy apply to all users, under\n          **Domains**, enter all the tenant domains.\n        - (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**\n          to be exempted from this policy.\n        - Click **Save**.\n    3. Click **Edit settings**\n    4. Under **Safe Attachments unknown malware response**, select **Block** or **Dynamic Delivery**.\n    5. Click **Save**.\n6.  If creating a new policy:\n    1. Click **Create**.\n    2. After naming the policy, click **Next**.\n    3. Add users, groups, and domains as needed. To make the policy apply to all users, under\n       **Domains**, enter all the tenant domains.\n    4. (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**\n       to be exempted from this policy.\n    5. Click **Next**.\n    4. Under **Safe Attachments unknown malware response**, select **Block** or **Dynamic Delivery**.\n    5. Click **Next** then **Submit**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.1.4v1": {
+      "id": "ms.securitysuite.1.4v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.1.4v1",
+      "group": "Malware Protection",
+      "groupNumber": 1,
+      "assertion": "SharePoint, OneDrive, and Teams message attachments SHOULD be scanned for malware.",
+      "obligation": "SHOULD",
+      "rationale": "Files shared through Teams or hosted on SharePoint/OneDrive can be used as a mechanism for delivering malware. In many cases, malware can be detected through scanning, reducing the risk for end users.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SI-3"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001"
+      ],
+      "productLicenseNotes": "Safe attachments require Defender for Office 365 Plan 1 or 2. These are included with\n  E5 and G5 and are available as add-ons for E3 and G3.",
+      "instructions": "This baseline policy is _not_ covered by the preset policies, so these steps\nneed to be taken even if the standard or strict policies are used.\n\n1.  Sign in to **Microsoft 365 Defender**.\n\n2.  Under **Email & collaboration**, select **Policies & rules**.\n\n3.  Select **Threat policies**.\n\n4.  Under **Policies**, select **Safe Attachments**.\n\n5.  Select **Global settings**.\n\n6.  Toggle the **Turn on Defender for Office 365 for SharePoint, OneDrive, and Microsoft Teams**\n    slider to **On**.\n\n7. Click **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.2.1v1": {
+      "id": "ms.securitysuite.2.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.2.1v1",
+      "group": "Impersonation Protection",
+      "groupNumber": 2,
+      "assertion": "User impersonation protection SHOULD be enabled for sensitive accounts.",
+      "obligation": "SHOULD",
+      "rationale": "User impersonation, especially of users seen as authority figures,",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1656"
+      ],
+      "details": "has the potential to result in serious harm. Impersonation protection mitigates\nthis risk.",
+      "productLicenseNotes": "- Impersonation protection and advanced phishing thresholds require\n  Defender for Office 365 Plan 1 or 2. These are included with E5 and G5\n  and are available as add-ons for E3 and G3. As of January 2026,\n  anti-phishing for user and domain impersonation and spoof intelligence\n  are not yet available in M365 Government Community Cloud (GCC High) and Department of Defense (DoD) environments. See [Platform features \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/office-365-platform-service-description/office-365-us-government/office-365-us-government#platform-features)\n  for current offerings.",
+      "instructions": "1.  Sign in to **Microsoft 365 Defender**.\n2.  Under **Email & collaboration**, select **Policies & rules**.\n3.  Select **Threat policies**.\n4.  Under **Policies**, select **Anti-phishing**.\n5.  Select the **Office365 AntiPhish Default (Default)** policy.\n6.  Click **Edit protection settings**.\n7.  Under **Impersonation**, select **Enable users to protect**.\n8.  Click **Manage [x] sender(s)**.\n9.  On the **Manage senders for impersonation protection** page, click **Add user**\nthen add a name and valid email address for each sensitive account and click **Add** after each.\n10. Click **Done** then **Save**.\n11. Click **Edit actions**.\n12. Under **If a message is detected as user impersonation**, select one of the following:\n    - **Redirect the message to other email addresses**\n    - **Move the message to the recipients' Junk Email folders**\n    - **Quarantine the message**\n    - **Delete the message before it's delivered**\n13. Click **Save**.\n\n**Note**: In order for ScubaGear to evaluate MS.SECURITYSUITE.2.1v1, it needs to know which users are considered sensitive. To configure this, use the `SensitiveUsers` config file option. If this config file option is not used or is empty, ScubaGear will report this policy as non-compliant. See [Security Suite Configuration](/docs/configuration/configuration.md#security-suite-configuration) for more details.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.2.2v1": {
+      "id": "ms.securitysuite.2.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.2.2v1",
+      "group": "Impersonation Protection",
+      "groupNumber": 2,
+      "assertion": "Domain impersonation protection SHOULD be enabled for domains owned by the agency.",
+      "obligation": "SHOULD",
+      "rationale": "Configuring domain impersonation protection for agency-owned domains",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1656"
+      ],
+      "details": "reduces the risk of a user being deceived by a look-alike domain.",
+      "productLicenseNotes": "- Impersonation protection and advanced phishing thresholds require\n  Defender for Office 365 Plan 1 or 2. These are included with E5 and G5\n  and are available as add-ons for E3 and G3. As of January 2026,\n  anti-phishing for user and domain impersonation and spoof intelligence\n  are not yet available in M365 Government Community Cloud (GCC High) and Department of Defense (DoD) environments. See [Platform features \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/office-365-platform-service-description/office-365-us-government/office-365-us-government#platform-features)\n  for current offerings.",
+      "instructions": "1.  Sign in to **Microsoft 365 Defender**.\n2.  Under **Email & collaboration**, select **Policies & rules**.\n3.  Select **Threat policies**.\n4.  Under **Policies**, select **Anti-phishing**.\n5.  Select the **Office365 AntiPhish Default (Default)** policy.\n6.  Click **Edit protection settings**.\n7.  Under **Impersonation**, check **Enable domains to protect** and **Include domains I own**.\n8.  Click **Save**.\n9. Click **Edit actions**.\n10. Under **If a message is detected as domain impersonation**, select one of the following:\n    - **Redirect the message to other email addresses**\n    - **Move the message to the recipients' Junk Email folders**\n    - **Quarantine the message**\n    - **Delete the message before it's delivered**\n11.  Click **Done** then **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.2.3v1": {
+      "id": "ms.securitysuite.2.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.2.3v1",
+      "group": "Impersonation Protection",
+      "groupNumber": 2,
+      "assertion": "Domain impersonation protection SHOULD be added for key suppliers and partners.",
+      "obligation": "SHOULD",
+      "rationale": "Configuring domain impersonation protection for domains owned by important partners reduces the risk of a user being deceived by a look-alike domain.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.001",
+        "T1566.002",
+        "T1656"
+      ],
+      "productLicenseNotes": "- Impersonation protection and advanced phishing thresholds require\n  Defender for Office 365 Plan 1 or 2. These are included with E5 and G5\n  and are available as add-ons for E3 and G3. As of January 2026,\n  anti-phishing for user and domain impersonation and spoof intelligence\n  are not yet available in M365 Government Community Cloud (GCC High) and Department of Defense (DoD) environments. See [Platform features \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/office-365-platform-service-description/office-365-us-government/office-365-us-government#platform-features)\n  for current offerings.",
+      "instructions": "1.  Sign in to **Microsoft 365 Defender**.\n2.  Under **Email & collaboration**, select **Policies & rules**.\n3.  Select **Threat policies**.\n4.  Under **Policies**, select **Anti-phishing**.\n5.  Select the **Office365 AntiPhish Default (Default)** policy.\n6.  Click **Edit protection settings**.\n7.  Under **Impersonation**, check **Enable domains to protect** and **Include custom domains**.\n8.  Click **Manage [x] custom domain(s)**.\n9.  On the **Manage custom domains for impersonation protection** page, click **Add domain**.\n10. Under **Domain**, enter each partner domain, then click **Add domains**.\n11. Click **Done** then **Save**.\n12. Click **Edit actions**.\n13. Under **If a message is detected as domain impersonation**, select one of the following:\n    - **Redirect the message to other email addresses**\n    - **Move the message to the recipients' Junk Email folders**\n    - **Quarantine the message**\n    - **Delete the message before it's delivered**\n14. Click **Save**.\n\n**Note**: In order for ScubaGear to evaluate MS.SECURITYSUITE.2.3v1, it needs to know which domains should be protected. To configure this, use the `PartnerDomains` config file option. If this config file option is not used or is empty, ScubaGear will report this policy as non-compliant. See [Security Suite Configuration](/docs/configuration/configuration.md#security-suite-configuration) for more details.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.2.4v1": {
+      "id": "ms.securitysuite.2.4v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.2.4v1",
+      "group": "Impersonation Protection",
+      "groupNumber": 2,
+      "assertion": "User warnings, comparable to the user safety tips included with EOP, SHOULD be displayed.",
+      "obligation": "SHOULD",
+      "rationale": "Many tasks are better suited for automated processes, such as identifying",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "AT-2b",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1656"
+      ],
+      "details": "unusual characters in the `FROM` address or identifying a first-time sender.\nUser warnings can handle these tasks, reducing the burden on end users and the risk of\nsuccessful phishing attempts.",
+      "productLicenseNotes": "- Impersonation protection and advanced phishing thresholds require\n  Defender for Office 365 Plan 1 or 2. These are included with E5 and G5\n  and are available as add-ons for E3 and G3. As of January 2026,\n  anti-phishing for user and domain impersonation and spoof intelligence\n  are not yet available in M365 Government Community Cloud (GCC High) and Department of Defense (DoD) environments. See [Platform features \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/office-365-platform-service-description/office-365-us-government/office-365-us-government#platform-features)\n  for current offerings.",
+      "instructions": "1.  Sign in to **Microsoft 365 Defender**.\n2.  Under **Email & collaboration**, select **Policies & rules**.\n3.  Select **Threat policies**.\n4.  Under **Policies**, select **Anti-phishing**.\n5.  Select the **Office365 AntiPhish Default (Default)** policy.\n6.  Click **Edit actions**.\n7.  Under **Safety tips & indicators**, ensure each safety tip and indicator is enabled.\n8.  Click **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.3.1v1": {
+      "id": "ms.securitysuite.3.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.3.1v1",
+      "group": "Data Loss Prevention",
+      "groupNumber": 3,
+      "assertion": "A DLP policy SHALL be configured to protect PII and sensitive information, as defined by the agency, blocking at a minimum: credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN).",
+      "obligation": "SHALL",
+      "rationale": "Users may inadvertently share sensitive information with others who should not have access to it. DLP policies provide a way for agencies to detect and prevent unauthorized disclosures.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1567",
+        "T1530",
+        "T1213"
+      ],
+      "productLicenseNotes": "- DLP for Teams requires an E5 or G5 license. See [Microsoft Purview Data Loss Prevention: Data Loss Prevention for Teams \\| Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#microsoft-purview-data-loss-prevention-data-loss-prevention-dlp-for-teams)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.\n\n- DLP for Endpoint, needed for MS.SECURITYSUITE.3.5v1, requires an E5 or G5 license. See [Get started with\n  Endpoint data loss prevention - Microsoft Purview (compliance) \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.",
+      "instructions": "DLP is _not_ covered by the preset policies, so these steps need to be taken even if the standard\nor strict policies are used.\n\nAs the steps for MS.SECURITYSUITE.3.1v1, MS.SECURITYSUITE.3.2v1, MS.SECURITYSUITE.3.3v1, and\nMS.SECURITYSUITE.3.4v1 share many steps in common, steps for all these policies are included in\nthis section. Steps that do not strictly apply to MS.SECURITYSUITE.3.1v1 are followed by the\napplicable SCuBA policy in parenthesis.\n\n1. Sign in to the **Microsoft Purview portal**.\n\n2. Under the **Solutions** section on the left-hand menu, select **Data loss\n   prevention**.\n\n3. Select **Policies** from the top of the page.\n\n4. Select **Create policy**.\n\n5. From the **Categories** list, select **Custom**.\n\n6. From the **Regulations** list, select **Custom policy** and then click\n   **Next**.\n\n7. Edit the name and description of the policy if desired, then click\n   **Next**.\n\n8. Under **Assign admin units**,  ensure **Admin units** is set to **Full directory** by default, then click **Next**.\n\n9. Under **Choose where to apply the policy**, set **Status** to **On**\n   for at least the Exchange email, OneDrive accounts, SharePoint\n   sites, Teams chat and channel messages, and Devices locations, then\n   click **Next**. (_MS.SECURITYSUITE.3.2v1_)\n\n10. Under **Define policy settings**, select **Create or customize advanced\n   DLP rules**, and then click **Next**.\n\n11. Click **Create rule**. Assign the rule an appropriate name and\n   description.\n\n12. Click **Add condition**, then **Content contains**.\n\n13. Click **Add**, then **Sensitive info types**.\n\n14. Add information types that protect information sensitive to the agency.\n    At a minimum, the agency should protect:\n\n    - Credit card numbers\n    - U.S. Individual Taxpayer Identification Numbers (ITIN)\n    - U.S. Social Security Numbers (SSN)\n    - All agency-defined PII and sensitive information\n\n15. Click **Add**.\n\n16. Under **Actions**, click **Add an action**.\n\n17. Check **Restrict Access or encrypt the content in Microsoft 365\n    locations**.\n\n18. Under this action, select **Block Everyone**. (_MS.SECURITYSUITE.3.3v1_)\n\n19. Under **User notifications**, turn on **Use notifications to inform your users and help educate them on the proper use of sensitive info**. (_MS.SECURITYSUITE.3.4v1_)\n\n20. Under **Microsoft 365 services** if using a GCC environment or under **Microsoft 365 files and Microsoft Fabric items** if using a Commercial environment, a section that appears after user notifications are turned on, check the box next to **Notify users in Office 365 service with a policy tip or email notifications**. (_MS.SECURITYSUITE.3.4v1_)\n\n21. Click **Save**, then **Next**.\n\n22. Select **Turn the policy on immediately**, then click **Next**.\n\n23. Click **Submit**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.3.2v1": {
+      "id": "ms.securitysuite.3.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.3.2v1",
+      "group": "Data Loss Prevention",
+      "groupNumber": 3,
+      "assertion": "The DLP policy SHOULD be applied to Exchange, OneDrive, SharePoint, Teams chat, and Devices.",
+      "obligation": "SHOULD",
+      "rationale": "Unauthorized disclosures may happen through M365 services or endpoint devices. DLP policies should cover all affected locations to be effective.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1567",
+        "T1530",
+        "T1213",
+        "T1213.002"
+      ],
+      "productLicenseNotes": "- DLP for Teams requires an E5 or G5 license. See [Microsoft Purview Data Loss Prevention: Data Loss Prevention for Teams \\| Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#microsoft-purview-data-loss-prevention-data-loss-prevention-dlp-for-teams)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.\n\n- DLP for Endpoint, needed for MS.SECURITYSUITE.3.5v1, requires an E5 or G5 license. See [Get started with\n  Endpoint data loss prevention - Microsoft Purview (compliance) \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.",
+      "instructions": "See [MS.SECURITYSUITE.3.1v1 Instructions](#mssecuritysuite31v1-instructions) step 9\n   for details on enforcing DLP policy in specific M365 service locations.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.3.3v1": {
+      "id": "ms.securitysuite.3.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.3.3v1",
+      "group": "Data Loss Prevention",
+      "groupNumber": 3,
+      "assertion": "The action for the DLP policy SHOULD be set to block sharing sensitive information with everyone.",
+      "obligation": "SHOULD",
+      "rationale": "Access to sensitive information should be prohibited unless explicitly allowed. Specific exemptions can be made based on agency policies and valid business justifications.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "AC-3",
+        "SC-7(10)"
+      ],
+      "mitreAttack": [
+        "T1567",
+        "T1530",
+        "T1213"
+      ],
+      "productLicenseNotes": "- DLP for Teams requires an E5 or G5 license. See [Microsoft Purview Data Loss Prevention: Data Loss Prevention for Teams \\| Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#microsoft-purview-data-loss-prevention-data-loss-prevention-dlp-for-teams)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.\n\n- DLP for Endpoint, needed for MS.SECURITYSUITE.3.5v1, requires an E5 or G5 license. See [Get started with\n  Endpoint data loss prevention - Microsoft Purview (compliance) \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.",
+      "instructions": "See [MS.SECURITYSUITE.3.1v1 Instructions](#mssecuritysuite31v1-instructions) steps\n   16-18 for details on configuring DLP policy to block sharing sensitive\n   information with everyone.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.3.4v1": {
+      "id": "ms.securitysuite.3.4v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.3.4v1",
+      "group": "Data Loss Prevention",
+      "groupNumber": 3,
+      "assertion": "Notifications to inform users and help educate them on the proper use of sensitive information SHOULD be enabled in the DLP policy.",
+      "obligation": "SHOULD",
+      "rationale": "Some users may not be aware of agency policies on proper use of sensitive information. Enabling notifications provides positive feedback to users when accessing sensitive information.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "AT-2b"
+      ],
+      "mitreAttack": [],
+      "productLicenseNotes": "- DLP for Teams requires an E5 or G5 license. See [Microsoft Purview Data Loss Prevention: Data Loss Prevention for Teams \\| Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#microsoft-purview-data-loss-prevention-data-loss-prevention-dlp-for-teams)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.\n\n- DLP for Endpoint, needed for MS.SECURITYSUITE.3.5v1, requires an E5 or G5 license. See [Get started with\n  Endpoint data loss prevention - Microsoft Purview (compliance) \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.",
+      "instructions": "See [MS.SECURITYSUITE.3.1v1 Instructions](#mssecuritysuite31v1-instructions) steps\n   19-20 for details on configuring DLP policy to notify users when accessing\n   sensitive information.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.3.5v1": {
+      "id": "ms.securitysuite.3.5v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.3.5v1",
+      "group": "Data Loss Prevention",
+      "groupNumber": 3,
+      "assertion": "The DLP policy SHOULD include an action to block access to sensitive information by restricted apps and unwanted Bluetooth applications.",
+      "obligation": "SHOULD",
+      "rationale": "Some apps may inappropriately share accessed files or not conform to agency policies for access to sensitive information. Defining a DLP policy with an action to block access from restricted apps and unwanted Bluetooth applications prevents unauthorized disclosure by those programs.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "AC-19a"
+      ],
+      "mitreAttack": [
+        "T1565",
+        "T1485",
+        "T1530",
+        "T1486"
+      ],
+      "note": "- This action can only be included if at least one device is onboarded to the agency tenant. Otherwise, the option to block restricted apps will not be available.",
+      "productLicenseNotes": "- DLP for Teams requires an E5 or G5 license. See [Microsoft Purview Data Loss Prevention: Data Loss Prevention for Teams \\| Microsoft\n  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#microsoft-purview-data-loss-prevention-data-loss-prevention-dlp-for-teams)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.\n\n- DLP for Endpoint, needed for MS.SECURITYSUITE.3.5v1, requires an E5 or G5 license. See [Get started with\n  Endpoint data loss prevention - Microsoft Purview (compliance) \\|\n  Microsoft\n  Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)\n  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.",
+      "instructions": "These implementation steps are only applicable if at least one device has been onboarded with\nDefender for Endpoint.\n\n1. Sign in to the **Microsoft Purview portal**.\n2. Under **Settings**, select **Data Loss Prevention**.\n3. (Optional) Select **Restricted apps and app groups**. Add or edit restricted apps per agency\n  discretion.\n4. Select **Unallowed Bluetooth apps** then **Add or edit unallowed Bluetooth apps**.\n5. Ensure **Include Bluetooth apps recommended by Microsoft** is **On**.\n6. (Optional) Add other apps to restrict, per agency discretion.\n7. Click **Save**.\n8. Return to the main menu. Under **Solutions**, select **Data Loss Prevention**.\n9. Select **Policies** from the top of the page.\n10. Find the custom DLP policy configured under\n   [MS.SECURITYSUITE.3.1v1 Instructions](#mssecuritysuite31v1-instructions) in the list\n   and click the Policy name to select.\n11. Select **Edit Policy**.\n12. Click **Next** on each page in the policy wizard until you reach the\n   **Advanced DLP rules page**.\n13. Select the relevant rule and click the pencil icon to edit it.\n14. Under **Actions**, click **Add an action**.\n15. Choose **Audit or restrict activities on device**\n16. Under **File activities for all apps**, select\n    **Apply restrictions to specific activity**.\n17. Check the box next to **Copy or move using unallowed Bluetooth app**\n    and set its action to **Block**.\n18. Under **App access restrictions**, check the **Access by restricted apps** box\n   and set the action drop-down to **Block**.\n19. Click **Save** to save the changes.\n20. Click **Next** on each page until reaching the\n    **Review your policy and create it** page.\n21. Review the policy and click **Submit** to complete the policy changes.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.4.1v1": {
+      "id": "ms.securitysuite.4.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.4.1v1",
+      "group": "Alerts",
+      "groupNumber": 4,
+      "assertion": "At a minimum, the following alerts SHALL be enabled:",
+      "obligation": "SHALL",
+      "rationale": "Potentially malicious or service-impacting events may go undetected without a means of detecting these events. Setting up a mechanism to alert administrators to the list of events linked above draws attention to them to minimize any impact to users and the agency.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SI-4(5)"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.006"
+      ],
+      "details": "a. **Suspicious email sending patterns detected.**\n  b. **Suspicious Connector Activity.**\n  c. **Suspicious Email Forwarding Activity.**\n  d. **Messages have been delayed.**\n  e. **Tenant restricted from sending unprovisioned email.**\n  f. **Tenant restricted from sending email.**\n  g. **A potentially malicious URL click was detected.**",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. Sign in to **Microsoft 365 Defender**.\n\n2. Under **Email & collaboration**, select **Policies & rules**.\n\n3. Select **Alert Policy**.\n\n4. Select the checkbox next to each alert to enable as determined by the\n   agency and at a minimum the following:\n\n   a. **Suspicious email sending patterns detected.**\n\n   b. **Suspicious connector activity.**\n\n   c. **Suspicious Email Forwarding Activity.**\n\n   d. **Messages have been delayed.**\n\n   e. **Tenant restricted from sending unprovisioned email.**\n\n   f. **Tenant restricted from sending email.**\n\n   g. **A potentially malicious URL click was detected.**\n\n5. Click the pencil icon from the top menu.\n\n6. Select the **Enable selected policies** action from the **Bulk actions**\n   menu.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.4.2v1": {
+      "id": "ms.securitysuite.4.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.4.2v1",
+      "group": "Alerts",
+      "groupNumber": 4,
+      "assertion": "The alerts SHOULD be sent to a monitored address or incorporated into a Security Information and Event Management (SIEM).",
+      "obligation": "SHOULD",
+      "rationale": "Suspicious or malicious events, if not resolved promptly, may have a greater impact to users and the agency. Sending alerts to a monitored email address or SIEM system helps ensure events are acted upon in a timely manner to limit overall impact.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SI-4(5)"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.006"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "For each enabled alert, to add one or more email recipients:\n\n1. Sign in to **Microsoft 365 Defender**.\n\n2. Under **Email & collaboration**, select **Policies & rules**.\n\n3. Select **Alert Policy**.\n\n4. Click the alert policy to modify.\n\n5. Click the pencil icon next to **Set your recipients**.\n\n6. Check the **Opt-In for email notifications** box.\n\n7. Add one or more email addresses to the **Email recipients** text box.\n\n8. Click **Next**.\n\n9. On the **Review** page, click **Submit** to save the notification settings.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.5.1v1": {
+      "id": "ms.securitysuite.5.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.5.1v1",
+      "group": "Audit Logging",
+      "groupNumber": 5,
+      "assertion": "Unified Audit logging SHALL be enabled.",
+      "obligation": "SHALL",
+      "rationale": "Responding to incidents without detailed information about activities that took place slows response actions. Enabling Unified Audit logging helps ensure agencies have visibility into user actions.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "AU-12"
+      ],
+      "mitreAttack": [
+        "T1562",
+        "T1562.008"
+      ],
+      "productLicenseNotes": "- The creation of a custom audit log retention policy requires E5/G5 licenses or E3/G3 licenses with add-on compliance licenses.\n- To maintain logs in M365 for longer than 180 days, the user generating the logs must have an Office 365 E5 or Microsoft 365 E5 license or a Microsoft Purview Suite (formerly known as Microsoft 365 E5 Compliance) or E5 eDiscovery and Audit add-on license.",
+      "instructions": "To enable auditing via the **Microsoft Purview portal**:\n\n1. Sign in to the **Microsoft Purview portal**.\n\n2. Under **Solutions**, select **Audit**.\n\n3. If auditing is not enabled, a banner is displayed to notify the\nadministrator to start recording user and admin activity.\n\n4. Click the **Start recording user and admin activity**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.5.2v1": {
+      "id": "ms.securitysuite.5.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.5.2v1",
+      "group": "Audit Logging",
+      "groupNumber": 5,
+      "assertion": "Audit logs SHALL be retained and searchable for a minimum of 3 months and retrievable for a minimum of 12 months.",
+      "obligation": "SHALL",
+      "rationale": "Audit logs may no longer be available when needed if they are not retained for a sufficient time. Increased log retention time gives an agency the necessary visibility to investigate incidents that occurred some time ago.",
+      "lastModified": "June 2026",
+      "nist80053": [
+        "AU-11"
+      ],
+      "mitreAttack": [
+        "T1070"
+      ],
+      "note": "To maintain logs in M365 for longer than 180 days, the user generating the logs must meet the license requirement described below. If the user does not meet these requirements, their data is retained according to the highest priority retention policy. This retention might be either the default retention policy for the user's license or the highest priority policy that matches the user and its record type.",
+      "productLicenseNotes": "- The creation of a custom audit log retention policy requires E5/G5 licenses or E3/G3 licenses with add-on compliance licenses.\n- To maintain logs in M365 for longer than 180 days, the user generating the logs must have an Office 365 E5 or Microsoft 365 E5 license or a Microsoft Purview Suite (formerly known as Microsoft 365 E5 Compliance) or E5 eDiscovery and Audit add-on license.",
+      "instructions": "One option for controlling how long logs are retained in M365 is to create one or more custom audit\nretention policies. For more details, see [Create an audit log retention policy](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies?view=o365-worldwide#create-an-audit-log-retention-policy)\ninstructions.\n\nAs noted in the [License Requirements](https://github.com/cisagov/ScubaGear/baselines/securitysuite.md#license-requirements-1)\nsection above, the creation of a custom audit log retention policy and its retention in the M365\nenvironment requires E5/G5 licenses or E3/G3 licenses with add-on compliance licenses. However, no\nadditional license is required to export logs. To export audit logs, follow\n[Export, configure, and view audit log records | Microsoft Learn](https://learn.microsoft.com/en-us/purview/audit-log-export-records)\nand/or [Untitled Goose Tool Fact Sheet | CISA.](https://www.cisa.gov/resources-tools/resources/untitled-goose-tool-fact-sheet).",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.6.1v1": {
+      "id": "ms.securitysuite.6.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.6.1v1",
+      "group": "Inbound Anti-Spam Protections",
+      "groupNumber": 6,
+      "assertion": "Emails detected as spam and phishing SHALL NOT be delivered to the user's inbox.",
+      "obligation": "SHALL NOT",
+      "rationale": "Spam is a constant threat as junk mail can reduce user productivity, fill up mailboxes unnecessarily, and in some cases include malicious links or attachments.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566"
+      ],
+      "details": "Moving spam messages to a separate junk or quarantine folder helps users filter out spam while still giving them the ability to review messages, as needed, in case a message is filtered incorrectly.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "Both the standard and strict preset policies meet this baseline policy requirement,\nso no further actions are needed for users added to those policies. See\n[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)\nfor instructions on adding users to these policies.\n\nAs the steps for MS.SECURITYSUITE.6.1v1 and MS.SECURITYSUITE.6.2v1 share many steps in common,\nsteps for both policies are included in this section. Steps that do not strictly apply to\nMS.SECURITYSUITE.6.1v1 are followed by the applicable SCuBA policy in parenthesis.\n\nFor users not added to the standard or strict preset policies:\n1.  Sign in to **Microsoft 365 Defender**.\n2.  Under **Email & collaboration**, select **Policies & rules**.\n3.  Select **Threat policies**.\n4.  Under **Policies**, select **Anti-spam**.\n5.  If modifying an existing policy:\n    1. Click the name of the policy from the policy list to open the policy summary. Note: be sure to\n    select an *inbound* policy. If it's a custom policy, it will say \"Custom anti-spam policy\"\n    under **Type** instead of of **Custom output spam policy**.\n    2. Click **Edit users, groups, and domains**. _Note:_ the **Anti-spam inbound policy (Default)** policy applies to all users, so skip this step if modifying the default policy.\n      - Add users, groups, and domains as needed. To make the policy apply to all users, under\n        **Domains**, enter all the tenant domains.\n      - (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**\n        to be exempted from this policy.\n      - Click **Save**.\n    3. Click **Edit spam threshold and properties** See [Recommended email and collaboration threat policy settings for cloud organizations](https://learn.microsoft.com/en-us/defender-office-365/recommended-settings-for-eop-and-office365)\n    for configuration guidance. We recommend mirroring the values used for either the standard or\n    strict preset policies. Click **Save**.\n    4. Click **Edit actions**.\n    5. For each email classification (**Spam**, **High confidence spam**, **Phishing**, and **High confidence phishing**), select one of the following options:\n      - **Move message to Junk Email folder**\n      - **Redirect message to email address**\n      - **Delete message**\n      - **Quarantine message**\n\n     Note: **Delete message** is not available for **High confidence phishing**; choose one of the other three options for that classification.\n\n    6. If you selected **Redirect message to email address**, also fill in an appropriate email for\n      the **Redirect to this email address** field, such as a mailbox set up for monitoring incoming\n      spam and phishing messages.\n    7. Click **Edit allowed and blocked senders and domains**.\n    8. Under **Allowed**, click **Allow domains**. Select any domains that have been allowed, then\n        **Delete** (the trash icon). (_MS.SECURITYSUITE.6.2v1_)\n    9. Click **Save**.\n7.  If creating a new policy:\n    1. Click **Create**, then **Inbound**.\n    2. After naming the policy, click **Next**.\n    3. Add users, groups, and domains as needed. To make the policy apply to all users, under\n       **Domains**, enter all the tenant domains.\n    4. (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**\n       to be exempted from this policy.\n    5. Click **Next**.\n    6. On the **Bulk email threshold & spam properties** page, see [Recommended email and collaboration threat policy settings for cloud organizations](https://learn.microsoft.com/en-us/defender-office-365/recommended-settings-for-eop-and-office365)\n    for configuration guidance. We recommend mirroring the values used for either the standard or\n    strict preset policies.\n    7. For each email classification (**Spam**, **High confidence spam**, **Phishing**, and **High confidence phishing**), select one of the following options:\n      - **Move message to Junk Email folder**\n      - **Redirect message to email address**\n      - **Delete message**\n      - **Quarantine message**\n    8. If you selected **Redirect message to email address**, also fill in an appropriate email for\n      the **Redirect to this email address** field, such as a mailbox set up for monitoring incoming\n      spam and phishing messages.\n    9. Click **Next**\n    10. On the **Allow & block list** page, do not click **Allow domains** under **Allowed**. It\n    should read **Domains (0)** under **Allowed**. (_MS.SECURITYSUITE.6.2v1_)\n    11. **Next**, then **Submit**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.6.2v1": {
+      "id": "ms.securitysuite.6.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.6.2v1",
+      "group": "Inbound Anti-Spam Protections",
+      "groupNumber": 6,
+      "assertion": "Allowed domains SHALL NOT be added to inbound anti-spam protection policies.",
+      "obligation": "SHALL NOT",
+      "rationale": "Legitimate emails may be incorrectly filtered",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1566"
+      ],
+      "note": "Allowed senders MAY be added.",
+      "details": "by spam protections. Adding allowed senders is an acceptable method of\ncombating these false positives. Allowing an entire domain, especially\na common domain like office.com, however, provides for a large number of\npotentially unknown users to bypass spam protections.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "Both the standard and strict preset policies meet this baseline policy requirement,\nso no further actions are needed for users added to those policies. See\n[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)\nfor instructions on adding users to these policies.\n\nFor users not added to the standard or strict preset policies, see [MS.SECURITYSUITE.6.1v1 Instructions](#mssecuritysuite61v1-instructions).",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.7.1v1": {
+      "id": "ms.securitysuite.7.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.7.1v1",
+      "group": "Link Protection",
+      "groupNumber": 7,
+      "assertion": "URL comparison with a block-list SHOULD be enabled for URLs in emails, Teams messages, and Office documents.",
+      "obligation": "SHOULD",
+      "rationale": "Users may be directed to malicious websites via links in email. Blocking access to known, malicious URLs can prevent users from accessing known malicious websites.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SI-3"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.002"
+      ],
+      "productLicenseNotes": "Safe links require Defender for Office 365 Plan 1 or 2. These are included with\nE5 and G5 and are available as add-ons for E3 and G3.",
+      "instructions": "Both the standard and strict preset policies meet this baseline policy requirement,\nso no further actions are needed for users added to those policies. See\n[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)\nfor instructions on adding users to these policies.\n\nAs the steps for MS.SECURITYSUITE.7.1v1, MS.SECURITYSUITE.7.2v1, and MS.SECURITYSUITE.7.3v1 share\nmany steps in common, steps for all three policies are included in this section. Steps that do not\nstrictly apply to MS.SECURITYSUITE.7.1v1 are followed by the applicable SCuBA policy in parenthesis.\n\nFor users not added to the standard or strict preset policies:\n1.  Sign in to **Microsoft 365 Defender**.\n2.  Under **Email & collaboration**, select **Policies & rules**.\n3.  Select **Threat policies**.\n4.  Under **Policies**, select **Safe-links**.\n5.  If modifying an existing policy:\n    1. Click the name of the policy from the policy list to open the policy summary.\n    2. Click **Edit users and domains**.\n        - Add users, groups, and domains as needed. To make the policy apply to all users, under\n          **Domains**, enter all the tenant domains.\n        - (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**\n          to be exempted from this policy.\n        - Click **Save**.\n    3. Click **Edit protection settings**.\n    4. Under **Email**, ensure the following options are selected:\n        - **On: Safe Links checks a list of known, malicious links when users click links in email. URLs are rewritten by default.**\n        - **Apply Safe Links to email messages sent within the organization**\n        - **Apply real-time URL scanning for suspicious links and links that point to files** (_MS.SECURITYSUITE.7.2v1_)\n        - **Wait for URL scanning to complete before delivering the message** (_MS.SECURITYSUITE.7.2v1_)\n    5. Under **Teams**, select **On: Safe Links checks a list of known, malicious links when users click links in Microsoft Teams. URLs are not rewritten.**\n    6. Under **Office 365 Apps**, select **On: Safe Links checks a list of known, malicious links when users click links in Microsoft Office Apps. URLs are not rewritten.**\n    7. Under **Click protection settings**, select **Track user clicks**. (_MS.SECURITYSUITE.7.3v1_)\n    8. Click **Save**.\n6. If creating a new policy:\n    1. Click **Create**.\n    2. After naming the policy, click **Next**.\n    3. Add users, groups, and domains as needed. To make the policy apply to all users, under\n       **Domains**, enter all the tenant domains.\n    4. (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**\n       to be exempted from this policy.\n    5. Click **Next**.\n    6. Under **Email**, ensure the following options are selected:\n        - **On: Safe Links checks a list of known, malicious links when users click links in email. URLs are rewritten by default.**\n        - **Apply Safe Links to email messages sent within the organization**\n        - **Apply real-time URL scanning for suspicious links and links that point to files** (_MS.SECURITYSUITE.7.2v1_)\n        - **Wait for URL scanning to complete before delivering the message** (_MS.SECURITYSUITE.7.2v1_)\n    7. Under **Teams**, select **On: Safe Links checks a list of known, malicious links when users click links in Microsoft Teams. URLs are not rewritten.**\n    8. Under **Office 365 Apps**, select **On: Safe Links checks a list of known, malicious links when users click links in Microsoft Office Apps. URLs are not rewritten.**\n    9. Under **Click protection settings**, select **Track user clicks**. (_MS.SECURITYSUITE.7.3v1_)\n    10. Click **Next**, **Next**, and **Submit**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.7.2v1": {
+      "id": "ms.securitysuite.7.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.7.2v1",
+      "group": "Link Protection",
+      "groupNumber": 7,
+      "assertion": "Direct download links SHOULD be scanned for malware.",
+      "obligation": "SHOULD",
+      "rationale": "URLs in emails may direct users to download and run malware.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SI-3"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.002"
+      ],
+      "details": "Scanning direct download links in real-time for known malware and blocking access can prevent\nusers from infecting their devices.",
+      "productLicenseNotes": "Safe links require Defender for Office 365 Plan 1 or 2. These are included with\nE5 and G5 and are available as add-ons for E3 and G3.",
+      "instructions": "Both the standard and strict preset policies meet this baseline policy requirement,\nso no further actions are needed for users added to those policies. See\n[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)\nfor instructions on adding users to these policies.\n\nFor users not added to the standard or strict preset policies, see [MS.SECURITYSUITE.7.1v1 Instructions](#mssecuritysuite71v1-instructions).",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.7.3v1": {
+      "id": "ms.securitysuite.7.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.7.3v1",
+      "group": "Link Protection",
+      "groupNumber": 7,
+      "assertion": "User click tracking SHOULD be enabled.",
+      "obligation": "SHOULD",
+      "rationale": "Users may click on malicious links in emails, leading to compromise or unauthorized data disclosure. Enabling user click tracking lets agencies know if a malicious link may have been visited after the fact to help tailor a response to a potential incident.",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "SI-3",
+        "AU-12c"
+      ],
+      "mitreAttack": [
+        "T1566",
+        "T1566.002"
+      ],
+      "productLicenseNotes": "Safe links require Defender for Office 365 Plan 1 or 2. These are included with\nE5 and G5 and are available as add-ons for E3 and G3.",
+      "instructions": "Both the standard and strict preset policies meet this baseline policy requirement,\nso no further actions are needed for users added to those policies. See\n[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)\nfor instructions on adding users to these policies.\n\nFor users not added to the standard or strict preset policies, see [MS.SECURITYSUITE.7.1v1 Instructions](#mssecuritysuite71v1-instructions).",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.8.1v1": {
+      "id": "ms.securitysuite.8.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.8.1v1",
+      "group": "IP Allow Lists",
+      "groupNumber": 8,
+      "assertion": "IP allow lists SHOULD NOT be created.",
+      "obligation": "SHOULD NOT",
+      "rationale": "Messages sent from IP addresses on an allow list bypass important",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "AC-4"
+      ],
+      "mitreAttack": [],
+      "details": "security mechanisms, including spam filtering and sender authentication checks.  Avoiding use of IP allow lists prevents potential threats from circumventing security mechanisms.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "To modify the connection filters, follow the instructions found in [Use\nthe Microsoft 365 Defender portal to modify the default connection\nfilter\npolicy](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/connection-filter-policies-configure?view=o365-worldwide#use-the-microsoft-365-defender-portal-to-modify-the-default-connection-filter-policy).\n\n1. Sign in to **Microsoft 365 Defender portal**.\n\n2. From the left-hand menu, find **Email & collaboration** and select **Policies and Rules**.\n\n3. Select **Threat Policies** from the list of policy names.\n\n4. Under **Policies**, select **Anti-spam**.\n\n5. Select **Connection filter policy (Default)**.\n\n6. Click **Edit connection filter policy**.\n\n7. Ensure no addresses are specified under **Always allow messages from\n   the following IP addresses or address range**.\n\n8. Ensure **Turn on safe list** is not selected.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.securitysuite.8.2v1": {
+      "id": "ms.securitysuite.8.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SECURITYSUITE.8.2v1",
+      "group": "IP Allow Lists",
+      "groupNumber": 8,
+      "assertion": "Safe lists SHOULD NOT be enabled.",
+      "obligation": "SHOULD NOT",
+      "rationale": "Messages sent from allowed safe list addresses bypass important",
+      "lastModified": "March 2026",
+      "nist80053": [
+        "AC-4"
+      ],
+      "mitreAttack": [],
+      "note": "A connection filter MAY be implemented to create an IP block list.",
+      "details": "security mechanisms, including spam filtering and sender authentication checks.\nAvoiding use of safe lists prevents potential threats from circumventing\nsecurity mechanisms. While blocking all malicious senders is not feasible,\nblocking specific known, malicious IP addresses may reduce the threat from\nspecific senders.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. Sign in to **Microsoft 365 Defender portal**.\n\n2. From the left-hand menu, find **Email & collaboration** and select **Policies and Rules**.\n\n3. Select **Threat Policies** from the list of policy names.\n\n4. Under **Policies**, select **Anti-spam**.\n\n5. Select **Connection filter policy (Default)**.\n\n6. Click **Edit connection filter policy**.\n\n7. (Optional) Enter addresses under **Always block messages from the following\n   IP addresses or address range** as needed.\n\n8. Ensure **Turn on safe list** is not selected.\n\n# Appendix A: Adding Users to the Preset Security Policies\nAs many controls in this baseline can be satisfied by adding users to the standard\nor strict security policies, we describe this process once here, rather than\nduplicating it in each applicable control.\n\nTo add users to the standard policy:\n1. Sign in to **Microsoft 365 Defender**.\n2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.\n3. Select **Threat Policies**.\n4. From the **Templated policies** section, select **Preset Security Policies**.\n5. Under **Standard protection**, ensure the toggle is enabled such that it reads \"Standard protection is on.\"\n6. Under **Standard protection is on**, select **Manage protection settings**.\n7. On the **Apply Exchange Online Protection** page, select **All recipients**.\n8. (Optional) Under **Exclude these recipients**, add **Users** and **Groups**\n   to be exempted from the preset policies.\n9. Select **Next**, then on the **Apply Defender for Office 365 protection** page, select **All recipients**.\n10. (Optional) Under **Exclude these recipients**, add **Users** and **Groups**\n   to be exempted from the preset policies.\n11. Select **Next** on each page until the **Review and confirm your changes** page.\n12. On the **Review and confirm your changes** page, select **Confirm**.\n\nTo add users to the strict policy:\n1. Sign in to **Microsoft 365 Defender**.\n2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.\n3. Select **Threat Policies**.\n4. From the **Templated policies** section, select **Preset Security Policies**.\n5. Under **Strict protection**, ensure the toggle is enabled such that it reads \"Strict protection is on.\"\n6. Under **Strict protection is on**, select **Manage protection settings**.\n7. On the **Apply Exchange Online Protection** page, select **All recipients**.\n8. (Optional) Under **Exclude these recipients**, add **Users** and **Groups**\n   to be exempted from the preset policies.\n9. Select **Next**, then on the **Apply Defender for Office 365 protection** page, select **All recipients**.\n10. (Optional) Under **Exclude these recipients**, add **Users** and **Groups**\n   to be exempted from the preset policies.\n11. Select **Next** on each page until the **Review and confirm your changes** page.\n12. On the **Review and confirm your changes** page, select **Confirm**.\n\nSee [Recommended email and collaboration threat policy settings for cloud organizations](https://learn.microsoft.com/en-us/defender-office-365/recommended-settings-for-eop-and-office365) to understand the\ndifferences between the two preset policies.\n\nNote that a user can be added to multiple policies. In that case, the policies\nare applied in order of precedence, as desribed by\n[Order of precedence for preset security policies and other threat policies](https://learn.microsoft.com/en-us/defender-office-365/preset-security-policies#order-of-precedence-for-preset-security-policies-and-other-threat-policies).\n\n**`TLP:CLEAR`**",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/securitysuite.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/securitysuite.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md"
+    },
+    "ms.sharepoint.1.1v1": {
+      "id": "ms.sharepoint.1.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SHAREPOINT.1.1v1",
+      "group": "External Sharing",
+      "groupNumber": 1,
+      "assertion": "External sharing for SharePoint SHALL be limited to \"Existing guests\" or \"Only people in your organization\".",
+      "obligation": "SHALL",
+      "rationale": "Sharing information outside the organization via SharePoint increases the risk of unauthorized access. By limiting external sharing, administrators decrease the risk of access to information.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-2",
+        "AC-3",
+        "IA-8"
+      ],
+      "mitreAttack": [
+        "T1048",
+        "T1213",
+        "T1213.002"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1. Sign in to the **SharePoint admin center**.\n\n2.  Select **Policies** \\> **Sharing**.\n\n3.  Adjust external sharing slider for SharePoint to **Existing guests** or **Only people in your organization**.\n\n4. Select **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/sharepoint.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/sharepoint.md"
+    },
+    "ms.sharepoint.1.2v1": {
+      "id": "ms.sharepoint.1.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SHAREPOINT.1.2v1",
+      "group": "External Sharing",
+      "groupNumber": 1,
+      "assertion": "External sharing for OneDrive SHALL be limited to \"Existing guests\" or \"Only people in your organization\".",
+      "obligation": "SHALL",
+      "rationale": "Sharing files outside the organization via OneDrive increases the risk of unauthorized access. By limiting external sharing, administrators decrease the risk of unauthorized access to information.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-2",
+        "AC-3",
+        "IA-8"
+      ],
+      "mitreAttack": [
+        "T1048",
+        "T1213",
+        "T1213.002",
+        "T1530"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to the **SharePoint admin center**.\n\n2.  Select **Policies** \\> **Sharing**.\n\n3.  Adjust external sharing slider for OneDrive to **Existing Guests** or **Only people in your organization**.\n\n4. Select **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/sharepoint.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/sharepoint.md"
+    },
+    "ms.sharepoint.1.3v1": {
+      "id": "ms.sharepoint.1.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SHAREPOINT.1.3v1",
+      "group": "External Sharing",
+      "groupNumber": 1,
+      "assertion": "External sharing SHALL be restricted to approved external domains and/or users in approved security groups per interagency collaboration needs.",
+      "obligation": "SHALL",
+      "rationale": "By limiting sharing to domains or approved security groups used for interagency collaboration purposes, administrators can help prevent sharing with unknown organizations and individuals.",
+      "lastModified": "March 2025",
+      "nist80053": [
+        "AC-3",
+        "AC-6(10)"
+      ],
+      "mitreAttack": [
+        "T1048",
+        "T1213",
+        "T1213.002",
+        "T1530"
+      ],
+      "note": "This policy is only applicable if the external sharing slider in the SharePoint admin center is not set to **Only people in your organization**.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "Note: If SharePoint external sharing is set to its most restrictive setting of \"Only people in your organization\", then no external sharing is allowed and no implementation changes are required for this policy item.\n\n1.  Sign in to the **SharePoint admin center**.\n\n2.  Select **Policies** \\> **Sharing**.\n\n3.  Expand **More external sharing settings**.\n\n4.  Select **Limit external sharing by domain**.\n\n5.  Select **Add domains**.\n\n6.  Add each approved external domain users are allowed to share files with.\n\n7.  Select **Manage security groups**\n\n8. Add each approved security group. Members of these groups will be allowed to share files externally.\n\n9.  Select **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/sharepoint.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/sharepoint.md"
+    },
+    "ms.sharepoint.2.1v1": {
+      "id": "ms.sharepoint.2.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SHAREPOINT.2.1v1",
+      "group": "File and Folder Default Sharing Settings",
+      "groupNumber": 2,
+      "assertion": "File and folder default sharing scope SHALL be set to \"Specific people (only the people the user specifies)\".",
+      "obligation": "SHALL",
+      "rationale": "By making the default sharing the most restrictive, administrators prevent accidentally sharing information too broadly.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-6"
+      ],
+      "mitreAttack": [
+        "T1048",
+        "T1213",
+        "T1213.002",
+        "T1565",
+        "T1565.001"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to the **SharePoint admin center**.\n\n2.  Select **Policies** \\> **Sharing**\n\n3.  Under **File and folder links**, set the default link type to **Specific people (only the people the user specifies)**\n\n4.  Select **Save**",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/sharepoint.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/sharepoint.md"
+    },
+    "ms.sharepoint.2.2v1": {
+      "id": "ms.sharepoint.2.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SHAREPOINT.2.2v1",
+      "group": "File and Folder Default Sharing Settings",
+      "groupNumber": 2,
+      "assertion": "File and folder default sharing permissions SHALL be set to view only.",
+      "obligation": "SHALL",
+      "rationale": "Edit access to files and folders could allow a user to make unauthorized changes.  By restricting default permissions to **View** only, administrators prevent unintended or malicious modification.",
+      "lastModified": "June 2023",
+      "nist80053": [
+        "AC-6"
+      ],
+      "mitreAttack": [
+        "T1080",
+        "T1565",
+        "T1565.001"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to the **SharePoint admin center**.\n\n2. Select **Policies** \\> **Sharing**.\n\n3. Under **File and folder links**, set the permission that is selected by default for sharing links to **View**.\n\n4. Select **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/sharepoint.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/sharepoint.md"
+    },
+    "ms.sharepoint.3.1v1": {
+      "id": "ms.sharepoint.3.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SHAREPOINT.3.1v1",
+      "group": "Securing Anyone Links and Verification Code Users",
+      "groupNumber": 3,
+      "assertion": "Expiration days for Anyone links SHALL be set to 30 days or less.",
+      "obligation": "SHALL",
+      "rationale": "Links may be used to provide access to information for a short period of time. Without expiration, however, access is indefinite. By setting expiration timers for links, administrators can prevent unintended sustained access to the link.",
+      "lastModified": "March 2025",
+      "nist80053": [
+        "AC-3",
+        "AC-21b"
+      ],
+      "mitreAttack": [
+        "T1048",
+        "T1213",
+        "T1213.002",
+        "T1530"
+      ],
+      "note": "This policy is only applicable if the external sharing slider in the SharePoint admin center is set to **Anyone**.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to the **SharePoint admin center**.\n\n2.  Select **Policies** \\> **Sharing**.\n\n3.  Scroll to the section **Choose expiration and permissions options for Anyone links**.\n\n4.  Select the checkbox **These links must expire within this many days**.\n\n5.  Enter **30** days or less.\n\n6.  Select **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/sharepoint.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/sharepoint.md"
+    },
+    "ms.sharepoint.3.2v1": {
+      "id": "ms.sharepoint.3.2v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.SHAREPOINT.3.2v1",
+      "group": "Securing Anyone Links and Verification Code Users",
+      "groupNumber": 3,
+      "assertion": "The allowable file and folder permissions for links SHALL be set to view only.",
+      "obligation": "SHALL",
+      "rationale": "Unauthorized changes to files can be made if permissions allow editing by anyone.  By restricting permissions on links to **View** only, administrators prevent anonymous file changes.",
+      "lastModified": "March 2025",
+      "nist80053": [
+        "AC-6"
+      ],
+      "mitreAttack": [
+        "T1080",
+        "T1565",
+        "T1565.001"
+      ],
+      "note": "This policy is only applicable if the external sharing slider in the SharePoint admin center is set to **Anyone**.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to the **SharePoint admin center**.\n\n2.  Select **Policies** \\> **Sharing**.\n\n3.  Scroll to the section **Choose expiration and permissions options for Anyone links**.\n\n4.  Set the configuration items in the section **These links can give these permissions**.\n\n5.  Set the **Files** option to **View**.\n\n6.  Set the **Folders** option to **View**.\n\n7.  Select **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/sharepoint.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/sharepoint.md"
+    },
+    "ms.sharepoint.3.3v2": {
+      "id": "ms.sharepoint.3.3v2",
+      "platform": "microsoft-365",
+      "policyId": "MS.SHAREPOINT.3.3v2",
+      "group": "Securing Anyone Links and Verification Code Users",
+      "groupNumber": 3,
+      "assertion": "Reauthentication days for people who use a verification code SHALL be set to 30 days or less.",
+      "obligation": "SHALL",
+      "rationale": "By setting expiration timers for verification code access, administrators can prevent unintended sustained access to documents.",
+      "lastModified": "April 2026",
+      "nist80053": [
+        "IA-11"
+      ],
+      "mitreAttack": [
+        "T1080",
+        "T1565",
+        "T1565.001"
+      ],
+      "note": "This policy is only applicable if the external sharing slider in the SharePoint admin center is set to **Anyone**, **New and existing guests**, or **Existing guests.**",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to the **SharePoint admin center**.\n\n2.  Select **Policies** \\> **Sharing**.\n\n3.  Expand **More external sharing settings**.\n\n4. Select **People who use a verification code must reauthenticate after this many days**.\n\n5.  Enter **30** days or less.\n\n6. Select **Save**.\n\n**`TLP:CLEAR`**",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/sharepoint.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/sharepoint.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/sharepoint.md"
+    },
+    "ms.teams.1.1v1": {
+      "id": "ms.teams.1.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.TEAMS.1.1v1",
+      "group": "Meeting Policies",
+      "groupNumber": 1,
+      "assertion": "External meeting participants SHOULD NOT be enabled to request control of shared desktops or windows.",
+      "obligation": "SHOULD NOT",
+      "rationale": "An external participant with control of a shared screen could potentially perform unauthorized actions on the shared screen. This policy reduces that risk by removing an external participant's ability to request control. However, if an agency has a legitimate use case to grant this control, it may be done on a case-by-case basis.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-17a"
+      ],
+      "mitreAttack": [],
+      "note": "This policy applies to the Global (Org-wide default) meeting policy, as well as custom meeting policies.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "To help ensure external participants do not have the ability to request\ncontrol of the shared desktop or window in the meeting:\n\n1.  Sign in to the **Microsoft Teams admin center**.\n\n2.  Select **Meetings** > **Meeting policies**.\n\n3.  Select the **Global (Org-wide default)** policy.\n\n4.  Under the **Content sharing** section, set **External\n    participants can give or request control** to **Off**.\n\n5.  If custom policies were created, repeat these steps for each\n    policy, selecting the appropriate policy in step 3.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/teams.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md"
+    },
+    "ms.teams.1.2v2": {
+      "id": "ms.teams.1.2v2",
+      "platform": "microsoft-365",
+      "policyId": "MS.TEAMS.1.2v2",
+      "group": "Meeting Policies",
+      "groupNumber": 1,
+      "assertion": "Anonymous users SHALL NOT be enabled to start meetings.",
+      "obligation": "SHALL NOT",
+      "rationale": "This policy protects against anonymous users starting Microsoft Teams meetings to scrape internal contacts. The policy is beneficial for agencies that have implemented custom policies, providing flexibility for some users to automatically admit \"everyone\" to a Microsoft Teams meeting.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "SC-15a"
+      ],
+      "mitreAttack": [
+        "T1078",
+        "T1078.001"
+      ],
+      "note": "This policy applies to the Global (Org-wide default) meeting policy, and custom meeting policies if they exist.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "To configure settings for anonymous users:\n\n1.\tSign in to the **Microsoft Teams admin center**.\n\n2.\tSelect **Meetings** > **Meeting policies**.\n\n3.\tSelect the **Global (Org-wide default)** policy.\n\n4.\tUnder the **Meeting join & lobby** section, ensure the **Anonymous users and dial-in callers can start a meeting** setting remains at the default position of **Off**.\n\n5.\tIf custom policies were created, repeat these steps for each policy, selecting the appropriate policy in step 3.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/teams.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md"
+    },
+    "ms.teams.1.3v1": {
+      "id": "ms.teams.1.3v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.TEAMS.1.3v1",
+      "group": "Meeting Policies",
+      "groupNumber": 1,
+      "assertion": "Anonymous users and dial-in callers SHOULD NOT be admitted automatically.",
+      "obligation": "SHOULD NOT",
+      "rationale": "Automatically allowing admittance to anonymous and dial-in users diminishes control of meeting participation and invites potential data breach. This policy reduces that risk by requiring all anonymous and dial-in users to wait in a lobby until admitted by an authorized meeting participant. If the agency has a use case to admit members of specific trusted organizations and/or B2B guests automatically, custom policies may be created and assigned to authorized meeting organizers.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SC-15a"
+      ],
+      "mitreAttack": [],
+      "note": "This policy applies to the Global (Org-wide default) meeting policy. Custom meeting policies MAY be created to allow specific users more flexibility. For example, B2B guest users and trusted partner members may be admitted automatically into meetings organized by authorized users.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.\tSign in to the **Microsoft Teams admin center**.\n\n2.\tSelect **Meetings** > **Meeting policies**.\n\n3.\tSelect the **Global (Org-wide default)** policy.\n\n4.\tUnder the **Meeting join & lobby** section, ensure **Who can bypass the lobby** is **not** set to **Everyone**. Bypassing the lobby should be set to **People in my org**, though other options may be used if needed.\n\n5.\tIn the same section, set **People dialing in can bypass the lobby** to **Off**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/teams.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md"
+    },
+    "ms.teams.1.4v1": {
+      "id": "ms.teams.1.4v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.TEAMS.1.4v1",
+      "group": "Meeting Policies",
+      "groupNumber": 1,
+      "assertion": "Internal users SHOULD be admitted automatically.",
+      "obligation": "SHOULD",
+      "rationale": "Requiring internal users to wait in the lobby for explicit admission can lead to admission fatigue. This policy enables internal users to be automatically admitted to the meeting through global policy.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "AC-3"
+      ],
+      "mitreAttack": [],
+      "note": "This policy applies to the Global (Org-wide default) meeting policy. Custom meeting policies MAY be created to allow specific users more flexibility.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.\tSign in to the **Microsoft Teams admin center**.\n\n2.\tSelect **Meetings** > **Meeting policies**.\n\n3.\tSelect the **Global (Org-wide default)** policy.\n\n4.\tUnder the **Meeting join & lobby** section, ensure **Who can bypass the lobby** is set to **People in my org**.\n\n5.\tIn the same section, set **People dialing in can bypass the lobby** to **Off**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/teams.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md"
+    },
+    "ms.teams.1.5v1": {
+      "id": "ms.teams.1.5v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.TEAMS.1.5v1",
+      "group": "Meeting Policies",
+      "groupNumber": 1,
+      "assertion": "Dial-in users SHOULD NOT be enabled to bypass the lobby.",
+      "obligation": "SHOULD NOT",
+      "rationale": "Automatically admitting dial-in users reduces control over who can participate in a meeting and increases potential for data breaches. This policy reduces the risk by requiring all dial-in users to wait in a lobby until they are admitted by an authorized meeting participant.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SC-15a"
+      ],
+      "mitreAttack": [],
+      "note": "This policy applies to the Global (Org-wide default) meeting policy, as well as custom meeting policies.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.\tSign in to the **Microsoft Teams admin center**.\n\n2.\tSelect **Meetings** > **Meeting policies**.\n\n3.\tSelect the **Global (Org-wide default)** policy.\n\n4.\tUnder the **Meeting join & lobby** section, set **People dialing in can bypass the lobby** to **Off**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/teams.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md"
+    },
+    "ms.teams.1.6v1": {
+      "id": "ms.teams.1.6v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.TEAMS.1.6v1",
+      "group": "Meeting Policies",
+      "groupNumber": 1,
+      "assertion": "Meeting recording SHOULD be disabled.",
+      "obligation": "SHOULD",
+      "rationale": "Allowing any user to record a Teams meeting or group call may lead to unauthorized disclosure of shared information, including audio, video, and shared screens. By disabling the meeting recording setting in the Global (Org-wide default) meeting policy, an agency limits information exposure.",
+      "lastModified": "March 2025",
+      "nist80053": [
+        "CM-7"
+      ],
+      "mitreAttack": [],
+      "note": "This policy applies to the Global (Org-wide default) meeting policy. Custom policies MAY be created to allow more flexibility for specific users.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to the **Microsoft Teams admin center**.\n\n2.  Select **Meetings** > **Meeting policies**.\n\n3.  Select the **Global (Org-wide default)** policy.\n\n4.  Under the **Recording & transcription** section, set **Meeting\n    recording** to **Off**.\n\n5.  Select **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/teams.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md"
+    },
+    "ms.teams.1.7v2": {
+      "id": "ms.teams.1.7v2",
+      "platform": "microsoft-365",
+      "policyId": "MS.TEAMS.1.7v2",
+      "group": "Meeting Policies",
+      "groupNumber": 1,
+      "assertion": "Record an event SHOULD NOT be set to Always record.",
+      "obligation": "SHOULD NOT",
+      "rationale": "Limiting recording permissions to only the organizer minimizes the security risk to the organizer's discretion for these Live Events, reducing data leakage and other security risks. Administrators can also disable recording for all live events.",
+      "lastModified": "March 2025",
+      "nist80053": [
+        "AC-21a"
+      ],
+      "mitreAttack": [],
+      "note": "This policy applies to the Global (Org-wide default) meeting policy. Custom policies MAY be created to allow more flexibility for specific users.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to the **Microsoft Teams admin\n    center**.\n\n2.  Select **Meetings** > **Live events policies**.\n\n3.  Select **Global (Org-wide default)** policy.\n\n4.  Set **Record an event** to either  **Organizer can record** or **Never record**\n\n5.  Click **Save**.\n\n6.  If custom policies were created, repeat these steps for each\n    policy, selecting the appropriate policy in step 3.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/teams.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md"
+    },
+    "ms.teams.2.1v2": {
+      "id": "ms.teams.2.1v2",
+      "platform": "microsoft-365",
+      "policyId": "MS.TEAMS.2.1v2",
+      "group": "External User Access",
+      "groupNumber": 2,
+      "assertion": "External access for users SHALL only be enabled on a per-domain basis.",
+      "obligation": "SHALL",
+      "rationale": "The default configuration allows members to communicate with all external users with similar access permissions. Unrestricted access can lead to data breaches and other security threats. This policy provides protection against threats posed by unrestricted access by allowing communication with only trusted domains.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "AC-3"
+      ],
+      "mitreAttack": [
+        "T1199",
+        "T1204",
+        "T1204.001"
+      ],
+      "productLicenseNotes": "- N/A",
+      "instructions": "To enable external access for only specific domains:\n\n1.  Sign in to the **Microsoft Teams admin center**.\n\n2.  Select **Users** > **External access** > **Organization settings**.\n\n3.  Next to **Teams and Skype for Business users in external organizations**,\n    select **Allow only specific external domains**\n\n4.  Select **Add external domains**. Enter domains allowed, and then select **Done**\n\n    **NOTE:** Domains will need to be added in this step in order for users to communicate with them.\n\n5.  Click **Save**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/teams.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md"
+    },
+    "ms.teams.2.2v2": {
+      "id": "ms.teams.2.2v2",
+      "platform": "microsoft-365",
+      "policyId": "MS.TEAMS.2.2v2",
+      "group": "External User Access",
+      "groupNumber": 2,
+      "assertion": "Unmanaged users SHALL NOT be enabled to initiate contact with internal users.",
+      "obligation": "SHALL NOT",
+      "rationale": "Allowing contact from unmanaged users can expose users to email and contact address harvesting. This policy provides protection against this type of harvesting.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "CM-7",
+        "SI-8"
+      ],
+      "mitreAttack": [
+        "T1204",
+        "T1204.001"
+      ],
+      "note": "This policy is not applicable to Government Community Cloud (GCC), GCC High, and Department of Defense (DoD) tenants.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to the **Microsoft Teams admin center**.\n\n2.  Select **Users > External access**.\n\n3.  Select **Policies**.\n\n4.  Select **Global (Org-wide Default)**.\n\n5. Under **Edit policy details**, toggle **People in my organization can communicate with unmanaged Teams accounts** to one of the following:\n    1. To completely block contact with unmanaged users, toggle the setting to **Off**.\n    2. To allow contact with unmanaged users only if the internal user initiates the contact:\n        - Toggle the setting to **On**.\n        - Clear the check next to **External users with Teams accounts not managed by an organization can contact users in my organization**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/teams.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md"
+    },
+    "ms.teams.2.3v2": {
+      "id": "ms.teams.2.3v2",
+      "platform": "microsoft-365",
+      "policyId": "MS.TEAMS.2.3v2",
+      "group": "External User Access",
+      "groupNumber": 2,
+      "assertion": "Internal users SHOULD NOT be enabled to initiate contact with unmanaged users.",
+      "obligation": "SHOULD NOT",
+      "rationale": "Contact with unmanaged users can pose the risk of data leakage and other security threats. This policy provides protection by disabling internal user access to unmanaged users.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "CM-7",
+        "SC-7(10)(a)"
+      ],
+      "mitreAttack": [
+        "T1204",
+        "T1204.001"
+      ],
+      "note": "This policy is not applicable to Government Community Cloud (GCC), GCC High, and Department of Defense (DoD) tenants.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to the **Microsoft Teams admin center**.\n\n2.  Select **Users > External access**.\n\n3.  Select **Policies**.\n\n4.  Select **Global (Org-wide Default)**.\n\n4.  To completely block contact with unmanaged users, under **Edit policy details**, set **People in my organization can communicate with unmanaged Teams accounts** to **Off**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/teams.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md"
+    },
+    "ms.teams.4.1v1": {
+      "id": "ms.teams.4.1v1",
+      "platform": "microsoft-365",
+      "policyId": "MS.TEAMS.4.1v1",
+      "group": "Teams Email Integration",
+      "groupNumber": 4,
+      "assertion": "Teams email integration SHALL be disabled.",
+      "obligation": "SHALL",
+      "rationale": "Microsoft Teams email integration associates a Microsoft, not tenant domain, email address with a Teams channel. Channel emails are addressed using the Microsoft-owned domain `&lt;teams.ms&gt;`. By disabling Teams email integration, an agency prevents potentially sensitive Teams messages from being sent through external email gateways.",
+      "lastModified": "July 2023",
+      "nist80053": [
+        "SI-8",
+        "SC-7(10)(a)",
+        "AC-4"
+      ],
+      "mitreAttack": [
+        "T1204",
+        "T1204.001",
+        "T1204.002"
+      ],
+      "note": "Teams email integration is not applicable to Government Community Cloud (GCC), GCC High, and Department of Defense (DoD) tenants.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to the **Microsoft Teams admin\n    center**.\n\n2.  Select **Teams** > **Teams Settings**.\n\n3.  Under the **Email integration** section, set **Users can send\n    emails to a channel email address** to **Off**.",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/teams.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md"
+    },
+    "ms.teams.5.1v2": {
+      "id": "ms.teams.5.1v2",
+      "platform": "microsoft-365",
+      "policyId": "MS.TEAMS.5.1v2",
+      "group": "App Management",
+      "groupNumber": 5,
+      "assertion": "Agencies SHOULD only allow installation of Microsoft apps approved by the agency.",
+      "obligation": "SHOULD",
+      "rationale": "Allowing Teams integration with all Microsoft apps can expose the agency to potential vulnerabilities present in those apps. By only allowing specific apps and blocking all others, the agency can better manage app integration and potential exposure points.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "CM-11"
+      ],
+      "mitreAttack": [
+        "T1195"
+      ],
+      "note": "This policy applies to the Global (Org-wide default) policy, all custom policies, and the org-wide app settings. Custom policies MAY be created to allow more flexibility for specific users.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to the **Microsoft Teams admin center**.\n\n2.  Select **Teams apps** > **Manage apps**.\n\n3.  In the upper right-hand corner select **Actions**\n\n4.  Select **Org-wide app settings**.\n\n5.  Under **Microsoft apps** > Select **On**\n\n6.  Click **Save**.\n\n    **NOTE:** This will make Microsoft apps in the application list available to \"Everyone.\" If adjustments are needed follow the remaining instructions\n\n7. Select **Teams apps** > **Manage apps**.\n\n8. Select each individual app.\n\n9. Select **Users and groups** > **Edit availability**\n\n10. Change **Available to** to the appropriate setting for your organization. (Everyone, Specific users or groups, or No one)\n\n11. Repeat steps 7 to 10 for each application",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/teams.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md"
+    },
+    "ms.teams.5.2v2": {
+      "id": "ms.teams.5.2v2",
+      "platform": "microsoft-365",
+      "policyId": "MS.TEAMS.5.2v2",
+      "group": "App Management",
+      "groupNumber": 5,
+      "assertion": "Agencies SHOULD only allow installation of third-party apps approved by the agency.",
+      "obligation": "SHOULD",
+      "rationale": "Allowing Teams integration with third-party apps can expose the agency to potential vulnerabilities present in an app not managed by the agency. By allowing only specific apps approved by the agency and blocking all others, the agency can limit its exposure to third-party app vulnerabilities.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "CM-11"
+      ],
+      "mitreAttack": [
+        "T1195",
+        "T1528"
+      ],
+      "note": "This policy applies to the Global (Org-wide default) policy, all custom policies if they exist, and the org-wide settings. Custom policies MAY be created to allow more flexibility for specific users. Third-party apps are not available in GCC, GCC High, or DoD regions.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to the **Microsoft Teams admin center**.\n\n2.  Select **Teams apps** > **Manage apps**.\n\n3.  In the upper right-hand corner select **Actions**\n\n4.  Select **Org-wide app settings**.\n\n5.  Under **Third-party apps** > Select **Off**\n\n6.  Click **Save**.\n\n    **NOTE:** This will make third party apps in the application list available to \"No one.\" If adjustments are needed follow the remaining                     instructions\n\n7.  Select **Teams apps** > **Manage apps**.\n\n8.  Select each individual app.\n\n9.  Select **Users and groups** > **Edit availability**\n\n10.  Change **Available to** to the appropriate setting for your organization. (Everyone, Specific users or groups, or No one)\n\n11.  Repeat steps 7 to 10 for each application",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/teams.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md"
+    },
+    "ms.teams.5.3v2": {
+      "id": "ms.teams.5.3v2",
+      "platform": "microsoft-365",
+      "policyId": "MS.TEAMS.5.3v2",
+      "group": "App Management",
+      "groupNumber": 5,
+      "assertion": "Agencies SHOULD only allow installation of custom apps approved by the agency.",
+      "obligation": "SHOULD",
+      "rationale": "Allowing custom apps integration can expose the agency to potential vulnerabilities present in an app not managed by the agency. By allowing only specific apps approved by the agency and blocking all others, the agency can limit its exposure to custom app vulnerabilities.",
+      "lastModified": "August 2025",
+      "nist80053": [
+        "CM-11"
+      ],
+      "mitreAttack": [
+        "T1195",
+        "T1528"
+      ],
+      "note": "This policy applies to the Global (Org-wide default) policy, all custom policies if they exist, and the org-wide settings. Custom policies MAY be created to allow more flexibility for specific users. Custom apps are not available in GCC, GCC High, or DoD regions.",
+      "productLicenseNotes": "- N/A",
+      "instructions": "1.  Sign in to the **Microsoft Teams admin center**.\n\n2.  Select **Teams apps** > **Manage apps**.\n\n3.  In the upper right-hand corner select **Actions**\n\n4.  Select **Org-wide app settings**.\n\n5.  Under **Custom apps** > Select **Off**\n\n6.  Click **Save**.\n\n    **NOTE:** This will make Custom apps in the application list available to \"No one.\" If adjustments are needed follow the remaining                     instructions\n\n7.  Select **Teams apps** > **Manage apps**.\n\n8.  Select each individual app.\n\n9.  Select **Users and groups** > **Edit availability**\n\n10.  Change **Available to** to the appropriate setting for your organization. (Everyone, Specific users or groups, or No one)\n\n11.  Repeat steps 7 to 10 for each application",
+      "license": "CC0-1.0 AND CC-BY-4.0",
+      "licenseObligations": {
+        "attribution": true,
+        "changeIndication": true,
+        "noticeText": [
+          "cisa-no-endorsement"
+        ]
+      },
+      "attribution": {
+        "attributionText": "Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), used under the Creative Commons Attribution 4.0 International license, via the CISA ScubaGear Secure Configuration Baselines. Text has been modified from the original (normalized formatting; see the vendored source for the verbatim upstream form).",
+        "sourceUrl": "https://github.com/cisagov/ScubaGear/blob/d7cf55f53fcc7faddde61086581b06da86a8da1d/PowerShell/ScubaGear/baselines/teams.md",
+        "licenseUrl": "https://creativecommons.org/licenses/by/4.0/",
+        "retrievedAt": "2026-07-20",
+        "upstream": {
+          "repo": "cisagov/ScubaGear",
+          "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+          "path": "PowerShell/ScubaGear/baselines/teams.md"
+        }
+      },
+      "sourcePath": "vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md"
+    }
+  }
+}

--- a/src/data/platformProcedures.test.js
+++ b/src/data/platformProcedures.test.js
@@ -1,0 +1,361 @@
+/**
+ * Contract suite for the generated platform-procedure bank (plan §7 PR-3),
+ * mirroring communityProcedures.test.js. Drift against vendor/scuba/ is
+ * caught by CI running `node scripts/generate-platform-bank.mjs --check`
+ * (and vendored-tree tampering by scripts/verify-vendor-integrity.mjs);
+ * this suite guards the contract the app and the license machinery rely on.
+ *
+ * License assertions run through the PRODUCTION schema (recordLicense /
+ * requiresAttribution / attributionComplete / validateLicensedRecords from
+ * PR-2) — the same code path the notices CI gate and the generator execute,
+ * not a re-implementation.
+ */
+import fs from 'fs';
+import path from 'path';
+import bank from './platformProcedures.json';
+import { PARSER_VERSION, POLICY_HEADING } from '../utils/scubaBaseline.mjs';
+import {
+  LICENSE_SCHEMA_VERSION,
+  recordLicense,
+  requiresAttribution,
+  attributionComplete,
+  ATTRIBUTION,
+  PUBLIC_DOMAIN
+} from '../utils/licenseClass.mjs';
+import { validateLicensedRecords, isCisaSourced } from '../utils/thirdPartyNotices.mjs';
+import { sanitizeInput } from '../utils/sanitize';
+
+const PLATFORM_POLICY_ID = /^(gws|ms)\.[a-z0-9]+\.\d+\.\d+v\d+$/;
+const ids = Object.keys(bank.procedures);
+const records = ids.map((id) => bank.procedures[id]);
+const VENDOR_DIR = path.resolve(__dirname, '..', '..', 'vendor', 'scuba');
+
+describe('platformProcedures.json (generated bank)', () => {
+  describe('bank envelope', () => {
+    test('carries bankFormat, a content-hash bankVersion, and an accurate count', () => {
+      expect(bank.bankFormat).toBe('platform-procedures-v1');
+      expect(bank.bankVersion).toMatch(/^[0-9a-f]{16}$/);
+      expect(bank.procedureCount).toBe(ids.length);
+    });
+
+    test('stamps the parser + license-schema versions that produced it (entry condition 3)', () => {
+      expect(bank.parserVersion).toBe(PARSER_VERSION);
+      expect(bank.licenseSchemaVersion).toBe(LICENSE_SCHEMA_VERSION);
+    });
+
+    test('exact census at the pinned SHAs: 137 GWS + 128 M365 = 265', () => {
+      expect(ids.length).toBe(265);
+      const byPlatform = records.reduce(
+        (acc, r) => ({ ...acc, [r.platform]: (acc[r.platform] || 0) + 1 }),
+        {}
+      );
+      expect(byPlatform).toEqual({ 'google-workspace': 137, 'microsoft-365': 128 });
+    });
+
+    test('record count matches an INDEPENDENT census of the vendored files', () => {
+      // Counted here by regex over vendor/scuba/, not via the parser — a
+      // parser that silently drops policies diverges from this number.
+      const manifest = JSON.parse(fs.readFileSync(path.join(VENDOR_DIR, 'MANIFEST.json'), 'utf8'));
+      let census = 0;
+      for (const source of manifest.sources) {
+        for (const relPath of Object.keys(source.files)) {
+          const text = fs.readFileSync(path.join(VENDOR_DIR, relPath), 'utf8');
+          for (const line of text.split('\n')) {
+            if (POLICY_HEADING.test(line.trim())) census++;
+          }
+        }
+      }
+      expect(ids.length).toBe(census);
+    });
+
+    test('the MANIFEST census agrees and stamps the same versions', () => {
+      const manifest = JSON.parse(fs.readFileSync(path.join(VENDOR_DIR, 'MANIFEST.json'), 'utf8'));
+      const manifestCensus = manifest.sources.reduce((n, s) => n + s.policyCensus, 0);
+      expect(manifestCensus).toBe(ids.length);
+      expect(manifest.parserVersion).toBe(PARSER_VERSION);
+      expect(manifest.licenseSchemaVersion).toBe(LICENSE_SCHEMA_VERSION);
+    });
+
+    test('removedpolicies.md is not vendored — deprecated policies are not procedures', () => {
+      const manifest = JSON.parse(fs.readFileSync(path.join(VENDOR_DIR, 'MANIFEST.json'), 'utf8'));
+      const allFiles = manifest.sources.flatMap((s) => Object.keys(s.files));
+      expect(allFiles.some((f) => f.includes('removedpolicies'))).toBe(false);
+      expect(allFiles.some((f) => f.endsWith('README.md'))).toBe(false);
+    });
+  });
+
+  describe('record shape (reference-shaped, R-3)', () => {
+    test('every key is a lowercased platform policy ID matching its record', () => {
+      for (const id of ids) {
+        expect(id).toMatch(PLATFORM_POLICY_ID);
+        expect(bank.procedures[id].id).toBe(id);
+        expect(bank.procedures[id].policyId.toLowerCase()).toBe(id);
+      }
+    });
+
+    test('every record carries the upstream facts: assertion, obligation, rationale, lastModified, group, instructions', () => {
+      for (const r of records) {
+        expect(r.assertion).toBeTruthy();
+        expect(['SHALL', 'SHALL NOT', 'SHOULD', 'SHOULD NOT', 'MAY']).toContain(r.obligation);
+        expect(r.rationale).toBeTruthy();
+        expect(r.lastModified).toBeTruthy();
+        expect(r.group).toBeTruthy();
+        expect(r.groupNumber).toBeGreaterThan(0);
+        expect(r.instructions).toBeTruthy();
+      }
+    });
+
+    test('100% NIST SP 800-53 coverage at the pinned SHAs (265/265 measured)', () => {
+      const missing = records.filter((r) => !Array.isArray(r.nist80053) || r.nist80053.length === 0);
+      expect(missing.map((r) => r.policyId)).toEqual([]);
+    });
+
+    test('mitreAttack IDs are normalized dot-form technique IDs (21 upstream "None" mappings are empty)', () => {
+      for (const r of records) {
+        for (const t of r.mitreAttack) expect(t).toMatch(/^T\d+(\.\d+)?$/);
+      }
+      expect(records.filter((r) => r.mitreAttack.length === 0).length).toBe(21);
+    });
+
+    test('Anti: no record carries a subcategories field — mapping is PR-4 (§7 R-2)', () => {
+      expect(records.filter((r) => 'subcategories' in r)).toEqual([]);
+    });
+
+    test('Anti: no record claims readOnly/privilegeRequired — the vendored text states neither (R-10)', () => {
+      expect(records.filter((r) => 'readOnly' in r || 'privilegeRequired' in r)).toEqual([]);
+    });
+  });
+
+  describe('license stamping (PR-2 schema; entry conditions 1-2)', () => {
+    test('every record carries a RAW license string and declared obligation components', () => {
+      for (const r of records) {
+        expect(typeof r.license).toBe('string');
+        expect(r.license.length).toBeGreaterThan(0);
+        expect(r.licenseObligations).toBeDefined();
+        expect(Array.isArray(r.licenseObligations.noticeText)).toBe(true);
+      }
+    });
+
+    test('Anti: no record stamps the computed classification join (no licenseClass key)', () => {
+      expect(records.filter((r) => 'licenseClass' in r)).toEqual([]);
+    });
+
+    test('all 128 M365 records derive attribution-class (recordLicense, production path)', () => {
+      const m365 = records.filter((r) => r.platform === 'microsoft-365');
+      expect(m365.length).toBe(128);
+      for (const r of m365) {
+        const { licenseClass, obligations } = recordLicense(r);
+        expect(licenseClass).toBe(ATTRIBUTION);
+        expect(obligations.attribution).toBe(true);
+        expect(obligations.changeIndication).toBe(true);
+        expect(obligations.noDerivatives).toBe(false);
+      }
+    });
+
+    test('all 137 GWS records derive public-domain (recordLicense, production path)', () => {
+      const gws = records.filter((r) => r.platform === 'google-workspace');
+      expect(gws.length).toBe(137);
+      for (const r of gws) {
+        const { licenseClass, obligations } = recordLicense(r);
+        expect(licenseClass).toBe(PUBLIC_DOMAIN);
+        expect(obligations.attribution).toBe(false);
+        expect(obligations.noDerivatives).toBe(false);
+      }
+    });
+
+    test('every record — attribution-obligated or not — carries a COMPLETE 5-field attribution block', () => {
+      for (const r of records) {
+        expect(attributionComplete(r)).toBe(true);
+        expect(r.attribution.sourceUrl).toContain(r.attribution.upstream.sha);
+        expect(r.attribution.upstream.repo).toMatch(/^cisagov\//);
+        expect(r.attribution.upstream.path).toBeTruthy();
+        expect(r.attribution.retrievedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      }
+    });
+
+    test('every attribution-OBLIGATED record satisfies the production gate pairing', () => {
+      const obligated = records.filter((r) => requiresAttribution(r));
+      expect(obligated.length).toBe(128);
+      for (const r of obligated) expect(attributionComplete(r)).toBe(true);
+    });
+
+    test('the CISA disclaimer triggers BOTH ways: structural provenance and declared notice key', () => {
+      for (const r of records) {
+        expect(isCisaSourced(r)).toBe(true);
+        expect(r.licenseObligations.noticeText).toContain('cisa-no-endorsement');
+      }
+    });
+
+    test('the real bank passes the production validation gate with zero errors', () => {
+      expect(validateLicensedRecords([{ name: 'platform', records: bank.procedures }])).toEqual([]);
+    });
+
+    test('POLARITY: a reference-only record is REFUSED by the production validation gate', () => {
+      const poisoned = {
+        ...bank.procedures[ids[0]],
+        license: 'CC BY-NC-SA 4.0'
+      };
+      const errors = validateLicensedRecords([{ name: 'platform', records: { [ids[0]]: poisoned } }]);
+      expect(errors.length).toBe(1);
+      expect(errors[0]).toContain('reference-only');
+    });
+
+    test('POLARITY: an attribution-incomplete record fails the production validation gate', () => {
+      const first = bank.procedures['ms.aad.1.1v1'];
+      const poisoned = { ...first, attribution: { ...first.attribution, retrievedAt: '' } };
+      const errors = validateLicensedRecords([{ name: 'platform', records: { 'ms.aad.1.1v1': poisoned } }]);
+      expect(errors.length).toBe(1);
+      expect(errors[0]).toContain('retrievedAt');
+    });
+  });
+
+  describe('sanitizer round-trip — REAL, per record, per text field', () => {
+    // The app routes every stored testProcedures write through
+    // sanitizeInput (DOMPurify, ALLOWED_TAGS: []). Generation normalizes to
+    // a fixpoint of that sanitizer, so attaching platform text in PR-5 is
+    // byte-lossless. This is the actual production sanitizer — not the
+    // community bank's proxy regex.
+    const TEXT_FIELDS = ['assertion', 'rationale', 'note', 'details', 'instructions', 'productLicenseNotes', 'group'];
+
+    test('sanitizeInput(field) === field for every text field of every record', () => {
+      const offenders = [];
+      for (const r of records) {
+        for (const f of TEXT_FIELDS) {
+          if (r[f] !== undefined && sanitizeInput(r[f]) !== r[f]) offenders.push(`${r.id}.${f}`);
+        }
+      }
+      expect(offenders).toEqual([]);
+    });
+
+    test('the round-trip test is not vacuous: the sanitizer DOES mutate un-normalized upstream shapes', () => {
+      // A raw upstream fragment (placeholder token + tag) — the exact class
+      // the normalization exists for. If sanitizeInput passed this through,
+      // the suite above would prove nothing.
+      expect(sanitizeInput('Enter your <domain> here')).not.toContain('<domain>');
+      expect(sanitizeInput('<b>bold</b>')).toBe('bold');
+    });
+  });
+
+  describe('drift and tamper guards, promoted into jest (test-analyzer round)', () => {
+    // A hand-edit to a record in the committed JSON passes every count,
+    // license, and fixpoint test — regeneration compare is the only defense.
+    // CI runs `generate-platform-bank.mjs --check`; this is the same
+    // guarantee through the SAME parser, repeatable in jest.
+    test('the committed bank equals a fresh parse of the vendored tree (record grain)', () => {
+      const manifest = JSON.parse(fs.readFileSync(path.join(VENDOR_DIR, 'MANIFEST.json'), 'utf8'));
+      const { parseBaselineFile } = require('../utils/scubaBaseline.mjs');
+      const rebuilt = {};
+      for (const source of manifest.sources) {
+        for (const relPath of Object.keys(source.files).sort()) {
+          const text = fs.readFileSync(path.join(VENDOR_DIR, relPath), 'utf8');
+          for (const record of parseBaselineFile(text, {
+            platformId: source.platformId,
+            repo: source.repo,
+            sha: source.sha,
+            baselinesPath: source.baselinesPath,
+            retrievedAt: manifest.retrievedAt,
+            fileName: path.basename(relPath),
+            sourcePath: `vendor/scuba/${relPath}`,
+            licenseId: source.licenseId
+          })) {
+            rebuilt[record.id] = record;
+          }
+        }
+      }
+      expect(bank.procedures).toEqual(rebuilt);
+    });
+
+    test('every vendored file matches its MANIFEST sha256 pin (tamper guard, jest grain)', () => {
+      const crypto = require('crypto');
+      const manifest = JSON.parse(fs.readFileSync(path.join(VENDOR_DIR, 'MANIFEST.json'), 'utf8'));
+      const mismatches = [];
+      for (const source of manifest.sources) {
+        for (const [relPath, expected] of Object.entries(source.files)) {
+          const actual = crypto
+            .createHash('sha256')
+            .update(fs.readFileSync(path.join(VENDOR_DIR, relPath)))
+            .digest('hex');
+          if (actual !== expected) mismatches.push(relPath);
+        }
+      }
+      expect(mismatches).toEqual([]);
+    });
+
+    test('POLARITY: the sha256 comparison detects a one-byte change', () => {
+      const crypto = require('crypto');
+      const manifest = JSON.parse(fs.readFileSync(path.join(VENDOR_DIR, 'MANIFEST.json'), 'utf8'));
+      const [relPath, expected] = Object.entries(manifest.sources[0].files)[0];
+      const tampered = Buffer.concat([fs.readFileSync(path.join(VENDOR_DIR, relPath)), Buffer.from('X')]);
+      expect(crypto.createHash('sha256').update(tampered).digest('hex')).not.toBe(expected);
+    });
+  });
+
+  describe('normalization conversion evidence — converted, not deleted (test-analyzer round)', () => {
+    // The fixpoint test cannot distinguish converted content from deleted
+    // content (deletion is also a fixpoint). These pin the measured
+    // conversion outputs in the real corpus at the pinned SHAs, so a
+    // normalizer regression that deletes instead of converts goes red.
+    const fieldText = (r) =>
+      ['assertion', 'rationale', 'note', 'details', 'instructions', 'productLicenseNotes']
+        .map((f) => r[f] || '')
+        .join('\n');
+
+    test('exactly 18 records carry a fenced code block (converted <pre> click-paths)', () => {
+      expect(records.filter((r) => fieldText(r).includes('```')).length).toBe(18);
+    });
+
+    test('exactly 227 records carry markdown bold (converted <b> emphasis and native **)', () => {
+      expect(records.filter((r) => /\*\*/.test(fieldText(r))).length).toBe(227);
+    });
+
+    test('exactly 25 records carry inline code outside fences (converted placeholder tokens and <code>)', () => {
+      const inlineCode = /`[^`\n]+`/;
+      expect(
+        records.filter((r) => inlineCode.test(fieldText(r).replace(/```[\s\S]*?```/g, ''))).length
+      ).toBe(25);
+    });
+
+    test('exactly 128 records carry productLicenseNotes (every M365 record, no GWS record)', () => {
+      const withNotes = records.filter((r) => r.productLicenseNotes);
+      expect(withNotes.length).toBe(128);
+      expect(withNotes.every((r) => r.platform === 'microsoft-365')).toBe(true);
+    });
+
+    test('GOLDEN spot-check: ms.aad.1.1v1 instructions carry the fenced Conditional Access click-path', () => {
+      const instructions = bank.procedures['ms.aad.1.1v1'].instructions;
+      // The upstream <pre> block became a fence; the <b> tags inside it were
+      // dropped (emphasis renders literally inside fences); the click-path
+      // text itself survives verbatim.
+      expect(instructions).toContain('```\n  Users > Include > All users');
+      expect(instructions).toContain('Access controls > Grant > Block Access\n```');
+      expect(instructions).not.toContain('<pre>');
+      expect(instructions).not.toContain('<b>');
+    });
+  });
+
+  describe('reserved-name fence: productLicenseNotes never reaches an egress surface', () => {
+    test('no src/ file outside the platform lane references productLicenseNotes', () => {
+      const SRC = path.resolve(__dirname, '..');
+      const ALLOWED = new Set([
+        path.join('utils', 'scubaBaseline.mjs'),
+        path.join('utils', 'scubaBaseline.test.js'),
+        path.join('utils', 'licenseClass.mjs'), // reserves the name in docs
+        path.join('data', 'platformProcedures.json'),
+        path.join('data', 'platformProcedures.test.js')
+      ]);
+      const offenders = [];
+      const walk = (dir) => {
+        for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+          const p = path.join(dir, e.name);
+          if (e.isDirectory()) { walk(p); continue; }
+          if (!/\.(js|jsx|mjs|json)$/.test(e.name)) continue;
+          const rel = path.relative(SRC, p);
+          if (ALLOWED.has(rel)) continue;
+          if (fs.readFileSync(p, 'utf8').includes('productLicenseNotes')) offenders.push(rel);
+        }
+      };
+      walk(SRC);
+      expect(offenders).toEqual([]);
+    });
+  });
+});

--- a/src/utils/licenseClass.mjs
+++ b/src/utils/licenseClass.mjs
@@ -29,6 +29,15 @@
  * and must never wire into any share-export or render block.
  */
 
+/**
+ * Version of this classification schema. Stamped (with the parser version)
+ * into the vendor MANIFEST and generated bank files so a future tightening
+ * (e.g. unknown ⇒ restricted) is a re-derivation over retained raw inputs,
+ * not undetectable data loss (PR-3 entry condition 3). Bump on any change to
+ * the token vocabulary, class set, or merge rules.
+ */
+export const LICENSE_SCHEMA_VERSION = 1;
+
 /* The gate axis. Order matters: merging takes the MOST restrictive. */
 export const UNDECLARED = 'undeclared'; // blank/unrecognized — asserts nothing, restricts nothing
 export const PUBLIC_DOMAIN = 'public-domain'; // CC0, US Government work

--- a/src/utils/scubaBaseline.mjs
+++ b/src/utils/scubaBaseline.mjs
@@ -74,12 +74,20 @@ const MITRE_TECHNIQUE_URL = /attack\.mitre\.org\/techniques\/(T\d+)(?:\/(\d+))?/
  */
 export const normalizeScubaMarkdown = (markdown) => {
   let text = markdown
-    // HTML comments are upstream build metadata (e.g. <!--Policy: ...-->),
-    // deleted by the sanitizer — strip them at generation instead.
-    .replace(/<!--[\s\S]*?-->/g, '')
     // The serializer would entity-encode a non-breaking space.
     .replace(/ /g, ' ')
     .replace(/\r\n/g, '\n');
+
+  // HTML comments are upstream build metadata (e.g. <!--Policy: ...-->),
+  // deleted by the sanitizer — strip them at generation instead. Loop
+  // until stable: a single pass can resurrect a `<!--` from nested sequences
+  // (CodeQL js/incomplete-multi-character-sanitization); the trailing
+  // `<` → `&lt;` encoding below is the universal backstop either way.
+  let previous;
+  do {
+    previous = text;
+    text = text.replace(/<!--[\s\S]*?-->/g, '');
+  } while (text !== previous);
 
   // <pre> blocks (ScubaGear console click-paths) become fenced code blocks;
   // inline emphasis tags inside them are dropped (markdown emphasis would

--- a/src/utils/scubaBaseline.mjs
+++ b/src/utils/scubaBaseline.mjs
@@ -1,0 +1,383 @@
+/**
+ * CISA SCuBA secure-configuration-baseline parser — turns vendored baseline
+ * markdown (vendor/scuba/) into platform-procedure bank records.
+ *
+ * Lives in src/utils (not scripts/lib) because CRA jest only collects from
+ * src/ — relatedSection.mjs precedent. Shared between the build-time
+ * generator (scripts/generate-platform-bank.mjs) and the jest suite, so the
+ * CI drift gate and the tests exercise the SAME code.
+ *
+ * Two upstream dialects, one parser (plan §5 C4):
+ *  - policy IDs carry a version suffix: GWS.COMMONCONTROLS.1.1v1 /
+ *    MS.AAD.1.1v1 — both forms parsed;
+ *  - ScubaGoggles writes the MITRE mapping line WITHOUT underscores
+ *    ("- MITRE ATT&CK TTP Mapping"), ScubaGear WITH
+ *    ("- _MITRE ATT&CK TTP Mapping:_") — both forms parsed.
+ * Field bullets additionally vary in punctuation across the corpus
+ * (measured at the pinned SHAs): `_Rationale:_` vs `_Rationale_:`,
+ * `_Last modified:_` vs `_Last Modified:_`, single vs double space after
+ * the dash, and instruction headings with double spaces or trailing colons.
+ * The regexes below tolerate every measured form; the manifest census
+ * cross-check in the generator catches any form they miss.
+ *
+ * License comes from PER-FILE detection, never the repo-level label (plan §7
+ * R-1): every ScubaGear M365 baseline carries an in-file "License Compliance
+ * and Copyright" section declaring portions adapted from Microsoft docs under
+ * CC BY 4.0 — those files stamp attribution-class metadata (raw license
+ * string + component obligations + a complete attribution block). Files
+ * without such a section stamp raw CC0-1.0. Records carry the RAW string and
+ * declared obligation COMPONENTS only — never the computed classification
+ * join, which recordLicense() derives at read (PR-3 entry condition 2).
+ *
+ * ScubaGear's "### License Requirements" sections are Microsoft PRODUCT
+ * licensing ("requires Entra ID P2"), not content licensing — parsed into
+ * productLicenseNotes, which must never wire into any share-export or render
+ * block (reserved name, see licenseClass.mjs).
+ */
+
+export const PARSER_VERSION = 1;
+
+/** noticeText key for the CISA no-endorsement disclaimer (thirdPartyNotices). */
+const CISA_NOTICE_KEY = 'cisa-no-endorsement';
+
+/** A `#### GWS.X.n.mvK` / `#### MS.X.n.mvK` policy heading (trimmed line). */
+export const POLICY_HEADING = /^####\s+((?:GWS|MS)\.[A-Z0-9]+\.\d+\.\d+v\d+)$/;
+
+const GROUP_HEADING = /^## (\d+)\. (.+)$/;
+const INSTRUCTIONS_HEADING = /^####\s+((?:GWS|MS)\.[A-Z0-9]+\.\d+\.\d+v\d+)\s+Instructions:?$/;
+/**
+ * Group-common instruction headings, in every measured upstream spelling:
+ * "Policy Group 9 Instructions", "Policy Group 2 common Instructions",
+ * "Policy 1 Common Instructions", "Policy Group 1 Common Implementation:",
+ * "GWS COMMONCONTROLS 18 Common Instructions".
+ */
+const GROUP_INSTRUCTIONS_HEADING =
+  /^####\s+(?:Policy(?:\s+Group)?|GWS\s+[A-Z0-9]+)\s+(\d+)\s+(?:[Cc]ommon\s+)?(?:Instructions|Implementation):?$/;
+const MITRE_LINE = /^-\s+_?MITRE ATT&CK TTP Mapping:?_?$/;
+const NIST_LINE = /^-\s+_NIST SP 800-53 Rev\. 5 FedRAMP High Baseline Mapping_?:_?\s*(.+)$/;
+const RATIONALE_LINE = /^-\s+_Rationale_?:_?\s*(.*)$/;
+const LAST_MODIFIED_LINE = /^-\s+_Last [Mm]odified_?:_?\s*(.+)$/;
+const NOTE_LINE = /^-\s+_Note_?:_?\s*(.*)$/;
+const BADGE_LINE = /^\[!\[/;
+const MITRE_TECHNIQUE_URL = /attack\.mitre\.org\/techniques\/(T\d+)(?:\/(\d+))?/g;
+
+/**
+ * Normalize baseline markdown into a fixpoint of the app's DOMPurify-based
+ * input sanitizer, so attaching platform text is byte-lossless. Measured
+ * sanitizer behavior (ALLOWED_TAGS: []): bare `&` and `>` pass through
+ * untouched (blockquotes and "ATT&CK" are safe); every `<` is hostile —
+ * letter-initial `<token>` sequences are DELETED outright (the class that
+ * already ate `<email>` lines from 9 community entries), known tags are
+ * stripped, comments are deleted, and any other `<` is entity-encoded.
+ * The contract test asserts sanitizeInput(field) === field per record —
+ * a REAL round-trip, not the community bank's proxy regex.
+ */
+export const normalizeScubaMarkdown = (markdown) => {
+  let text = markdown
+    // HTML comments are upstream build metadata (e.g. <!--Policy: ...-->),
+    // deleted by the sanitizer — strip them at generation instead.
+    .replace(/<!--[\s\S]*?-->/g, '')
+    // The serializer would entity-encode a non-breaking space.
+    .replace(/ /g, ' ')
+    .replace(/\r\n/g, '\n');
+
+  // <pre> blocks (ScubaGear console click-paths) become fenced code blocks;
+  // inline emphasis tags inside them are dropped (markdown emphasis would
+  // render literally inside a fence).
+  text = text.replace(/<pre>([\s\S]*?)<\/pre>/gi, (whole, inner) => {
+    const cleaned = inner
+      .replace(/<\/?(?:b|strong|i|em)>/gi, '')
+      .replace(/^\n+|\n+$/g, '');
+    return '```\n' + cleaned + '\n```';
+  });
+
+  return (
+    text
+      // Inline emphasis outside fences becomes markdown emphasis.
+      .replace(/<\/?(?:b|strong)>/gi, '**')
+      .replace(/<\/?(?:i|em)>/gi, '*')
+      .replace(/<code>([^<]*)<\/code>/gi, '`$1`')
+      .replace(/<br\s*\/?>/gi, '\n')
+      // Named anchors and images are GitHub-render furniture the app cannot
+      // resolve (relative image paths, in-page anchor targets) — dropped.
+      .replace(/<\/?a(?:\s[^<>]*)?>/gi, '')
+      .replace(/<img\s[^<>]*>/gi, '')
+      // Autolinks and emails lose their brackets (community-bank rules).
+      .replace(/<(https?:\/\/[^<>\s]+)>/g, '$1')
+      .replace(/<([^<>\s]+@[^<>\s]+)>/g, '$1')
+      // Remaining letter-initial tokens are placeholders (<domain>,
+      // <tenant-id>) the sanitizer would DELETE — carry them as inline code.
+      .replace(/<([a-zA-Z][^<>]*)>/g, '`$1`')
+      // Any `<` still standing (numeric comparisons like "<4") would be
+      // entity-encoded on attach; store the encoded fixpoint form.
+      .replace(/</g, '&lt;')
+      .replace(/[ \t]+$/gm, '')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim()
+  );
+};
+
+/**
+ * Per-file license detection (plan §7 R-1). The vendoring manifest's
+ * per-source licenseId (the repo-grain license, positively recorded at
+ * vendoring time) is the FLOOR; the file content — an in-file "License
+ * Compliance and Copyright" section declaring CC BY portions — can only
+ * TIGHTEN it, mirroring the licenseClass floor/ceiling model. CC0 is never
+ * inferred from the mere absence of a CC BY marker, and which repo a file
+ * came from never decides its class. The license string is a machine-
+ * parseable SPDX expression (advisor adoption: `AND`, both licenses apply
+ * to different portions — a composed prose phrase is a derivation wearing
+ * a raw label); the human explanation lives in attributionText, and the
+ * computed class is derived at read by recordLicense().
+ */
+export const detectFileLicense = (text, repoLicenseId) => {
+  const floor = repoLicenseId || 'CC0-1.0';
+  const licenseSection = extractSection(text, /^## License Compliance and Copyright\s*$/);
+  const hasCcByPortions =
+    licenseSection !== null && /Creative Commons Attribution 4\.0/i.test(licenseSection);
+  const hasCisaDisclaimer = /CISA does not endorse/i.test(text);
+
+  const noticeText = hasCisaDisclaimer ? [CISA_NOTICE_KEY] : [];
+
+  if (hasCcByPortions) {
+    return {
+      license: `${floor} AND CC-BY-4.0`,
+      licenseObligations: { attribution: true, changeIndication: true, noticeText },
+      licenseUrl: 'https://creativecommons.org/licenses/by/4.0/',
+      attributionText:
+        'Portions adapted from Microsoft M365 and Azure documentation (© Microsoft), ' +
+        'used under the Creative Commons Attribution 4.0 International license, via ' +
+        'the CISA ScubaGear Secure Configuration Baselines. Text has been modified ' +
+        'from the original (normalized formatting; see the vendored source for the ' +
+        'verbatim upstream form).'
+    };
+  }
+  return {
+    license: floor,
+    licenseObligations: { noticeText },
+    licenseUrl: 'https://creativecommons.org/publicdomain/zero/1.0/',
+    attributionText:
+      'Derived from the CISA Secure Configuration Baselines (SCuBA), released ' +
+      'under CC0 1.0 Universal.'
+  };
+};
+
+/** Text of the section opened by headingRe up to the next same-level heading. */
+const extractSection = (text, headingRe) => {
+  const lines = text.split('\n');
+  const start = lines.findIndex((l) => headingRe.test(l.trim()));
+  if (start === -1) return null;
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^## /.test(lines[i])) { end = i; break; }
+  }
+  return lines.slice(start + 1, end).join('\n').trim();
+};
+
+const extractObligation = (assertion) => {
+  const m = assertion.match(/\b(SHALL NOT|SHOULD NOT|SHALL|SHOULD|MAY)\b/);
+  return m ? m[1] : '';
+};
+
+/**
+ * Segment a policy block (the lines after its #### heading, up to the next
+ * heading) into assertion + structured fields + leftover details. Bullet
+ * grammar: a top-level `- ` line opens a segment; indented or blank lines
+ * continue it. Everything that is not a recognized field bullet, badge, or
+ * comment lands in `details` — nothing is silently dropped.
+ */
+const parsePolicyBlock = (block) => {
+  const out = {
+    assertion: '', rationale: '', lastModified: '', note: '',
+    nist80053: [], mitreAttack: [], details: ''
+  };
+
+  let cursor = 0;
+  while (cursor < block.length && block[cursor].trim() === '') cursor++;
+  const assertionLines = [];
+  while (cursor < block.length) {
+    const line = block[cursor].trim();
+    if (line === '' || BADGE_LINE.test(line) || /^<!--/.test(line) || /^-\s/.test(line)) break;
+    assertionLines.push(line);
+    cursor++;
+  }
+  out.assertion = normalizeScubaMarkdown(assertionLines.join(' '));
+
+  // Segment the remainder into top-level bullets (with their continuation
+  // lines) and non-bullet prose.
+  const segments = [];
+  let current = null;
+  for (let i = cursor; i < block.length; i++) {
+    const raw = block[i];
+    const trimmed = raw.trim();
+    if (/^-\s/.test(trimmed) && !/^\s/.test(raw)) {
+      current = { head: trimmed, lines: [raw] };
+      segments.push(current);
+    } else if (current && (trimmed === '' || /^\s/.test(raw))) {
+      current.lines.push(raw);
+    } else {
+      if (trimmed !== '') segments.push({ head: null, lines: [raw] });
+      current = null;
+    }
+  }
+
+  const detailParts = [];
+  const noteParts = [];
+  for (const seg of segments) {
+    const head = seg.head;
+    if (head === null) {
+      const text = seg.lines.join('\n');
+      if (!BADGE_LINE.test(text.trim()) && !/^<!--/.test(text.trim())) detailParts.push(text);
+      continue;
+    }
+    const rationale = head.match(RATIONALE_LINE);
+    if (rationale) {
+      out.rationale = normalizeScubaMarkdown(
+        [rationale[1], ...seg.lines.slice(1).map((l) => l.trim())].join(' ').trim()
+      );
+      continue;
+    }
+    const lastModified = head.match(LAST_MODIFIED_LINE);
+    if (lastModified) { out.lastModified = lastModified[1].trim(); continue; }
+    const nist = head.match(NIST_LINE);
+    if (nist) {
+      // Continuation lines scan like MITRE's: a future upstream wrap of the
+      // control list must not silently drop the wrapped controls.
+      out.nist80053 = [nist[1], ...seg.lines.slice(1).map((l) => l.trim())]
+        .join(' ')
+        .split(/,\s*/)
+        .map((s) => s.trim())
+        .filter(Boolean);
+      continue;
+    }
+    if (MITRE_LINE.test(head)) {
+      const seen = new Set();
+      for (const line of seg.lines) {
+        for (const m of line.matchAll(MITRE_TECHNIQUE_URL)) {
+          // GWS writes sub-techniques T1110:001, ScubaGear T1110.001 — the
+          // URL path (T1110/001) is dialect-free; normalize to the dot form.
+          const id = m[2] ? `${m[1]}.${m[2]}` : m[1];
+          if (!seen.has(id)) { seen.add(id); out.mitreAttack.push(id); }
+        }
+      }
+      continue;
+    }
+    const note = head.match(NOTE_LINE);
+    if (note) {
+      noteParts.push(
+        normalizeScubaMarkdown([note[1], ...seg.lines.slice(1).map((l) => l.trim())].join(' ').trim())
+      );
+      continue;
+    }
+    // Unrecognized bullet (e.g. aad.md's "Additional mitigations ..." advisory)
+    // — preserved in details rather than silently dropped.
+    detailParts.push(seg.lines.join('\n'));
+  }
+
+  out.note = noteParts.join('\n\n');
+  out.details = normalizeScubaMarkdown(detailParts.join('\n'));
+  return out;
+};
+
+/**
+ * Parse one vendored baseline file into policy records.
+ * source: { platformId, repo, sha, baselinesPath, retrievedAt, fileName,
+ *           sourcePath, licenseId }
+ */
+export const parseBaselineFile = (text, source) => {
+  const fileLicense = detectFileLicense(text, source.licenseId);
+  const lines = text.replace(/\r\n/g, '\n').split('\n');
+
+  const headingEnd = (start) => {
+    for (let j = start + 1; j < lines.length; j++) {
+      if (/^#### /.test(lines[j]) || /^###? /.test(lines[j])) return j;
+    }
+    return lines.length;
+  };
+
+  // Pass 1 — instruction blocks (per-policy and group-common) and per-group
+  // product-license notes, all keyed before the policy walk so position in
+  // the file doesn't matter.
+  const instructions = {};
+  const groupInstructions = new Map();
+  const groupProductNotes = new Map();
+  let walkGroup = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    const g = trimmed.match(GROUP_HEADING);
+    if (g) { walkGroup = Number(g[1]); continue; }
+    const per = trimmed.match(INSTRUCTIONS_HEADING);
+    if (per) {
+      instructions[per[1]] = normalizeScubaMarkdown(lines.slice(i + 1, headingEnd(i)).join('\n'));
+      continue;
+    }
+    const common = trimmed.match(GROUP_INSTRUCTIONS_HEADING);
+    if (common) {
+      groupInstructions.set(Number(common[1]), normalizeScubaMarkdown(lines.slice(i + 1, headingEnd(i)).join('\n')));
+      continue;
+    }
+    if (/^### License Requirements$/.test(trimmed)) {
+      const note = normalizeScubaMarkdown(lines.slice(i + 1, headingEnd(i)).join('\n'));
+      if (note) groupProductNotes.set(walkGroup, note);
+    }
+  }
+
+  // Pass 2 — policy blocks.
+  const records = [];
+  let group = '';
+  let groupNumber = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const g = lines[i].trim().match(GROUP_HEADING);
+    if (g) {
+      groupNumber = Number(g[1]);
+      group = g[2].trim();
+      continue;
+    }
+    const p = lines[i].trim().match(POLICY_HEADING);
+    if (!p) continue;
+
+    const policyId = p[1];
+    const parsed = parsePolicyBlock(lines.slice(i + 1, headingEnd(i)));
+
+    const record = {
+      id: policyId.toLowerCase(),
+      platform: source.platformId,
+      policyId,
+      group,
+      groupNumber,
+      assertion: parsed.assertion,
+      obligation: extractObligation(parsed.assertion),
+      rationale: parsed.rationale,
+      lastModified: parsed.lastModified,
+      nist80053: parsed.nist80053,
+      mitreAttack: parsed.mitreAttack
+    };
+    if (parsed.note) record.note = parsed.note;
+    if (parsed.details) record.details = parsed.details;
+    const productNote = groupProductNotes.get(groupNumber);
+    if (productNote) record.productLicenseNotes = productNote;
+    // Per-policy instructions win; a group-common block ("Policy Group 9
+    // Instructions") is the fallback for policies without their own.
+    const policyInstructions = instructions[policyId] || groupInstructions.get(groupNumber);
+    if (policyInstructions) record.instructions = policyInstructions;
+
+    record.license = fileLicense.license;
+    record.licenseObligations = fileLicense.licenseObligations;
+    record.attribution = {
+      attributionText: fileLicense.attributionText,
+      sourceUrl: `https://github.com/${source.repo}/blob/${source.sha}/${source.baselinesPath}/${source.fileName}`,
+      licenseUrl: fileLicense.licenseUrl,
+      retrievedAt: source.retrievedAt,
+      upstream: {
+        repo: source.repo,
+        sha: source.sha,
+        path: `${source.baselinesPath}/${source.fileName}`
+      }
+    };
+    record.sourcePath = source.sourcePath;
+
+    records.push(record);
+  }
+
+  return records;
+};

--- a/src/utils/scubaBaseline.test.js
+++ b/src/utils/scubaBaseline.test.js
@@ -1,0 +1,367 @@
+/**
+ * Parser tests for the SCuBA baseline parser — synthetic fixtures covering
+ * both upstream dialects (plan §5 C4), the measured punctuation variance,
+ * and the per-file license detection (plan §7 R-1).
+ *
+ * Discrimination discipline (G19/G20 C/R/L): fixtures are built so the WRONG
+ * implementation SUCCEEDS at its wrong behavior — a parser that stamps
+ * license from the repo-level label (instead of per-file detection) passes a
+ * naive "M365 file is attribution-class" test, so the fixtures cross-wire
+ * dialect and license section: a GWS-shaped file WITH the section must stamp
+ * attribution, an MS-shaped file WITHOUT it must stamp CC0.
+ */
+import {
+  PARSER_VERSION,
+  POLICY_HEADING,
+  normalizeScubaMarkdown,
+  detectFileLicense,
+  parseBaselineFile
+} from './scubaBaseline.mjs';
+
+const SOURCE = {
+  platformId: 'test-platform',
+  repo: 'cisagov/ScubaTest',
+  sha: 'a'.repeat(40),
+  baselinesPath: 'baselines',
+  retrievedAt: '2026-07-20',
+  fileName: 'test.md',
+  sourcePath: 'vendor/scuba/test/baselines/test.md',
+  licenseId: 'CC0-1.0'
+};
+
+const LICENSE_SECTION = [
+  '## License Compliance and Copyright',
+  'Portions of this document are adapted from documents in Microsoft’s repositories.',
+  'The respective documents are adapted under the terms of the Creative Commons Attribution 4.0 International license.',
+  ''
+].join('\n');
+
+const CISA_DISCLAIMER_LINE =
+  'For non-federal users, this is provided as is. CISA does not endorse any commercial product or service.';
+
+describe('scubaBaseline parser', () => {
+  describe('policy IDs (C4: v-suffix, both dialects)', () => {
+    test.each([
+      ['#### GWS.COMMONCONTROLS.1.1v1', 'GWS.COMMONCONTROLS.1.1v1'],
+      ['#### MS.AAD.1.1v1', 'MS.AAD.1.1v1'],
+      ['#### MS.TEAMS.1.7v2', 'MS.TEAMS.1.7v2'],
+      ['####  MS.AAD.2.1v1', 'MS.AAD.2.1v1'] // double space (measured in aad.md)
+    ])('%s parses', (line, id) => {
+      expect(line.trim().match(POLICY_HEADING)[1]).toBe(id);
+    });
+
+    test('an Instructions heading is NOT a policy heading', () => {
+      expect('#### GWS.GMAIL.1.1v1 Instructions'.match(POLICY_HEADING)).toBeNull();
+    });
+  });
+
+  describe('field extraction across measured upstream variants', () => {
+    const file = (bullets) =>
+      [
+        '## 1. Test Group',
+        '### Policies',
+        '#### GWS.TESTBASE.1.1v1',
+        'Widgets SHALL be disabled for all users.',
+        '',
+        ...bullets,
+        ''
+      ].join('\n');
+
+    test('canonical GWS form: rationale, last modified, NIST, bare MITRE line with colon-form sub-techniques', () => {
+      const [r] = parseBaselineFile(
+        file([
+          '- _Rationale:_ Widgets are risky.',
+          '- _Last modified:_ January 2025',
+          '- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), AC-17a, SI-8',
+          '- MITRE ATT&CK TTP Mapping',
+          '  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)',
+          '    - [T1110:001: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)'
+        ]),
+        SOURCE
+      );
+      expect(r.assertion).toBe('Widgets SHALL be disabled for all users.');
+      expect(r.obligation).toBe('SHALL');
+      expect(r.rationale).toBe('Widgets are risky.');
+      expect(r.lastModified).toBe('January 2025');
+      expect(r.nist80053).toEqual(['IA-2(1)', 'AC-17a', 'SI-8']);
+      // Colon-form sub-technique normalized to the dot form via the URL path.
+      expect(r.mitreAttack).toEqual(['T1110', 'T1110.001']);
+      expect(r.group).toBe('Test Group');
+      expect(r.groupNumber).toBe(1);
+    });
+
+    test('ScubaGear form: underscored MITRE line, dot-form sub-techniques', () => {
+      const [r] = parseBaselineFile(
+        file([
+          '- _Rationale:_ Risky.',
+          '- _Last modified:_ June 2023',
+          '- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7',
+          '- _MITRE ATT&CK TTP Mapping:_',
+          '  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)',
+          '    - [T1078.004: Cloud Accounts](https://attack.mitre.org/techniques/T1078/004/)'
+        ]),
+        SOURCE
+      );
+      expect(r.mitreAttack).toEqual(['T1078', 'T1078.004']);
+    });
+
+    test('measured punctuation variants: _Rationale_:, _Last Modified:_, double-space dash', () => {
+      const [r] = parseBaselineFile(
+        file([
+          '-  _Rationale_: Spacing and underscores vary upstream.',
+          '- _Last Modified:_ August 2025',
+          '- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-5'
+        ]),
+        SOURCE
+      );
+      expect(r.rationale).toBe('Spacing and underscores vary upstream.');
+      expect(r.lastModified).toBe('August 2025');
+    });
+
+    test('a NIST control list wrapped across lines keeps the wrapped controls', () => {
+      const [r] = parseBaselineFile(
+        file([
+          '- _Rationale:_ Risky.',
+          '- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-6a, SI-3a,',
+          '  SI-8, AC-2'
+        ]),
+        SOURCE
+      );
+      expect(r.nist80053).toEqual(['CM-6a', 'SI-3a', 'SI-8', 'AC-2']);
+    });
+
+    test('a "None" MITRE mapping yields an empty list, not a parse failure', () => {
+      const [r] = parseBaselineFile(
+        file([
+          '- _Rationale:_ Risky.',
+          '- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-5',
+          '- _MITRE ATT&CK TTP Mapping:_',
+          '  - None'
+        ]),
+        SOURCE
+      );
+      expect(r.mitreAttack).toEqual([]);
+      expect(r.nist80053).toEqual(['AC-5']);
+    });
+
+    test('Note bullets are captured; unrecognized bullets land in details — nothing drops', () => {
+      const [r] = parseBaselineFile(
+        file([
+          '- _Rationale:_ Risky.',
+          '- _Note:_ Applies to the Global policy.',
+          '- _Additional mitigations to reduce risks:_ consider conditional access.'
+        ]),
+        SOURCE
+      );
+      expect(r.note).toBe('Applies to the Global policy.');
+      expect(r.details).toContain('Additional mitigations');
+    });
+
+    test('SHOULD NOT is extracted as the full obligation', () => {
+      const [r] = parseBaselineFile(
+        [
+          '## 1. G',
+          '#### MS.TESTBASE.1.1v1',
+          'Control SHOULD NOT be enabled.',
+          ''
+        ].join('\n'),
+        SOURCE
+      );
+      expect(r.obligation).toBe('SHOULD NOT');
+    });
+  });
+
+  describe('instructions: per-policy wins, group-common is the fallback', () => {
+    const doc = [
+      '## 9. Group Nine',
+      '### Policies',
+      '#### GWS.TESTBASE.9.1v1',
+      'A SHALL hold.',
+      '',
+      '#### GWS.TESTBASE.9.2v1',
+      'B SHALL hold.',
+      '',
+      '### Implementation',
+      '#### Policy Group 9 Instructions',
+      'Common steps for the group.',
+      '',
+      '#### GWS.TESTBASE.9.2v1 Instructions:',
+      'Specific steps for 9.2.',
+      ''
+    ].join('\n');
+
+    test('policy without its own block inherits the group-common instructions', () => {
+      const records = parseBaselineFile(doc, SOURCE);
+      expect(records[0].instructions).toBe('Common steps for the group.');
+    });
+
+    test('per-policy instructions (with measured trailing colon) win over group-common', () => {
+      const records = parseBaselineFile(doc, SOURCE);
+      expect(records[1].instructions).toBe('Specific steps for 9.2.');
+    });
+
+    test.each([
+      '#### Policy Group 2 common Instructions',
+      '#### Policy 1 Common Instructions',
+      '#### Policy Group 1 Common Implementation:',
+      '#### GWS COMMONCONTROLS 18 Common Instructions'
+    ])('measured group-heading variant "%s" is recognized', (heading) => {
+      const records = parseBaselineFile(
+        [
+          `## ${heading.match(/(\d+)/)[1]}. G`,
+          '#### GWS.TESTBASE.' + heading.match(/(\d+)/)[1] + '.1v1',
+          'A SHALL hold.',
+          '',
+          '### Implementation',
+          heading,
+          'Common text.',
+          ''
+        ].join('\n'),
+        SOURCE
+      );
+      expect(records[0].instructions).toBe('Common text.');
+    });
+  });
+
+  describe('per-file license detection (R-1) — content decides, never the repo label', () => {
+    const policies = (prefix) =>
+      [
+        '## 1. G',
+        `#### ${prefix}.TESTBASE.1.1v1`,
+        'A SHALL hold.',
+        ''
+      ].join('\n');
+
+    test('file WITH a CC BY license section stamps attribution-class components (SPDX AND expression)', () => {
+      const [r] = parseBaselineFile(
+        [LICENSE_SECTION, CISA_DISCLAIMER_LINE, policies('MS')].join('\n'),
+        SOURCE
+      );
+      expect(r.license).toBe('CC0-1.0 AND CC-BY-4.0');
+      expect(r.licenseObligations).toEqual({
+        attribution: true,
+        changeIndication: true,
+        noticeText: ['cisa-no-endorsement']
+      });
+      expect(r.attribution.attributionText).toContain('Microsoft');
+      // CC BY 4.0 §3(a)(1)(B): modification must be indicated.
+      expect(r.attribution.attributionText).toContain('modified');
+      expect(r.attribution.licenseUrl).toBe('https://creativecommons.org/licenses/by/4.0/');
+    });
+
+    test('file WITHOUT a license section stamps the manifest-declared repo license floor', () => {
+      const [r] = parseBaselineFile([CISA_DISCLAIMER_LINE, policies('GWS')].join('\n'), SOURCE);
+      expect(r.license).toBe('CC0-1.0');
+      expect(r.licenseObligations).toEqual({ noticeText: ['cisa-no-endorsement'] });
+    });
+
+    test('the floor is the source licenseId, not a hardcoded CC0 (positive evidence, no silent default)', () => {
+      const [r] = parseBaselineFile(policies('GWS'), { ...SOURCE, licenseId: 'CC0-1.0-TEST-FLOOR' });
+      expect(r.license).toBe('CC0-1.0-TEST-FLOOR');
+    });
+
+    // Mutation-killing fixtures (test-analyzer round, both mutants CONFIRMED
+    // surviving the natural corpus): the natural corpus has perfect
+    // presence⇔content correlation, so a detector keying on section PRESENCE
+    // alone, or grepping the WHOLE FILE for the CC BY sentence, passes every
+    // natural fixture — and would stamp a fabricated Microsoft-adaptation
+    // claim on CC0 files at a future pin move.
+    test('MUTANT KILL: a license section that does NOT declare CC BY portions stays at the floor', () => {
+      const cc0OnlySection = [
+        '## License Compliance and Copyright',
+        'This document is released under CC0 1.0 Universal. No other terms apply.',
+        ''
+      ].join('\n');
+      const [r] = parseBaselineFile([cc0OnlySection, policies('GWS')].join('\n'), SOURCE);
+      expect(r.license).toBe('CC0-1.0');
+      expect(r.licenseObligations.attribution).toBeUndefined();
+    });
+
+    test('MUTANT KILL: the CC BY sentence OUTSIDE a license section does not stamp attribution', () => {
+      const doc = [
+        '## 1. G',
+        '#### GWS.TESTBASE.1.1v1',
+        'A SHALL hold.',
+        '',
+        '- _Rationale:_ Cited prose mentions the Creative Commons Attribution 4.0 International license by name.',
+        ''
+      ].join('\n');
+      const [r] = parseBaselineFile(doc, SOURCE);
+      expect(r.license).toBe('CC0-1.0');
+      expect(r.licenseObligations.attribution).toBeUndefined();
+    });
+
+    // The discrimination pair: cross-wire dialect and license section. A
+    // parser keying license off the repo/dialect (GWS ⇒ CC0, MS ⇒ CC BY)
+    // succeeds at its wrong behavior on the natural corpus but FAILS here.
+    test('DISCRIMINATION: GWS-shaped file WITH the section stamps attribution', () => {
+      const [r] = parseBaselineFile([LICENSE_SECTION, policies('GWS')].join('\n'), SOURCE);
+      expect(r.licenseObligations.attribution).toBe(true);
+    });
+
+    test('DISCRIMINATION: MS-shaped file WITHOUT the section stamps CC0', () => {
+      const [r] = parseBaselineFile(policies('MS'), SOURCE);
+      expect(r.license).toBe('CC0-1.0');
+      expect(r.licenseObligations.attribution).toBeUndefined();
+    });
+
+    test('no CISA disclaimer in the file ⇒ no notice key declared', () => {
+      expect(detectFileLicense(policies('GWS')).licenseObligations.noticeText).toEqual([]);
+    });
+
+    test('records never carry a computed licenseClass (entry condition 2)', () => {
+      const [r] = parseBaselineFile(
+        [LICENSE_SECTION, policies('MS')].join('\n'),
+        SOURCE
+      );
+      expect('licenseClass' in r).toBe(false);
+    });
+  });
+
+  describe('product licensing (License Requirements) stays out of the license lane', () => {
+    test('### License Requirements parses into productLicenseNotes, not license fields', () => {
+      const [r] = parseBaselineFile(
+        [
+          '## 1. G',
+          '### Policies',
+          '#### MS.TESTBASE.1.1v1',
+          'A SHALL hold.',
+          '',
+          '### License Requirements',
+          '- Requires a Microsoft Entra ID P2 license',
+          '',
+          '### Implementation',
+          '#### MS.TESTBASE.1.1v1 Instructions',
+          'Steps.',
+          ''
+        ].join('\n'),
+        SOURCE
+      );
+      expect(r.productLicenseNotes).toBe('- Requires a Microsoft Entra ID P2 license');
+      expect(r.license).toBe('CC0-1.0'); // product licensing never mutates content license
+    });
+  });
+
+  describe('normalizeScubaMarkdown — sanitizer-fixpoint normalization', () => {
+    test.each([
+      ['<!--Policy: MS.AAD.1.1v1; Criticality: SHALL -->text', 'text'],
+      ['<pre>\n  Users > Include > <b>All users</b>\n</pre>', '```\n  Users > Include > All users\n```'],
+      ['make it <b>bold</b>', 'make it **bold**'],
+      ['see <code>Get-Thing</code>', 'see `Get-Thing`'],
+      ['<a name="anchor">jump</a>', 'jump'],
+      ['before <img src="images/MFA.PNG"> after', 'before  after'],
+      ['go to <https://example.com/x>', 'go to https://example.com/x'],
+      ['mail <soc@example.com> now', 'mail soc@example.com now'],
+      ['line one<br>line two', 'line one\nline two'],
+      ['use your <domain> and <tenant-id>', 'use your `domain` and `tenant-id`'],
+      ['fewer than <4 minutes', 'fewer than &lt;4 minutes'],
+      ['ATT&CK and 5 > 3 and > quote stay put', 'ATT&CK and 5 > 3 and > quote stay put']
+    ])('%s', (input, expected) => {
+      expect(normalizeScubaMarkdown(input)).toBe(expected);
+    });
+
+    test('PARSER_VERSION is stamped for re-derivation lineage (entry condition 3)', () => {
+      expect(typeof PARSER_VERSION).toBe('number');
+    });
+  });
+});

--- a/src/utils/thirdPartyNotices.mjs
+++ b/src/utils/thirdPartyNotices.mjs
@@ -46,14 +46,19 @@ export const MITRE_NOTICE =
  * CISA-sourced — detected STRUCTURALLY from upstream provenance, not from a
  * hand-entered notice key, so forgetting the key cannot silently omit a
  * required notice (the key remains honored as a belt-and-braces trigger).
+ * Wording reconciled (PR-3) against the disclaimer the vendored baselines
+ * themselves carry: their standard form provides the material "as is" for
+ * informational purposes only and disclaims endorsement of any commercial
+ * product or service — both clauses are reflected below.
  */
 export const CISA_DISCLAIMER =
-  'Portions of this project are derived from CISA Secure Configuration ' +
-  'Baselines (SCuBA), released under CC0 1.0 Universal. CISA and the United ' +
-  'States Government do not endorse this project or its authors, and no such ' +
-  'endorsement may be inferred; CISA material is referenced for informational ' +
-  'purposes only. CC0 1.0 does not waive trademark rights: no CISA or DHS ' +
-  'marks, seals, or logos are used by this project.';
+  'Portions of this project are derived from the CISA Secure Configuration ' +
+  'Baselines (SCuBA), released under CC0 1.0 Universal. Per the disclaimer ' +
+  'those baselines carry, the material is provided "as is" for informational ' +
+  'purposes only. CISA and the United States Government do not endorse this ' +
+  'project, its authors, or any commercial product or service, and no such ' +
+  'endorsement may be inferred. CC0 1.0 does not waive trademark rights: no ' +
+  'CISA or DHS marks, seals, or logos are used by this project.';
 
 /** Structural CISA provenance: the record's upstream repo is a cisagov one. */
 export const isCisaSourced = (record) =>

--- a/src/utils/thirdPartyNotices.test.js
+++ b/src/utils/thirdPartyNotices.test.js
@@ -127,14 +127,18 @@ describe('notices markdown — deterministic, scope + standing notices', () => {
   });
 
   test('the committed THIRD-PARTY-NOTICES.md matches a fresh render of the shipped banks (drift = red here AND in CI)', () => {
-    const real = JSON.parse(
+    const community = JSON.parse(
       fs.readFileSync(path.join(__dirname, '..', 'data', 'communityProcedures.json'), 'utf8')
+    );
+    const platform = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', 'data', 'platformProcedures.json'), 'utf8')
     );
     const committed = fs.readFileSync(
       path.join(__dirname, '..', '..', 'THIRD-PARTY-NOTICES.md'), 'utf8'
     );
     expect(committed).toBe(noticesMarkdown([
-      { name: 'Community test-procedure bank (src/data/communityProcedures.json)', records: real.procedures }
+      { name: 'Community test-procedure bank (src/data/communityProcedures.json)', records: community.procedures },
+      { name: 'Platform procedure bank (src/data/platformProcedures.json)', records: platform.procedures }
     ]));
   });
 });

--- a/vendor/scuba/LICENSE-CC0-1.0.txt
+++ b/vendor/scuba/LICENSE-CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/vendor/scuba/MANIFEST.json
+++ b/vendor/scuba/MANIFEST.json
@@ -1,0 +1,48 @@
+{
+  "manifestFormat": "scuba-vendor-v1",
+  "parserVersion": 1,
+  "licenseSchemaVersion": 1,
+  "retrievedAt": "2026-07-20",
+  "note": "Baseline TEXT only is imported (plan §6 item 3). The upstream repos vendor third-party dependencies under their own licenses; per-file license detection (src/utils/scubaBaseline.mjs), never the repo-level CC0 label, decides what each record stamps. removedpolicies.md (deprecated policies) and README.md are excluded.",
+  "sources": [
+    {
+      "platformId": "google-workspace",
+      "repo": "cisagov/ScubaGoggles",
+      "sha": "95d80462699e469b569e5b5caf921c4b8c6c884a",
+      "baselinesPath": "scubagoggles/baselines",
+      "licenseId": "CC0-1.0",
+      "policyCensus": 137,
+      "files": {
+        "scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/assuredcontrols.md": "842c530bdb448e979b8dd44dddb411356341ccafb182925ac7863f42cbc661dc",
+        "scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/calendar.md": "2eb9434a25659fec204011f3555a09dacb3648f885be608a97667d2dbad24386",
+        "scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/chat.md": "536b616a6c05d51259d42d8b13261730bd993457d1b576f7d3f5700590436114",
+        "scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/classroom.md": "ec918f2c2e549eafe41163530b6a0a31fad7fe6897b96fea57352e6ebc4f5806",
+        "scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md": "3b513afae5197b54ea98401db46cdbf92af2a76e85bec2be2c2967abc4b5ddb7",
+        "scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md": "0f319850cf02315d812119fd20bbb5f31e5f5e026455c0e48e40792e0f1719ed",
+        "scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gemini.md": "4a5ab54aa13c8d63ae12a6321a1f8f2d11648f384589ba6adb1db56558f035f0",
+        "scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md": "f1af0a08aa88ea66d6aae0e92d2b0ce8ad4067f341a2208df3d29d8000ac8592",
+        "scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/groups.md": "ea8d2f756100f0651bfd5089829625d76f02a1428b1461fb22039c097d0dc51b",
+        "scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/meet.md": "441b55d0ab40ff7fc197f57069c3df33ff0bddab2e9d7cbf510d4946595121a6",
+        "scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/sites.md": "3d1617d16aeac86120114eb19c6ea1a1fd0b221ce5936b3afe537f10395d6508"
+      }
+    },
+    {
+      "platformId": "microsoft-365",
+      "repo": "cisagov/ScubaGear",
+      "sha": "d7cf55f53fcc7faddde61086581b06da86a8da1d",
+      "baselinesPath": "PowerShell/ScubaGear/baselines",
+      "licenseId": "CC0-1.0",
+      "policyCensus": 128,
+      "files": {
+        "scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md": "3d2815f597f2be044f9e140535cce4d90b67f4ed734d5a3d4c1323f10ec96604",
+        "scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md": "5718b800e9c99ac73f0196a2665ba563e36bfe0236aaf6a54a0eccbcf97f402e",
+        "scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md": "de6fd5151958383ecaae4f8a0d1092d5bb6d6d885d21afc8f13221dd775d80c1",
+        "scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerbi.md": "f9d22c204fdd11d53800d1da9afece03edcb05dac11878417f5042f73ea66b1f",
+        "scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerplatform.md": "e87a2d553aa0390dcce5d9e7d4a69e1cd898080cd5cf1c519e8e72e2a1cc98e5",
+        "scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md": "46fbd4c9a7212ae968ea4edfe290f0ecc4af6f0d6bf47661740ab45257200104",
+        "scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/sharepoint.md": "7ea2f414156f2d367924f8a8d5b2267cfd39a679ae65bbfbc2327cafaac2cb10",
+        "scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md": "6306c7e414785abb85ed9695002b2f27772e179af5c573fb03a9b6f045c6d0df"
+      }
+    }
+  ]
+}

--- a/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md
+++ b/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/aad.md
@@ -1,0 +1,1285 @@
+**`TLP:CLEAR`**
+
+# CISA M365 Secure Configuration Baseline for Microsoft Entra ID
+
+Microsoft Entra ID is a cloud-based identity and access control service that provides security and functional capabilities. This Secure Configuration Baseline (SCB) provides specific policies to help secure Microsoft Entra ID.
+
+The Secure Cloud Business Applications (SCuBA) project, run by the Cybersecurity and Infrastructure Security Agency (CISA), provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies’ cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for M365 help secure federal information assets stored within M365 cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government’s threats and risk tolerance with the knowledge that every organization has different threat models and risk tolerance. While use of these baselines will be mandatory for civilian Federal Government agencies, organizations outside of the Federal Government may also find these baselines to be useful references to help reduce risks.
+
+For non-Federal users, the information in this document is being provided “as is” for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products; CISA has no control over vendor changes to products offerings or features.  Accordingly, these SCuBA SCBs for M365 may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+> This document is marked TLP:CLEAR. Recipients may share this information without restriction. Information is subject to standard copyright rules. For more information on the Traffic Light Protocol, see https://www.cisa.gov/tlp.
+
+## License Compliance and Copyright
+Portions of this document are adapted from documents in Microsoft’s [M365](https://github.com/MicrosoftDocs/microsoft-365-docs/blob/public/LICENSE) and [Azure](https://github.com/MicrosoftDocs/azure-docs/blob/main/LICENSE) GitHub repositories. The respective documents are subject to copyright and are adapted under the terms of the Creative Commons Attribution 4.0 International license. Sources are linked throughout this document. The United States government has adapted selections of these documents to develop innovative and scalable configuration standards to strengthen the security of widely used cloud-based software services.
+
+## Assumptions
+The **License Requirements** sections of this document assume the organization is using an [M365 E3](https://www.microsoft.com/en-us/microsoft-365/compare-microsoft-365-enterprise-plans) or [G3](https://www.microsoft.com/en-us/microsoft-365/government) license level at a minimum. Therefore, only licenses not included in E3/G3 are listed.
+
+Some of the policies in this baseline may link to Microsoft instruction pages which assume that an agency has created emergency access accounts in Microsoft Entra ID and [implemented strong security measures](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/security-emergency-access#create-emergency-access-accounts) to protect the credentials of those accounts.
+
+## Key Terminology
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+The following are key terms and descriptions used in this document.
+
+**Microsoft Entra ID hybrid**: This term denotes the scenario
+when an organization has an on-premises Microsoft Windows Server Active Directory that contains the
+master user directory but federates access to the cloud M365
+Microsoft Entra ID tenant.
+
+**Resource Tenant & Home Tenant**: In scenarios where guest users are involved the **resource tenant** hosts the M365 target resources that the guest user is accessing. The **home tenant** is the one that hosts the guest user's identity.
+
+**BOD 25-01 Requirement**: This indicator means that the policy is required under CISA BOD 25-01.
+
+**Automated Check**: This indicator means that the policy can be automatically checked via ScubaGear. See the [Quick Start Guide](../../../README.md#quick-start-guide) for help getting started.
+
+**Configurable**: This indicator means that the policy can be customized via config file.
+
+**Manual**: This indicator means that the policy requires manual verification of configuration settings.
+
+## Highly Privileged Roles
+
+This section provides a list of what CISA considers highly privileged [built-in roles in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference).
+
+- Global Administrator
+- Privileged Role Administrator
+- User Administrator
+- SharePoint Administrator
+- Exchange Administrator
+- Hybrid Identity Administrator
+- Application Administrator
+- Cloud Application Administrator
+
+Throughout this document, this list of highly privileged roles is referenced in numerous baseline policies. Agencies should consider this list a foundational reference and apply respective baseline policies to additional Microsoft Entra ID roles as necessary.
+
+## Conditional Access Policies
+
+Numerous policies in this baseline rely on Microsoft Entra ID Conditional Access. Conditional Access is a feature that allows administrators to limit access to resources using characteristics such as user or group membership, device, IP location, and real-time risk detection. This section provides guidance and tools when implementing baseline policies which rely on Microsoft Entra ID Conditional Access.
+
+As described in Microsoft’s literature related to conditional access policies, CISA recommends initially setting a policy to **Report-only** when it is created and then performing thorough hands-on testing to help prevent unintended consequences before toggling the policy from **Report-only** to **On**. The policy will only be enforced when it is set to **On**. One tool that can assist with running test simulations is the [What If tool](https://learn.microsoft.com/en-us/entra/identity/conditional-access/what-if-tool). Microsoft also describes [Conditional Access insights and reporting](https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-insights-reporting) that can assist with testing.
+
+ScubaGear does not assess Conditions configuration values within conditional access policies aside from the specific conditions specified in the SCuBA policy implementation sections. While these conditions are designed to refine access controls, overly granular or misaligned configurations may exclude certain scenarios from enforcement and can unintentionally introduce gaps in policy coverage. For example:
+
+- **Overlapping or conflicting conditions** can result in users or devices falling outside intended protections.
+- **Unaccounted exceptions** (e.g., new cloud apps or unmanaged devices) may bypass critical controls.
+- **Dynamic environments** (such as hybrid identities or evolving IP ranges) can render static conditions ineffective over time.
+
+To help mitigate risk from the gaps in conditional access policies, organizations should regularly review conditional access policy logic, validate coverage against all user and device contexts, and implement monitoring to detect unintended exclusions.
+
+# Baseline Policies
+
+## 1. Legacy Authentication
+
+This section provides policies that reduce security risks related to legacy authentication protocols that do not support multifactor authentication (MFA).
+
+### Policies
+#### MS.AAD.1.1v1
+Legacy authentication SHALL be blocked.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/configuration.md#conditional-access-policy-exclusions)
+
+<!--Policy: MS.AAD.1.1v1; Criticality: SHALL -->
+<!--ExclusionType: CapExclusions-->
+- _Rationale:_ The security risk of allowing legacy authentication protocols is they do not support MFA. Blocking legacy protocols reduces the impact of user credential theft.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110.001: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110.002: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110.003: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.004: Cloud Accounts](https://attack.mitre.org/techniques/T1078/004/)
+
+### Resources
+
+- [Block legacy authentication with Conditional Access](https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-block-legacy)
+
+- [Five steps to securing your identity infrastructure](https://learn.microsoft.com/en-us/azure/security/fundamentals/steps-secure-identity)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.AAD.1.1v1 Instructions
+
+1. [Determine if an agency’s existing applications use legacy authentication](https://learn.microsoft.com/en-us/entra/identity/conditional-access/block-legacy-authentication#identify-legacy-authentication-use) before blocking legacy authentication across the entire application base.
+
+2. Create a Conditional Access policy to block legacy authentication
+
+<pre>
+  Users > Include > <b>All users</b>
+
+  Target resources > Include > <b>All resources (formerly 'All cloud apps') </b>
+
+  Conditions > Client apps > Configure > <b>Yes</b> > Legacy authentication clients > Select only <b>Exchange ActiveSync clients</b> and <b>Other clients</b>
+
+  Access controls > Grant > <b>Block Access</b>
+</pre>
+
+## 2. Risk Based Policies
+
+This section provides policies that reduce security risks related to potentially compromised user accounts. These policies combine Microsoft Entra ID Protection and Microsoft Entra ID Conditional Access. Microsoft Entra ID Protection uses numerous signals to detect the risk level for each user or sign-in and determine if an account may have been compromised.
+
+- _Additional mitigations to reduce risks associated with the authentication of workload identities:_ Although not covered in this baseline due to the need for an additional non-standard license, Microsoft provides support for mitigating risks related to workload identities (Microsoft Entra ID applications or service principals). Agencies should strongly consider implementing this feature because workload identities present many of the same risks as interactive user access and are commonly used in modern systems. CISA urges organizations to [apply Conditional Access policies to workload identities](https://learn.microsoft.com/en-us/entra/identity/conditional-access/workload-identity).
+
+- _Note:_ In this section, the term ["high risk"](https://learn.microsoft.com/en-us/entra/id-protection/concept-identity-protection-risks) denotes the risk level applied by the Microsoft Entra ID Protection service to a user account or sign-in event.
+
+### Policies
+#### MS.AAD.2.1v1
+Users detected as high risk SHALL be blocked.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/configuration.md#conditional-access-policy-exclusions)
+
+<!--Policy: MS.AAD.2.1v1; Criticality: SHALL -->
+<!--ExclusionType: CapExclusions-->
+- _Rationale:_ Blocking high-risk users may prevent compromised accounts from accessing the tenant.
+- _Last modified:_ June 2023
+- _Note:_ Users identified as high risk by Microsoft Entra ID Identity Protection can be blocked from accessing the system via a Microsoft Entra ID Conditional Access policy. A high-risk user will be blocked until an administrator remediates their account.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-2(12), AC-2(13)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.004: Cloud Accounts](https://attack.mitre.org/techniques/T1078/004/)
+
+#### MS.AAD.2.2v1
+A notification SHOULD be sent to the administrator when high-risk users are detected.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#msaad22v1-instructions)
+
+<!--Policy: MS.AAD.2.2v1; Criticality: SHOULD -->
+- _Rationale:_ Notification enables the admin to monitor the event and remediate the risk. This helps the organization proactively respond to cyber intrusions as they occur.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-2(12)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.004: Cloud Accounts](https://attack.mitre.org/techniques/T1078/004/)
+
+#### MS.AAD.2.3v1
+Sign-ins detected as high risk SHALL be blocked.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/configuration.md#conditional-access-policy-exclusions)
+
+<!--Policy: MS.AAD.2.3v1; Criticality: SHALL -->
+<!--ExclusionType: CapExclusions-->
+- _Rationale:_ This prevents compromised accounts from accessing the tenant.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-2(12), AC-2(13)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.004: Cloud Accounts](https://attack.mitre.org/techniques/T1078/004/)
+
+### Resources
+
+- [What are risk detections?](https://learn.microsoft.com/en-us/entra/id-protection/concept-identity-protection-risks)
+
+- [Simulating risk detections in Identity Protection](https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-simulate-risk)
+
+- [Self-remediation experience with Microsoft Entra ID Protection and Conditional Access](https://learn.microsoft.com/en-us/entra/id-protection/concept-identity-protection-user-experience)
+
+### License Requirements
+
+- Requires a Microsoft Entra ID P2 license
+
+### Implementation
+
+####  MS.AAD.2.1v1 Instructions
+
+1.  Create a conditional access policy blocking users categorized as high risk by the Identity Protection service. Configure the following policy settings in the new conditional access policy as per the values below:
+
+<pre>
+  Users > Include > <b>All users</b>
+
+  Target resources > Include > <b>All resources (formerly 'All cloud apps') </b>
+
+  Conditions > User risk > <b>High</b>
+
+  Access controls > Grant > <b>Block Access</b>
+</pre>
+
+#### MS.AAD.2.2v1 Instructions
+
+1.  [Configure Microsoft Entra ID Protection to send a regularly monitored security mailbox email notification](https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-notifications#configure-users-at-risk-detected-alerts) when user accounts are determined to be high risk.
+
+#### MS.AAD.2.3v1 Instructions
+
+1.  Create a Conditional Access policy blocking sign-ins determined high risk by the Identity Protection service. Configure the following policy settings in the new Conditional Access policy as per the values below:
+
+<pre>
+  Users > Include > <b>All users</b>
+
+  Target resources > Include > <b>All resources (formerly 'All cloud apps') </b>
+
+  Conditions > Sign-in risk > <b>High</b>
+
+  Access controls > Grant > <b>Block Access</b>
+</pre>
+
+## 3. Strong Authentication and a Secure Registration Process
+
+This section provides policies that help reduce security risks related to user authentication and registration.
+
+Phishing-resistant MFA is required per [Office of Management and Budget Memorandum 22-09](https://www.whitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf).
+
+<img src="/images/aad-mfa.png"
+alt="Weak MFA methods are SMS and Voice. Stronger MFA are Authenticator Push Notifications, Authenticator Phone Sign-in, Software Tokens OTP, and Hardware Tokens OTP. Strongest MFA methods are FIDO2 (preferred), Windows Hello (preferred), Microsoft Entra certificate-based authentication (preferred) and federated PIV card." />
+
+Figure 1: Depiction of MFA methods from weakest to strongest. _Adapted from [Microsoft Page](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-methods)_
+
+### Policies
+#### MS.AAD.3.1v1
+Phishing-resistant MFA SHALL be enforced for all users.
+
+The phishing-resistant methods **Microsoft Entra ID certificate-based authentication (CBA)**, **FIDO2 Security Key**, **Windows Hello for Business**, and **device-bound passkeys** are the recommended authentication options since they offer forms of MFA with the least weaknesses. For federal agencies, Microsoft Entra ID CBA supports federal PIV card authentication directly to Microsoft Entra ID.
+
+If on-premises PIV authentication and federation to Microsoft Entra ID is used, [enforce PIV logon via Microsoft Active Directory group policy](https://www.idmanagement.gov/implement/scl-windows/).
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/configuration.md#conditional-access-policy-exclusions)
+
+<!--Policy: MS.AAD.3.1v1; Criticality: SHALL -->
+<!--ExclusionType: CapExclusions-->
+- _Rationale:_ Weaker forms of MFA do not protect against sophisticated phishing attacks. By enforcing methods resistant to phishing, those risks are minimized.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), IA-2(2), IA-5c, IA-5g, IA-2(8)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+#### MS.AAD.3.2v2
+MFA SHALL be enforced for all users.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/configuration.md#conditional-access-policy-exclusions)
+
+
+<!--Policy: MS.AAD.3.2v2; Criticality: SHALL -->
+<!--ExclusionType: CapExclusions-->
+- _Rationale:_ This policy helps protect the tenant for guest users or any other group with multifactor authentication where phishing-resistant MFA is not enforceable due to technical limitations. It protects against the weaknesses inherent in singlefactor authentication.
+- _Last modified:_ February 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), IA-2(2)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110.001: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110.002: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110.003: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+    
+#### MS.AAD.3.3v2
+If Microsoft Authenticator is enabled, it SHALL be configured to show login context information.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.3.3v2; Criticality: SHALL -->
+- _Rationale:_ This policy helps protect the tenant when Microsoft Authenticator is used by showing user context information, which helps reduce MFA phishing compromises.
+- _Last modified:_ March 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), IA-2(2), IA-5c, IA-5g, IA-2(8), IA-2(13)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110.001: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110.002: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110.003: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+
+
+#### MS.AAD.3.4v1
+The Authentication Methods Manage Migration feature SHALL be set to Migration Complete.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.3.4v1; Criticality: SHALL -->
+- _Rationale:_ To disable the legacy authentication methods screen for the tenant, configure the Manage Migration feature to Migration Complete. The MFA and Self-Service Password Reset (SSPR) authentication methods are both managed from a central admin page, thereby reducing administrative complexity and potential security misconfigurations.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+#### MS.AAD.3.5v2
+The authentication methods SMS, Voice Call, and Email One-Time Passcode (OTP) SHALL be disabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.AAD.3.5v2; Criticality: SHALL -->
+- _Rationale:_ SMS, voice call, and email OTP are the weakest authenticators. This policy forces users to use stronger MFA methods.
+- _Last modified:_ February 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7b, IA-5c
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1621: Multi-Factor Authentication Request Generation](https://attack.mitre.org/techniques/T1621/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+#### MS.AAD.3.6v1
+Phishing-resistant MFA SHALL be required for highly privileged roles.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/configuration.md#conditional-access-policy-exclusions)
+
+<!--Policy: MS.AAD.3.6v1; Criticality: SHALL -->
+<!--ExclusionType: CapExclusions-->
+- _Rationale:_ This is a backup security policy to help protect privileged access to the tenant if the conditional access policy, which requires MFA for all users, is disabled or misconfigured.
+- _Last modified:_ June 2023
+- _Note:_ Refer to the Highly Privileged Roles section at the top of this document for a reference list of roles considered highly privileged.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), IA-5c, IA-5g, IA-2(8)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.004: Cloud Accounts](https://attack.mitre.org/techniques/T1078/004/)
+
+#### MS.AAD.3.7v1
+Managed devices SHOULD be required for authentication.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/configuration.md#conditional-access-policy-exclusions)
+
+<!--Policy: MS.AAD.3.7v1; Criticality: SHOULD -->
+<!--ExclusionType: CapExclusions-->
+- _Rationale:_ The security risk of an adversary authenticating to the tenant from their own device is reduced by requiring a managed device to authenticate. Managed devices are under the provisioning and control of the agency. [OMB-22-09](https://www.whitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf) states, "When authorizing users to access resources, agencies must consider at least one device-level signal alongside identity information about the authenticated user."
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-20b, IA-3
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.004: Cloud Accounts](https://attack.mitre.org/techniques/T1078/004/)
+
+#### MS.AAD.3.8v1
+Managed Devices SHOULD be required to register MFA.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/configuration.md#conditional-access-policy-exclusions)
+
+<!--Policy: MS.AAD.3.8v1; Criticality: SHOULD -->
+<!--ExclusionType: CapExclusionsWithoutApps-->
+- _Rationale:_ Reduce risk of an adversary using stolen user credentials and then registering their own MFA device to access the tenant by requiring a managed device provisioned and controlled by the agency to perform registration actions. This prevents the adversary from using their own unmanaged device to perform the registration.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-20b, IA-3
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.004: Cloud Accounts](https://attack.mitre.org/techniques/T1078/004/)
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.005: Device Registration](https://attack.mitre.org/techniques/T1098/005/)
+
+#### MS.AAD.3.9v1
+Device code authentication SHOULD be blocked.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/configuration.md#conditional-access-policy-exclusions)
+
+<!--Policy: MS.AAD.3.9v1; Criticality: SHOULD -->
+<!--ExclusionType: CapExclusions-->
+- _Rationale:_ The device code authentication flow has been abused to compromise user accounts via phishing. Since most organizations using M365 don't need device code authentication, blocking it mitigates the risk.
+- _Last modified:_ February 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1528: Steal Application Access Token](https://attack.mitre.org/techniques/T1528/)
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.004: Cloud Accounts](https://attack.mitre.org/techniques/T1078/004/)
+
+### Resources
+
+- [What authentication and verification methods are available in Microsoft Entra ID?](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-methods)
+
+- [Use additional context in Authenticator notifications - Authentication methods policy](https://learn.microsoft.com/en-us/entra/identity/authentication/how-to-mfa-additional-context#enable-additional-context-in-the-portal)
+
+- [M-22-09 Federal Zero Trust Architecture Strategy](https://www.whitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf)
+
+- [Configure Microsoft Entra hybrid join](https://learn.microsoft.com/en-us/entra/identity/devices/how-to-hybrid-join)
+
+- [Microsoft Entra joined devices](https://learn.microsoft.com/en-us/entra/identity/devices/concept-directory-join)
+
+- [Set up automatic enrollment for Windows devices (for Intune)](https://learn.microsoft.com/en-us/mem/intune/enrollment/windows-enroll)
+
+- [Enable passkeys (FIDO2) for your organization](https://learn.microsoft.com/en-us/entra/identity/authentication/how-to-enable-passkey-fido2)
+
+- [Storm-2372 conducts device code phishing campaign](https://www.microsoft.com/en-us/security/blog/2025/02/13/storm-2372-conducts-device-code-phishing-campaign/)
+
+- [Microsoft 365 Device Code Phishing Cyber Attack – Demonstration, Analysis and Mitigation](https://github.com/cisagov/ScubaGear/issues/1599)
+
+- [Block device code flow](https://learn.microsoft.com/en-us/entra/identity/conditional-access/managed-policies#block-device-code-flow)
+
+### License Requirements
+
+- Policies related to managed devices require Microsoft Intune.
+
+### Implementation
+
+#### MS.AAD.3.1v1 Instructions
+
+1. Create a conditional access policy enforcing phishing-resistant MFA for all users. Configure the following policy settings in the new conditional access policy, per the values below:
+
+<pre>
+  Users > Include > <b>All users</b>
+
+  Target resources > Include > <b>All resources (formerly 'All cloud apps') </b>
+
+  Access controls > Grant > Grant Access > Require authentication strength > <b>Phishing-resistant MFA</b>
+</pre>
+
+#### MS.AAD.3.2v2 Instructions
+
+There are a few different options to implement a conditional access policy that enforces MFA. Each option is described below, followed by our recommendation and the respective instructions for each option.
+
+- **Option 1** - Create a custom authentication strength that includes the specific multifactor authentication methods supported by your organization and then create a policy that enforces your custom authentication strength.
+- **Option 2** - Create a policy that enforces multifactor authentication (no specific MFA method).
+- **Option 3** - Create a policy that enforces the built-in authentication strength named "Multifactor authentication" (no specific MFA method).
+
+We recommend using a custom authentication strength because you can enforce the specific methods that offer the highest security. We recommend that you require the passwordless authentication strength Microsoft Authenticator (Phone Sign-in) in lieu of alternative MFA methods, since it removes passwords from the sign-in flow, reducing the exposure to credential compromise.
+
+**Option 1**. [Follow the instructions at this link](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-strength-advanced-options#create-a-custom-authentication-strength) to create a custom authentication strength. Create a conditional access policy that enforces your custom authentication. Configure the following policy settings in the new conditional access policy, per the values below:
+
+<pre>
+  Users > Include > <b>All users</b>
+
+  Target resources > Include > <b>All resources (formerly 'All cloud apps') </b>
+
+  Access controls > Grant > Grant Access > <b>Require authentication strength</b> > <b>YOUR_CUSTOM_AUTHENTICATION_STRENGTH</b>
+</pre>
+
+**Option 2**. Create a conditional access policy that enforces MFA but does not dictate a specific MFA method. Configure the following policy settings in the new conditional access policy, per the values below:
+
+<pre>
+  Users > Include > <b>All users</b>
+
+  Target resources > Include > <b>All resources (formerly 'All cloud apps') </b>
+
+  Access controls > Grant > Grant Access > <b>Require multifactor authentication</b>
+</pre>
+
+**Option 3**. Create a conditional access policy that enforces the built-in authentication strength named "Multifactor authentication" and does not dictate a specific MFA method. Configure the following policy settings in the new conditional access policy, per the values below:
+
+<pre>
+  Users > Include > <b>All users</b>
+
+  Target resources > Include > <b>All resources (formerly 'All cloud apps') </b>
+
+  Access controls > Grant > Grant Access > <b>Require authentication strength</b> > <b>Multifactor authentication</b>
+</pre>
+
+#### MS.AAD.3.3v2 Instructions
+If Microsoft Authenticator is in use, configure Authenticator to display context information to users when they log in.
+
+1. In **Microsoft Entra admin center**, click **Protection > Authentication methods > Microsoft Authenticator**.
+2. Click the **Configure** tab.
+3. For **Allow use of Microsoft Authenticator OTP** select *No*.
+4. Under **Show application name in push and passwordless notifications** select **Status > Enabled** and **Target > Include > All users**.
+5. Under **Show geographic location in push and passwordless notifications** select **Status > Enabled** and **Target > Include > All users**.
+6. Select **Save**
+
+
+#### MS.AAD.3.4v1 Instructions
+1. Go through the process of [How to migrate MFA and SSPR policy settings to the Authentication methods policy for Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/authentication/how-to-authentication-methods-manage).
+2. Once ready to finish the migration, [set the **Manage Migration** option to **Migration Complete**](https://learn.microsoft.com/en-us/entra/identity/authentication/how-to-authentication-methods-manage#finish-the-migration).
+
+#### MS.AAD.3.5v2 Instructions
+1. In **Microsoft Entra admin center** , click **Protection > Authentication methods**
+2. Click on the **SMS**, **Voice Call**, and **Email OTP** authentication methods and disable each of them. Their statuses should be **Enabled > No** on the **Authentication methods > Policies** page.
+
+#### MS.AAD.3.6v1 Instructions
+
+1. Create a conditional access policy enforcing phishing-resistant MFA for highly privileged roles.  Configure the following policy settings in the new conditional access policy, per the values below:
+
+<pre>
+  Users > Include > Select users and groups > Directory roles > <b>select each of the roles listed in the Highly Privileged Roles section at the top of this document</b>
+
+  Target resources > Include > <b>All resources (formerly 'All cloud apps') </b>
+
+  Access controls > Grant > Grant Access > Require authentication strength > <b>Phishing-resistant MFA</b>
+</pre>
+
+#### MS.AAD.3.7v1 Instructions
+
+1. Create a conditional access policy requiring a user's device to be either Microsoft Entra ID hybrid joined or compliant during authentication. Configure the following policy settings in the new conditional access policy, per the values below:
+
+<pre>
+  Users > Include > <b>All users</b>
+
+  Target resources > Include > <b>All resources (formerly 'All cloud apps') </b>
+
+  Access controls > Grant > Grant Access > <b>Require device to be marked as compliant</b> and <b>Require Microsoft Entra ID hybrid joined device</b> > For multiple controls > <b>Require one of the selected controls</b>
+</pre>
+
+#### MS.AAD.3.8v1 Instructions
+
+1. Create a conditional access policy requiring a user to be on a managed device when registering for MFA. Configure the following policy settings in the new conditional access policy, per the values below:
+
+<pre>
+  Users > Include > <b>All users</b>
+
+  Target resources > User actions > <b>Register security information</b>
+
+  Access controls > Grant > Grant Access > <b>Require device to be marked as compliant</b> and <b>Require Microsoft Entra ID hybrid joined device</b> > For multiple controls > <b>Require one of the selected controls</b>
+</pre>
+
+#### MS.AAD.3.9v1 Instructions
+
+1. Create a Conditional Access policy to block device code flow
+
+<pre>
+  Users > Include > <b>All users</b>
+
+  Target resources > Include > <b>All resources (formerly 'All cloud apps') </b>
+
+  Conditions > Authentication Flows > Configure > <b>Yes</b> > Select <b>Device code flow</b>
+
+  Access controls > Grant > <b>Block Access</b>
+</pre>
+
+## 4. Centralized Log Collection
+
+This section provides policies to reduce security risks related to the lack of security logs, which hampers security visibility.
+
+### Policies
+#### MS.AAD.4.1v1
+Security logs SHALL be sent to the agency's security operations center for monitoring.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#msaad41v1-instructions)
+
+<!--Policy: MS.AAD.4.1v1; Criticality: SHALL -->
+- _Rationale:_ The security risk of not having visibility into cyber attacks is reduced by collecting logs in the agency’s centralized security detection infrastructure. This makes security events available for auditing, query, and incident response.
+- _Last modified:_ June 2023
+- _Note:_ The following Microsoft Entra ID logs (configured in diagnostic settings), are required: `AuditLogs, SignInLogs, RiskyUsers, UserRiskEvents, NonInteractiveUserSignInLogs, ServicePrincipalSignInLogs, ADFSSignInLogs, RiskyServicePrincipals, ServicePrincipalRiskEvents, EnrichedOffice365AuditLogs, MicrosoftGraphActivityLogs`. If managed identities are used for Azure resources, also send the `ManagedIdentitySignInLogs` log type. If the Microsoft Entra ID Provisioning Service is used to provision users to software-as-a-service (SaaS) apps or other systems, also send the `ProvisioningLogs` log type.
+- _Note:_ Agencies can benefit from security detection capabilities offered by the CISA Cloud Log Aggregation Warehouse (CLAW) system. Agencies are urged to send the logs to CLAW. Contact CISA at cyberliason@cisa.dhs.gov to request integration instructions.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AU-4
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562.008: Disable or Modify Cloud Logs](https://attack.mitre.org/techniques/T1562/008/)
+
+### Resources
+
+- [Everything you wanted to know about Security and Audit Logging in Office 365](https://thecloudtechnologist.com/2021/10/15/everything-you-wanted-to-know-about-security-and-audit-logging-in-office-365/)
+
+- [What are Microsoft Entra sign-in logs??](https://learn.microsoft.com/en-us/entra/identity/monitoring-health/concept-sign-ins)
+
+- [National Cybersecurity Protection System-Cloud Interface Reference Architecture Volume One: General Guidance](https://www.cisa.gov/sites/default/files/publications/NCPS%20Cloud%20Interface%20RA%20Volume%20One%20%282021-05-14%29.pdf)
+
+### License Requirements
+
+- An Azure subscription may be required to send logs to an external system, such as the agency's Security Information and Event Management (SIEM).
+
+### Implementation
+
+#### MS.AAD.4.1v1 Instructions
+
+Follow the configuration instructions unique to the products and integration patterns at your organization to send the security logs to the security operations center for monitoring.
+
+## 5. Application Registration and Consent
+
+This section provides policies that help reduce security risk of malicious applications or service principals added to the tenant by non-privileged users. Malicious applications can perform many of the same operations as interactive users and can access data on behalf of compromised users. These policies apply to custom-developed applications and applications published by third-party vendors.
+
+### Policies
+#### MS.AAD.5.1v1
+Only administrators SHALL be allowed to register applications.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.5.1v1; Criticality: SHALL -->
+- _Rationale:_ Application access for the tenant presents a heightened security risk compared to interactive user access because applications are typically not subject to critical security protections, such as MFA policies. Reduce risk of unauthorized users installing malicious applications into the tenant by ensuring that only specific privileged users can register applications.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(10), CM-5
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.001: Additional Cloud Credentials](https://attack.mitre.org/techniques/T1098/001/)
+    - [T1098.003: Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003/)
+
+#### MS.AAD.5.2v1
+User consent to applications SHALL be restricted.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.5.2v1; Criticality: SHALL -->
+- _Rationale:_ Restricting user consent for applications reduces risk of users giving insecure applications access to their data via [consent grant attacks](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/detect-and-remediate-illicit-consent-grants?view=o365-worldwide).
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(10), CM-5
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.001: Additional Cloud Credentials](https://attack.mitre.org/techniques/T1098/001/)
+    - [T1098.003: Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003/)
+
+#### MS.AAD.5.3v1
+An admin consent workflow SHALL be configured for applications.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.5.3v1; Criticality: SHALL -->
+- _Rationale:_ Configuring an admin consent workflow reduces the risk of the previous policy by setting up a process for users to securely request access to applications necessary for business purposes. Administrators have the opportunity to review the permissions requested by new applications and approve or deny access based on a risk assessment.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-4
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.001: Additional Cloud Credentials](https://attack.mitre.org/techniques/T1098/001/)
+    - [T1098.003: Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003/)
+
+#### MS.AAD.5.5v1
+Application Password Addition SHOULD be blocked.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.5.5v1; Criticality: SHOULD -->
+- _Rationale:_ Applications that use client secrets might store them in configuration files, hardcode them in scripts, or risk exposure in other ways. The complexities of secret management make client secrets susceptible to leaks and attractive to attackers. Blocking password addition forces the use of more secure certificate-based authentication.
+- _Last modified:_ April 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-5
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.001: Additional Cloud Credentials](https://attack.mitre.org/techniques/T1098/001/)
+  - [T1528: Steal Application Access Token](https://attack.mitre.org/techniques/T1528/)
+
+#### MS.AAD.5.6v1
+Application password lifetime SHOULD be restricted to 180 days or less.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.5.6v1; Criticality: SHOULD -->
+- _Rationale:_ Long-lived credentials increase the window of opportunity for attackers to exploit compromised secrets. Enforcing a maximum password lifetime of 180 days ensures regular credential rotation, reducing the impact of credential theft and improving overall security hygiene.
+- _Last modified:_ April 2026
+- _Note:_ Due to how Microsoft Entra ID evaluates the MaxLifetime restriction using "less than" (not "less than or equal to"), the portal setting must be configured to **181 days** to enforce the requirement of "180 days or less."
+- _Note:_ This policy applies only if password credentials are permitted. Microsoft and CISA recommend blocking password addition entirely (MS.AAD.5.5v1) as the preferred approach.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-5, SC-12
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1552: Unsecured Credentials](https://attack.mitre.org/techniques/T1552/)
+    - [T1552.001: Credentials In Files](https://attack.mitre.org/techniques/T1552/001/)
+
+#### MS.AAD.5.7v1
+Application certificate lifetime SHOULD be restricted to 365 days or less.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.5.7v1; Criticality: SHOULD -->
+- _Rationale:_ While certificates provide more secure authentication than passwords, long-lived certificates can still be compromised. Limiting certificate lifetime to 365 days reduces the risk of exploitation while balancing operational overhead. Regular certificate rotation is a security best practice that minimizes exposure from compromised keys.
+- _Note:_ Due to how Microsoft Entra ID evaluates the MaxLifetime restriction using "less than" (not "less than or equal to"), the portal setting must be configured to **366 days** to enforce the requirement of "365 days or less."
+- _Last modified:_ April 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-12, IA-5
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1649: Steal or Forge Authentication Certificates](https://attack.mitre.org/techniques/T1649/)
+
+### Resources
+
+- [Restrict Application Registration for Non-Privileged Users](https://www.trendmicro.com/cloudoneconformity/knowledge-base/azure/ActiveDirectory/users-can-register-applications.html)
+
+- [Configure the admin consent workflow](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-admin-consent-workflow)
+- [Configure restrictions on how applications can be configured](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-app-management-policies)
+- [Tutorial: Enforce secret and certificate standards using application management policies](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/tutorial-enforce-secret-standards)
+- [Application Management Policies API Overview](https://learn.microsoft.com/en-us/graph/api/resources/applicationauthenticationmethodpolicy)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.AAD.5.1v1 Instructions
+
+1.  In **Microsoft Entra admin center**, select **Users**.
+
+2. Select **User settings**.
+
+3. For **Users can register applications**, select **No**.
+
+4. Click **Save**.
+
+#### MS.AAD.5.2v1 Instructions
+
+There are a couple of configuration options to restrict user consent. Each option is described below, followed by its respective instructions.
+
+- **Option 1** - Most restrictive - Do not allow user consent for applications. An administrator is required to consent for all applications. Users can submit requests to use an application via the admin consent workflow but they cannot perform the consent themselves.
+- **Option 2** - More flexible - Allow users to consent to applications from Microsoft verified publishers that use low-risk permissions. When selecting this option, an administrator must configure a set of permissions considered low risk in the **Consent and permissions** > **Permission classifications** page in the Microsoft Entra admin center.
+
+**Option 1**. Do not allow user consent.
+
+1.  In **Microsoft Entra admin center** select **Enterprise Applications**.
+
+2. Under **Security**, select **Consent and permissions**. Then select **User Consent Settings**.
+
+3. Under **User consent for applications**, select **Do not allow user consent**.
+
+4. Click **Save**.
+
+**Option 2**. Allow restricted user consent.
+
+1.  In **Microsoft Entra admin center** select **Enterprise apps**.
+
+2. Under **Security**, select **Consent and permissions**. Then select **User Consent Settings**.
+
+3. Under **User consent for applications**, select **Allow user consent for apps from verified publishers, for selected permissions**.
+
+4. Click **Save**.
+
+5. In the page navigation menu, select **Permission classifications**.
+
+6. Click on the **Low** tab.
+
+7. [Add a list of low risk application permissions that users will be able to consent to](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-permission-classifications). We recommend only including permissions that provide minimal access to a user's data. For a reference of permissions that are considered risky and should be avoided [go to this JSON file and examine the permissions listed](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/schemas/RiskyAppPermissions.json) in the **Delegated** sections under Microsoft Graph and other apps.
+
+#### MS.AAD.5.3v1 Instructions
+
+1.  In **Microsoft Entra admin center**  create a new Microsoft Entra ID Group that contains admin users responsible for reviewing and adjudicating application consent requests. Group members will be notified when users request consent for new applications.
+
+2. Then in **Microsoft Entra admin center**  under **Applications**, select **Enterprise Applications**.
+
+3. Under **Security**, select **Consent and permissions**. Then select **Admin consent settings**.
+
+4. Under **Admin consent requests** navigate to **Users can request admin consent to apps they are unable to consent to** and select **Yes**.
+
+5. Under **Who can review admin consent requests**, select **+ Add groups** and select the group responsible for reviewing and adjudicating app requests (created in step one above).
+
+6. Click **Save**.
+
+#### MS.AAD.5.5v1 Instructions
+
+1. In **Microsoft Entra admin center**, select **Enterprise apps**.
+
+2. Under **Security**, select **Application policies**.
+
+3. Select **Block password addition**.
+
+4. Set status to **On**. Ensure **Applies to** is set to **All applications**.
+
+5. Leave **Only apply to apps created after** blank. Setting a date allows apps created before that date to bypass this restriction.
+
+6. Click **Save**.
+
+#### MS.AAD.5.6v1 Instructions
+
+1. In **Microsoft Entra admin center**, select **Enterprise apps**.
+
+2. Under **Security**, select **Application policies**.
+
+3. Select **Restrict max password lifetime**.
+
+4. Set status to **On**. Set maximum lifetime to **181 days**. Ensure **Applies to** is set to **All applications**.
+
+5. Leave **Only apply to apps created after** blank. Setting a date allows apps created before that date to bypass this restriction.
+
+6. Click **Save**.
+
+#### MS.AAD.5.7v1 Instructions
+
+1. In **Microsoft Entra admin center**, select **Enterprise apps**.
+
+2. Under **Security**, select **Application policies**.
+
+3. Select **Restrict max certificate lifetime**.
+
+4. Set status to **On**. Set maximum lifetime to **366 days**. Ensure **Applies to** is set to **All applications**.
+
+5. Leave **Only apply to apps created after** blank. Setting a date allows apps created before that date to bypass this restriction.
+
+6. Click **Save**.
+
+## 6. Passwords
+
+This section provides policies that reduce security risks associated with legacy password practices.
+
+### Policies
+#### MS.AAD.6.1v1
+User passwords SHALL NOT expire.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.6.1v1; Criticality: SHALL -->
+- _Rationale:_ The National Institute of Standards and Technology (NIST), OMB, and Microsoft have published guidance indicating mandated periodic password changes make user accounts less secure. For example, OMB-22-09 states, "Password policies must not require use of special characters or regular rotation."
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-5(1)
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+### Resources
+
+- [Password expiration requirements for users](https://learn.microsoft.com/en-us/microsoft-365/admin/misc/password-policy-recommendations?view=o365-worldwide#password-expiration-requirements-for-users)
+
+- [passwordValidityPeriodInDays property](https://learn.microsoft.com/en-us/graph/api/resources/domain?view=graph-rest-1.0#properties)
+
+- [Eliminate bad passwords using Microsoft Entra Password Protection](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-password-ban-bad)
+
+- [NIST Special Publication 800-63B - Digital Identity Guidelines](https://pages.nist.gov/800-63-3/sp800-63b.html)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.AAD.6.1v1 Instructions
+
+> **Note:** Tenants created after October 2021 have password expiration disabled by default (`passwordValidityPeriodInDays = null`), which Microsoft treats as equivalent to "never expire." Tenants created before October 2021, or any tenant where the policy was explicitly configured and then reverted, will show `2147483647` (INT_MAX). ScubaGear treats both values as compliant. The M365 admin center password expiration checkbox applies to all managed domains in the tenant. If a tenant has **multiple root domains**, use the PowerShell in Step 2 to audit all of them and remediate any that have a finite expiration period set.
+
+1. Sign in to the [Microsoft 365 admin center](https://admin.microsoft.com) and [configure the **Password expiration policy** to **Set passwords to never expire**](https://learn.microsoft.com/en-us/microsoft-365/admin/manage/set-password-expiration-policy?view=o365-worldwide#set-password-expiration-policy).
+
+2. Optionally, verify and remediate all root domains via PowerShell. This is useful if any domain had a finite expiration configured explicitly. This uses `Invoke-MgGraphRequest`, which is included with the `Microsoft.Graph.Authentication` module already required by ScubaGear. To audit only, connect with `Domain.Read.All`; to also remediate, use `Domain.ReadWrite.All`.
+
+  ```powershell
+  Connect-MgGraph -Scopes "Domain.ReadWrite.All" # or alternatively "Domain.Read.All" for determining which domains are in a non-compliant state.
+
+  $NonCompliantDomains = (Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/v1.0/domains").value | Where-Object {
+    $_.isRoot -and $_.isVerified -and
+    $null -ne $_.passwordValidityPeriodInDays -and
+    $_.passwordValidityPeriodInDays -ne [int32]::MaxValue
+  }
+
+  Write-Host $NonCompliantDomains | Format-List
+
+  # Remediate each non-compliant domain
+  Invoke-MgGraphRequest -Method PATCH -Uri "https://graph.microsoft.com/v1.0/domains/example.com" `
+    -Body @{ passwordValidityPeriodInDays = [int32]::MaxValue }
+
+  # Verify domain configurations
+  $AllDomains = (Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/v1.0/domains").value | Where-Object {
+    $_.isRoot -and $_.isVerified
+  }
+
+  Write-Host "All current domain password expiration policies"
+  foreach ($Domain in $AllDomains) {
+    Write-Host "Domain passwordValidityPeriodInDays: $($Domain.id) $($Domain.passwordValidityPeriodInDays)"
+  }
+  ```
+
+## 7. Highly Privileged User Access
+
+This section provides policies that help reduce security risks related to the usage of [highly privileged Microsoft Entra ID built-in roles](#highly-privileged-roles). Privileged administrative users have access to operations that can undermine the security of the tenant by changing configurations and security policies. Special protections are necessary to secure this level of access.
+
+Some of the policy implementations in this section reference specific features of the Microsoft Entra ID Privileged Identity Management (PIM) service that provides Privileged Access Management (PAM) capabilities. As an alternative to Microsoft Entra ID PIM, third-party products and services with equivalent PAM capabilities can be leveraged.
+
+### Policies
+#### MS.AAD.7.1v1
+A minimum of two users and a maximum of eight users SHALL be provisioned with the Global Administrator role.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.7.1v1; Criticality: SHALL -->
+- _Rationale:_  The Global Administrator role provides unfettered access to the tenant. Limiting the number of users with this level of access makes tenant compromise more challenging. Microsoft recommends fewer than five users in the Global Administrator role. However, additional user accounts, up to eight, may be necessary to support emergency access and some operational scenarios.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(5)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.003: Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003/)
+
+#### MS.AAD.7.2v1
+Privileged users SHALL be provisioned with finer-grained roles instead of Global Administrator.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.7.2v1; Criticality: SHALL -->
+- _Rationale:_ Many privileged administrative users do not need unfettered access to the tenant to perform their duties. By assigning them to roles based on least privilege, the risks associated with having their accounts compromised are reduced.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-5
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.003: Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003/)
+  - [T1651: Cloud Administration Command](https://attack.mitre.org/techniques/T1651/)
+  - [T1136: Create Account](https://attack.mitre.org/techniques/T1136/)
+    - [T1136.003: Cloud Account](https://attack.mitre.org/techniques/T1136/003/)
+
+#### MS.AAD.7.3v1
+Privileged users SHALL be provisioned cloud-only accounts separate from an on-premises directory or other federated identity providers.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.7.3v1; Criticality: SHALL -->
+- _Rationale:_ By provisioning cloud-only Microsoft Entra ID user accounts to privileged users, the risks associated with a compromise of on-premises federation infrastructure are reduced. It is more challenging for the adversary to pivot from the compromised environment to the cloud with privileged access.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(5)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1556: Modify Authentication Process](https://attack.mitre.org/techniques/T1556/)
+    - [T1556.007: Hybrid Identity](https://attack.mitre.org/techniques/T1556/007/)
+
+#### MS.AAD.7.4v1
+Permanent active role assignments SHALL NOT be allowed for highly privileged roles.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/configuration.md#privileged-user-policy-exclusions)
+
+
+<!--Policy: MS.AAD.7.4v1; Criticality: SHALL -->
+<!--ExclusionType: RoleExclusions-->
+- _Rationale:_ Instead of giving users permanent assignments to privileged roles, provisioning access just in time lessens exposure if those accounts become compromised. In Microsoft Entra ID PIM or an alternative PAM system, just in time access can be provisioned by assigning users to roles as eligible instead of perpetually active.
+- _Last modified:_ June 2023
+- _Note:_ Exceptions to this policy are:
+  - Emergency access accounts that need perpetual access to the tenant in the rare event of system degradation or other scenarios.
+  - Some types of service accounts that require a user account with privileged roles; since these accounts are used by software programs, they cannot perform role activation.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-2
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.003: Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003/)
+
+#### MS.AAD.7.5v1
+Provisioning users to highly privileged roles SHALL NOT occur outside of a PAM system.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.7.5v1; Criticality: SHALL -->
+- _Rationale:_ Provisioning users to privileged roles within a PAM system enables enforcement of numerous privileged access policies and monitoring. If privileged users are assigned directly to roles in the M365 admin center or via PowerShell outside of the context of a PAM system, a significant set of critical security capabilities are bypassed.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-2
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1651: Cloud Administration Command](https://attack.mitre.org/techniques/T1651/)
+
+#### MS.AAD.7.6v1
+Activation of the Global Administrator role SHALL require approval.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.7.6v1; Criticality: SHALL -->
+- _Rationale:_ Requiring approval for a user to activate Global Administrator, which provides unfettered access, makes it more challenging for an attacker to compromise the tenant with stolen credentials, and it provides visibility of activities indicating a compromise is taking place.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(1)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.003: Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003/)
+
+#### MS.AAD.7.7v1
+Eligible and active highly privileged role assignments SHALL trigger an alert.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.7.7v1; Criticality: SHALL -->
+- _Rationale:_ Closely monitor assignment of the highest privileged roles for signs of compromise. Send assignment alerts to enable the security monitoring team to detect compromise attempts.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-2(1)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.003: Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003/)
+
+#### MS.AAD.7.8v1
+User activation of the Global Administrator role SHALL trigger an alert.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.AAD.7.8v1; Criticality: SHALL -->
+- _Rationale:_ Closely monitor activation of the Global Administrator role for signs of compromise. Send activation alerts to enable the security monitoring team to detect compromise attempts.
+- _Last modified:_ June 2023
+- _Note:_ It is recommended to prioritize user activation of Global Administrator as one of the most important events to monitor and respond to.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(9)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.003: Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003/)
+
+#### MS.AAD.7.9v1
+User activation of other highly privileged roles SHOULD trigger an alert.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.AAD.7.9v1; Criticality: SHOULD -->
+- _Rationale:_ Closely monitor activation of high-risk roles for signs of compromise. Send activation alerts to enable the security monitoring team to detect compromise attempts. In some environments, activating privileged roles can generate a significant number of alerts.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(9)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.003: Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003/)
+  - [T1136: Create Account](https://attack.mitre.org/techniques/T1136/)
+    - [T1136.003: Cloud Account](https://attack.mitre.org/techniques/T1136/003/)
+
+
+### Resources
+
+- [Limit number of Global Administrators to less than 5](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices#5-limit-the-number-of-global-administrators-to-less-than-5)
+
+- [Implement Privilege Access Management](https://learn.microsoft.com/en-us/azure/security/fundamentals/steps-secure-identity#implement-privilege-access-management)
+
+- [Assign Microsoft Entra roles in Privileged Identity Management](https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-how-to-add-role-to-user)
+
+- [Privileged Identity Management (PIM) for Groups](https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/concept-pim-for-groups)
+
+- [Approve or deny requests for Microsoft Entra roles in Privileged Identity Management](https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-approval-workflow)
+
+- [Configure security alerts for Microsoft Entra roles in Privileged Identity Management](https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-how-to-configure-security-alerts)
+
+### License Requirements
+
+- Policies [MS.AAD.7.4v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad74v1), [MS.AAD.7.5v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad75v1), [MS.AAD.7.6v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad76v1), [MS.AAD.7.7v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad77v1), [MS.AAD.7.8v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad78v1), and [MS.AAD.7.9v1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/aad.md#msaad79v1) require a Microsoft Entra ID P2 license; however, a third-party Privileged Access Management (PAM) solution may also be used to satisfy the requirements. If a third-party solution is used, then a P2 license is not required for the respective policies.
+### Implementation
+
+The following implementation instructions that reference the Microsoft Entra ID PIM service will vary if using a third-party PAM system instead.
+
+#### MS.AAD.7.1v1 Instructions
+
+When counting the number of users assigned to the Global Administrator role, count each user only once.
+
+1. In **Microsoft Entra admin center**  count the number of users assigned to the **Global Administrator** role. Count users that are assigned directly to the role and users assigned via group membership. If you have Microsoft Entra ID PIM, count both the **Eligible assignments** and **Active assignments**. If any of the groups assigned to Global Administrator are enrolled in PIM for Groups, also count the number of group members from the PIM for Groups portal **Eligible** assignments.
+
+2. Validate that there are a total of two to eight users assigned to the Global Administrator role.
+
+#### MS.AAD.7.2v1 Instructions
+
+This policy is based on the ratio below:
+
+`X = (Number of users assigned to the Global Administrator role) / (Number of users assigned to other highly privileged roles)`
+
+1. Follow the instructions for policy MS.AAD.7.1v1 above to get a count of users assigned to the Global Administrator role.
+
+2. Follow the instructions for policy MS.AAD.7.1v1 above but get a count of users assigned to the other highly privileged roles (not Global Administrator). If a user is assigned to both Global Administrator and other roles, only count that user for the Global Administrator assignment.
+
+3. Divide the value from step 2 from the value from step 1 to calculate X. If X is less than or equal to 1 then the tenant is compliant with the policy.
+
+#### MS.AAD.7.3v1 Instructions
+
+1. Perform the steps below for each highly privileged role. We reference the Global Administrator role as an example.
+
+2. Create a list of all the users assigned to the **Global Administrator** role. Include users that are assigned directly to the role and users assigned via group membership. If you have Microsoft Entra ID PIM, include both the **Eligible assignments** and **Active assignments**. If any of the groups assigned to Global Administrator are enrolled in PIM for Groups, also include group members from the PIM for Groups portal **Eligible** assignments.
+
+3. For each highly privileged user in the list, execute the Powershell code below but replace the `username@somedomain.com` with the principal name of the user who is specific to your environment. You can get the data value from the **Principal name** field displayed in the Microsoft Entra ID portal.
+
+    ```
+    Connect-MgGraph
+    Get-MgBetaUser -Filter "userPrincipalName eq 'username@somedomain.com'" | FL
+    ```
+
+6. Review the output field named **OnPremisesImmutableId**. If this field contains a data value, it means that the  user is not cloud-only. If the user is not cloud-only, create a cloud-only account for that user, assign the user to their respective roles and then remove the account that is not cloud-only from Microsoft Entra ID.
+
+#### MS.AAD.7.4v1 Instructions
+
+1. In **Microsoft Entra admin center**  select **Roles and admins**. Perform the steps below for each highly privileged role. We reference the Global Administrator role as an example.
+
+2. Select the **Global Administrator** role.
+
+3. Under **Manage**, select **Assignments** and click the **Active assignments** tab.
+
+4. Verify there are no users or groups with a value of **Permanent** in the **End time** column. If there are any, recreate those assignments to have an expiration date using Microsoft Entra ID PIM or an alternative PAM system. If a group is identified and it is enrolled in PIM for Groups, see the exception cases below for details.
+
+Exception cases:
+- Emergency access accounts that require perpetual active assignment.
+- Service accounts that require perpetual active assignment.
+- If using PIM for Groups, a group that is enrolled in PIM is allowed to have a perpetual active assignment to a role because activation is handled by PIM for Groups.
+
+#### MS.AAD.7.5v1 Instructions
+
+1. Perform the steps below for each highly privileged role. We reference the Global Administrator role as an example.
+
+2. In **Microsoft Entra admin center**  select **Roles and Admins**.
+
+3. Select the **Global Administrator** role.
+
+4. Under **Manage**, select **Assignments** and click the **Active assignments** tab.
+
+5. For each user or group listed, examine the value in the **Start time** column. If it contains a value of **-**, this indicates the respective user/group was assigned to that role outside of Microsoft Entra ID PIM. If the role was assigned outside of Microsoft Entra ID PIM, delete the assignment and recreate it using Microsoft Entra ID PIM.
+
+#### MS.AAD.7.6v1 Instructions
+
+1. In the **Microsoft Entra Portal**, under **Identity Governance**, select **Privileged Identity Management (PIM)**, and then under **Manage**, select **Microsoft Entra roles**.
+
+2. Under **Manage**, select **Roles**.
+
+  1.  Select the **Global Administrator** role in the list.
+  2.  Click **Settings**.
+  3.  Click **Edit**.
+  4.  Select the **Require approval to activate** option.
+  5.  Click **Update**.
+
+3. Review the list of groups that are actively assigned to the **Global Administrator** role. If any of the groups are enrolled in PIM for Groups, also apply the same configurations as steps 2-7 above to each PIM group's **Member** settings.
+
+#### MS.AAD.7.7v1 Instructions
+
+1.  In the **Microsoft Entra Portal**, under **Identity Governance**, select **Privileged Identity Management (PIM)**, and then under **Manage**, select **Microsoft Entra roles**.
+
+2. Under **Manage**, select **Roles**. Perform the steps below for each highly privileged role. We reference the Global Administrator role as an example:
+
+  1. Click the **Global Administrator** role.
+  2. Click **Settings** and then click **Edit**.
+  3. Click the **Notification** tab.
+  4. Under **Send notifications when members are assigned as eligible to this role**, in the **Role assignment alert > Additional recipients** textbox, enter the email address of the security monitoring mailbox configured to receive privileged role assignment alerts.
+  5. Under **Send notifications when members are assigned as active to this role**, in the **Role assignment alert > Additional recipients** textbox, enter the email address of the security monitoring mailbox configured to receive privileged role assignment alerts.
+  6. Click **Update**.
+
+3. For each of the highly privileged roles, if they have any PIM groups actively assigned to them, apply the same configurations as steps 2-8 above to each PIM group's **Member** settings.
+
+#### MS.AAD.7.8v1 Instructions
+
+1. In the **Microsoft Entra Portal**, under **Identity Governance**, select **Privileged Identity Management (PIM)**. Under **Manage**, select **Microsoft Entra roles**.
+
+2. Click the **Global Administrator** role.
+
+3. Click **Settings** then click **Edit**.
+
+4. Click the **Notification** tab.
+
+5. Under **Send notifications when eligible members activate this role**, in the **Role activation alert** select the  **Additional recipients** textbox and enter the email address of the security monitoring mailbox configured to receive Global Administrator activation alerts.
+
+6. Click **Update**.
+
+7. If the Global Administrator role has any PIM groups actively assigned to it, then also apply the same configurations per the steps above to each PIM group's **Member** settings.
+
+#### MS.AAD.7.9v1 Instructions
+
+ 1. Follow the same instructions as MS.AAD.7.8v1 for each of the highly privileged roles (other than Global Administrator) but enter a security monitoring mailbox different from the one used to monitor Global Administrator activations.
+
+ 2. For each of the highly privileged roles, if they have any PIM groups actively assigned to them, then also apply the same configurations per step 1 to each PIM group's **Member** settings.
+
+## 8. Guest User Access
+
+This section provides policies that help reduce security risks related to integrating M365 guest users. A guest user is a specific type of external user who belongs to a separate organization but can access files, meetings, Teams, and other data in the target tenant. It is common to invite guest users to a tenant for cross-agency collaboration purposes.
+
+### Policies
+#### MS.AAD.8.1v1
+Guest users SHOULD have limited or restricted access to Microsoft Entra ID directory objects.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.AAD.8.1v1; Criticality: SHOULD -->
+- _Rationale:_ Limiting the amount of object information available to guest users in the tenant, reduces malicious reconnaissance exposure if a guest account is compromised or created by an adversary.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1087: Account Discovery](https://attack.mitre.org/techniques/T1087/)
+    - [T1087.003: Email Account](https://attack.mitre.org/techniques/T1087/003/)
+    - [T1087.004: Cloud Account](https://attack.mitre.org/techniques/T1087/004/)
+  - [T1526: Cloud Service Discovery](https://attack.mitre.org/techniques/T1526/)
+
+#### MS.AAD.8.2v1
+Only users with the Guest Inviter role SHOULD be able to invite guest users.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.AAD.8.2v1; Criticality: SHOULD -->
+- _Rationale:_ By only allowing an authorized group of individuals to invite external users to create accounts in the tenant, an agency can enforce a guest user account approval process, reducing the risk of unauthorized account creation.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.003: Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003/)
+
+#### MS.AAD.8.3v1
+Guest invites SHOULD only be allowed to specific external domains that have been authorized by the agency for legitimate business purposes.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#msaad83v1-instructions)
+
+<!--Policy: MS.AAD.8.3v1; Criticality: SHOULD -->
+- _Rationale:_ Limiting which domains can be invited to create guest accounts in the tenant helps reduce the risk of users from unauthorized external organizations getting access.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.001: Default Accounts](https://attack.mitre.org/techniques/T1078/001/)
+
+### Resources
+
+- [Configure external collaboration settings for B2B in Microsoft Entra External ID](https://learn.microsoft.com/en-us/entra/external-id/external-collaboration-settings-configure)
+
+- [Compare member and guest default permissions](https://learn.microsoft.com/en-us/entra/fundamentals/users-default-permissions#compare-member-and-guest-default-permissions)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.AAD.8.1v1 Instructions
+
+1. In **Microsoft Entra admin center**  select **External Identities > External collaboration settings**.
+
+2. Under **Guest user access**, select either **Guest users have limited access to properties and memberships of directory objects** or **Guest user access is restricted to properties and memberships of their own directory objects (most restrictive)**.
+
+3. Click **Save**.
+
+#### MS.AAD.8.2v1 Instructions
+
+1. In **Microsoft Entra admin center**  select **External Identities > External collaboration settings**.
+
+2.  Under **Guest invite settings**, select **Only users assigned to specific admin roles can invite guest users**.
+
+3. Click **Save**.
+
+#### MS.AAD.8.3v1 Instructions
+
+1. In **Microsoft Entra admin center**  select **External Identities > External collaboration settings**.
+
+2. Under **Collaboration restrictions**, select **Allow invitations
+    only to the specified domains (most restrictive)**.
+
+3. Select **Target domains** and enter the names of the external domains authorized by the agency for guest user access.
+
+4. Click **Save**.
+
+## 9. AI Security
+
+This section provides policies that help reduce security risks related to the usage of AI Agents and automated services that interact with tenant resources.
+
+### Policies
+#### MS.AAD.9.1v1
+Risky AI agents SHALL be blocked.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.AAD.9.1v1; Criticality: SHALL -->
+- _Rationale:_ AI agents may access tenant resources using application permissiona and can perform actions autonomously. Blocking high-risk AI agents reduces the risk of unauthorized access and automated misuse of resources.
+- _Last modified:_ March 2026
+- _Note:_ This policy is not applicable to Government Community Cloud (GCC) High, and Department of Defense (DoD) tenants.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, AC-6, CM-7(4)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.004: Cloud Account](https://attack.mitre.org/techniques/T1078/004/)
+
+### Resources
+
+- [Block access by high-risk agent identities](https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-agent-block-high-risk)
+
+### License Requirements
+
+- Requires a Microsoft Entra ID P2 license
+
+### Implementation
+
+#### MS.AAD.9.1v1 Instructions
+
+1. Create a conditional access policy blocking High Risk AI Agents. Configure the following policy settings in the new conditional access policy, per the values below:
+
+<pre>
+  Assignments > Users, agents (Preview) or workload identities > What does this policy apply to? > Agents (Preview) > Include > <b>All agent identities (Preview) </b>
+
+  Target resources > Include > <b>All resources (formerly 'All cloud apps') </b>
+
+  Conditions > Agent risk (Preview) > Configure > Yes > Configure agent risk levels needed for policy to be enforced > <b>High </b>
+</pre>
+
+
+# Appendix A: Microsoft Entra ID hybrid Guidance
+
+Most of this document does not focus on securing Microsoft Entra ID hybrid environments. CISA released a separate [Hybrid Identity Solutions Architecture](https://www.cisa.gov/sites/default/files/2023-03/csso-scuba-guidance_document-hybrid_identity_solutions_architecture-2023.03.22-final.pdf) document addressing the unique implementation requirements of Microsoft Entra ID hybrid infrastructure.
+
+# Appendix B: Cross-tenant Access Guidance
+
+Some of the conditional access policies contained in this security baseline, if implemented as described, will impact guest user access to a tenant. For example, the policies require users to perform MFA and originate from a managed device to gain access. These requirements are also enforced for guest users. For these policies to work effectively with guest users, both the home tenant (the one the guest user belongs to) and the resource tenant (the target tenant) may need to configure their Microsoft Entra ID cross-tenant access settings.
+
+Microsoft’s [Authentication and Conditional Access for External ID](https://learn.microsoft.com/en-us/entra/external-id/authentication-conditional-access) provides an understanding of how MFA and device claims are passed from the home tenant to the resource tenant. To configure the inbound and outbound cross-tenant access settings in Microsoft Entra External ID, refer to Microsoft’s [Overview: Cross-tenant access with Microsoft Entra External ID](https://learn.microsoft.com/en-us/entra/external-id/cross-tenant-access-overview).
+
+**`TLP:CLEAR`**

--- a/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md
+++ b/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/defender.md
@@ -1,0 +1,964 @@
+**`TLP:CLEAR`**
+
+# CISA M365 Secure Configuration Baseline for Defender
+
+Microsoft 365 (M365) Defender is a cloud-based enterprise defense suite that coordinates prevention, detection, investigation, and response. This set of tools and features are used to detect many types of attacks.
+
+This baseline focuses on the features of Defender for Office 365, but some settings are actually configured in the Microsoft Purview portal. However, for simplicity, both the M365 Defender and Microsoft Purview portal items are contained in this baseline.
+
+Generally, use of Microsoft Defender is not required by the baselines of the core M365 products (Exchange Online, Teams, etc.). Should an agency elect to use Defender as their tool of choice, agencies should apply these baseline settings. Please note that some of the controls in the core baselines require the use of a dedicated security tool that provides comparable protection as Defender.   In addition to applying these controls, agencies should consider using a cloud access security broker to secure their environments as they adopt zero trust principles.
+
+The Secure Cloud Business Applications (SCuBA) project, run by the Cybersecurity and Infrastructure Security Agency (CISA), provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies’ cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for M365 help secure federal information assets stored within M365 cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government’s threats and risk tolerance with the knowledge that every organization has different threat models and risk tolerance. While use of these baselines will be mandatory for civilian Federal Government agencies, organizations outside of the Federal Government may also find these baselines to be useful references to help reduce risks.
+
+For non-Federal users, the information in this document is being provided “as is” for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products; CISA has no control over vendor changes to products offerings or features.  Accordingly, these SCuBA SCBs for M365 may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+
+
+> This document is marked TLP:CLEAR. Recipients may share this information without restriction. Information is subject to standard copyright rules. For more information on the Traffic Light Protocol, see https://www.cisa.gov/tlp.
+
+## License Compliance and Copyright
+Portions of this document are adapted from documents in Microsoft's [M365](https://github.com/MicrosoftDocs/microsoft-365-docs/blob/public/LICENSE) and [Azure](https://github.com/MicrosoftDocs/azure-docs/blob/main/LICENSE) GitHub repositories. The respective documents are subject to copyright and are adapted under the terms of the Creative Commons Attribution 4.0 International license. Sources are linked throughout this document. The United States government has adapted selections of these documents to develop innovative and scalable configuration standards to strengthen the security of widely used cloud-based software services.
+
+## Assumptions
+The agency has identified a set of user accounts that are considered sensitive accounts. See [Key Terminology](#key-terminology) for a detailed description of sensitive accounts.
+
+The **License Requirements** sections of this document assume the organization is using an [M365 E3](https://www.microsoft.com/en-us/microsoft-365/compare-microsoft-365-enterprise-plans) or [G3](https://www.microsoft.com/en-us/microsoft-365/government) license level at a minimum. Therefore, only licenses not included in E3/G3 are listed.
+
+## Key Terminology
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+The following are key terms and descriptions used in this document.
+
+**Sensitive Accounts**: This term denotes a set of user accounts that have access to sensitive and high-value information. Certain accounts—like those belonging to CEOs, CFOs, CISOs, and IT administrators—have access to highly sensitive data and critical systems, making them prime targets for cyberattacks. These accounts, referred to as priority accounts, require enhanced security measures to minimize the risk of compromise.
+
+**BOD 25-01 Requirement**: This indicator means that the policy is required under CISA BOD 25-01.
+
+**Automated Check**: This indicator means that the policy can be automatically checked via ScubaGear. See the [Quick Start Guide](../../../README.md#quick-start-guide) for help getting started.
+
+**Requires Configuration**: This indicator means that ScubaGear requires configuration via config file in order to check the policy.
+
+**Manual**: This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. Preset Security Profiles
+
+Microsoft Defender defines three [preset security
+profiles](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/preset-security-policies?view=o365-worldwide):
+built-in protection, standard, and strict. These preset policies are informed by Microsoft's observations, and are designed to strike the balance between usability and security. They allow administrators to enable the full feature set of Defender by simply adding users to the policies rather than manually configuring each setting.
+
+Within the standard and strict preset policies, users can be enrolled in [Exchange Online Protection](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/eop-about?view=o365-worldwide) (EOP) and [Defender for Office 365 protection](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/microsoft-defender-for-office-365-product-overview?view=o365-worldwide). Additionally, preset policies support configuration of [impersonation protection](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/anti-phishing-policies-about?view=o365-worldwide#impersonation-settings-in-anti-phishing-policies-in-microsoft-defender-for-office-365).
+
+### Policies
+#### MS.DEFENDER.1.1v1
+The standard and strict preset security policies SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.DEFENDER.1.1v1; Criticality: SHALL -->
+- _Rationale:_ Defender includes a large number of features and settings to protect users against threats. Using the preset security policies, administrators can help ensure all new and existing users automatically have secure defaults applied.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-6a, SI-3a, SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+    - [T1566.003: Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)
+
+
+#### MS.DEFENDER.1.2v1
+All users SHALL be added to Exchange Online Protection (EOP) in either the standard or strict preset security policy.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.DEFENDER.1.2v1; Criticality: SHALL -->
+- _Rationale:_ Important user protections are provided by EOP, including anti-spam, anti-malware, and anti-phishing protections. By using the preset policies, administrators can help ensure all new and existing users have secure defaults applied automatically.
+- _Last modified:_ June 2023
+- _Note:_
+  - The standard and strict preset security policies must be enabled as directed
+    by [MS.DEFENDER.1.1v1](#msdefender11v1) for protections to be applied.
+  - Specific user accounts, except for sensitive accounts, MAY be exempt from the preset policies, provided they are added to one or more custom policies offering comparable protection. These users might need flexibility not offered by the preset policies. Their accounts should be added to a custom policy conforming, as closely as possible to the settings used by the preset policies. See the **Resources** section for more details on configuring policies.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-6a, SI-3a, SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+    - [T1566.003: Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)
+
+#### MS.DEFENDER.1.3v1
+All users SHALL be added to Defender for Office 365 protection in either the standard or strict preset security policy.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.DEFENDER.1.3v1; Criticality: SHALL -->
+- _Rationale:_ Important user protections are provided by Defender for Office 365 protection, including safe attachments and safe links. By using the preset policies, administrators can help ensure all new and existing users have secure defaults applied automatically.
+- _Last modified:_ June 2023
+- _Note:_
+  - The standard and strict preset security policies must be enabled as directed
+    by [MS.DEFENDER.1.1v1](#msdefender11v1) for protections to be applied.
+  - Specific user accounts, except for sensitive accounts, MAY be exempt from the preset policies, provided they are added to one or more custom policies offering comparable protection. These users might need flexibility not offered by the preset policies. Their accounts should be added to a custom policy conforming as closely as possible to the settings used by the preset policies. See the **Resources** section for more details on configuring policies.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-6a, SI-3a, SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+    - [T1566.003: Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)
+
+#### MS.DEFENDER.1.4v1
+Sensitive accounts SHALL be added to Exchange Online Protection in the strict preset security policy.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Requires Configuration](https://img.shields.io/badge/Requires_Configuration-981D20)](../../../docs/configuration/configuration.md#defender-configuration)
+
+
+<!--Policy: MS.DEFENDER.1.4v1; Criticality: SHALL -->
+<!--ExclusionType: SensitiveAccounts-->
+- _Rationale:_ Unauthorized access to a sensitive account may result in greater harm than a standard user account. Adding sensitive accounts to the strict preset security policy, with its increased protections, better mitigates their elevated risk to email threats.
+- _Last modified:_ June 2023
+- _Note:_ The strict preset security policy must be enabled to protect
+          sensitive accounts.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-6a, SI-3a, SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+#### MS.DEFENDER.1.5v1
+Sensitive accounts SHALL be added to Defender for Office 365 protection in the strict preset security policy.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Requires Configuration](https://img.shields.io/badge/Requires_Configuration-981D20)](../../../docs/configuration/configuration.md#defender-configuration)
+
+
+<!--Policy: MS.DEFENDER.1.5v1; Criticality: SHALL -->
+<!--ExclusionType: SensitiveAccounts-->
+- _Rationale:_ Unauthorized access to a sensitive account may result in greater harm than to a standard user account. Adding sensitive accounts to the strict preset security policy, with its increased protections, better mitigates their elevated risk.
+- _Last modified:_ June 2023
+- _Note:_ The strict preset security policy must be enabled to protect
+          sensitive accounts.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-6a, SI-3a, SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+### Resources
+
+- [Use the Microsoft 365 Defender portal to assign Standard and Strict preset security policies to users \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/preset-security-policies?view=o365-worldwide#use-the-microsoft-365-defender-portal-to-assign-standard-and-strict-preset-security-policies-to-users)
+- [Recommended settings for EOP and Microsoft Defender for Office 365
+  security \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/recommended-settings-for-eop-and-office365)
+- [Configure anti-phishing policies in EOP \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/anti-phishing-policies-eop-configure?view=o365-worldwide)
+- [Configure anti-malware policies in EOP \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/anti-malware-policies-configure?view=o365-worldwide)
+- [Configure anti-spam policies in EOP \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/anti-spam-policies-configure?view=o365-worldwide)
+- [Configure anti-phishing policies in Defender for Office 365 \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/anti-phishing-policies-mdo-configure?view=o365-worldwide)
+- [Set up Safe Attachments policies in Microsoft Defender for Office 365 \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/safe-attachments-policies-configure?view=o365-worldwide)
+- [Set up Safe Links policies in Microsoft Defender for Office 365 \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/safe-links-policies-configure?view=o365-worldwide)
+
+### License Requirements
+
+- Defender for Office 365 capabilities require Defender for Office 365 Plan 1 or 2. These are included with E5 and G5 and are available as add-ons for E3 and G3. However, third-party solutions can be used to meet this requirement. If a third-party solution is used, then a Defender for Office 365 Plan 1 or 2, E5, and G5 license is not required for the respective policies.
+
+### Implementation
+
+#### MS.DEFENDER.1.1v1 Instructions
+
+1. Sign in to **Microsoft 365 Defender**.
+2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.
+3. Select **Threat Policies**.
+4. From the **Templated policies** section, select **Preset Security Policies**.
+5. Under **Standard protection**, slide the toggle switch to the right so the text next to the toggle reads **Standard protection is on**.
+6. Under **Strict protection**, slide the toggle switch to the right so the text next to the toggle reads **Strict protection is on**.
+
+Note: If the toggle slider in step 5 is grayed out, click on **Manage protection settings**
+instead and configure the policy settings according to [Use the Microsoft 365 Defender portal to assign Standard and Strict preset security policies to users \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/preset-security-policies?view=o365-worldwide#use-the-microsoft-365-defender-portal-to-assign-standard-and-strict-preset-security-policies-to-users).
+
+#### MS.DEFENDER.1.2v1 Instructions
+
+1. Sign in to **Microsoft 365 Defender**.
+2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.
+3. Select **Threat Policies**.
+4. From the **Templated policies** section, select **Preset Security Policies**.
+5. Select **Manage protection settings** under either **Standard protection**
+   or **Strict protection**.
+6. On the **Apply Exchange Online Protection** page, select **All recipients**.
+7. (Optional) Under **Exclude these recipients**, add **Users** and **Groups**
+   to be exempted from the preset policies.
+8. Select **Next** on each page until the **Review and confirm your changes** page.
+9. On the **Review and confirm your changes** page, select **Confirm**.
+
+#### MS.DEFENDER.1.3v1 Instructions
+
+1. Sign in to **Microsoft 365 Defender**.
+2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.
+3. Select **Threat Policies**.
+4. From the **Templated policies** section, select **Preset Security Policies**.
+5. Under either **Standard protection** or **Strict protection**, select **Manage
+   protection settings**.
+6. Select **Next** until you reach the **Apply Defender for Office 365 protection** page.
+7. On the **Apply Defender for Office 365 protection** page, select **All recipients**.
+8. (Optional) Under **Exclude these recipients**, add **Users** and **Groups**
+   to be exempted from the preset policies.
+9. Select **Next** on each page until the **Review and confirm your changes** page.
+10. On the **Review and confirm your changes** page, select **Confirm**.
+
+#### MS.DEFENDER.1.4v1 Instructions
+
+1. Sign in to **Microsoft 365 Defender**.
+2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.
+3. Select **Threat Policies**.
+4. From the **Templated policies** section, select **Preset Security Policies**.
+5. Under **Strict protection**, select **Manage protection settings**.
+6. On the **Apply Exchange Online Protection** page, select **Specific recipients**.
+7. Add all sensitive accounts via the **User** and **Group** boxes using the
+   names of mailboxes, users, contacts, M365 groups, and distribution groups.
+8. Select **Next** on each page until the **Review and confirm your changes** page.
+9. On the **Review and confirm your changes** page, select **Confirm**.
+
+#### MS.DEFENDER.1.5v1 Instructions
+
+1. Sign in to **Microsoft 365 Defender**.
+2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.
+3. Select **Threat Policies**.
+4. From the **Templated policies** section, select **Preset Security Policies**.
+5. Under **Strict protection**, select **Manage protection settings**.
+6. Select **Next** until you reach the **Apply Defender for Office 365 protection** page.
+7. On the **Apply Defender for Office 365 protection** page, select
+   **Specific recipients** or **Previously selected recipients** if sensitive
+   accounts were already set on the EOP page.
+8. If adding sensitive accounts separately via **Specific recipients**, add all
+   sensitive accounts via the **User** and **Group** boxes using the names of
+   mailboxes, users, contacts, M365 groups, and distribution groups.
+9. (Optional) Under **Exclude these recipients**, add **Users** and **Groups**
+   to be exempted from the preset policies.
+10. Select **Next** on each page until the **Review and confirm your changes** page.
+11. On the **Review and confirm your changes** page, select **Confirm**.
+
+## 2. Impersonation Protection
+Impersonation protection checks incoming emails to see if the sender
+address is similar to the users or domains on an agency-defined list. If
+the sender address is significantly similar, as to indicate an
+impersonation attempt, the email is quarantined.
+
+### Policies
+#### MS.DEFENDER.2.1v1
+User impersonation protection SHOULD be enabled for sensitive accounts in both the standard and strict preset policies.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Requires Configuration](https://img.shields.io/badge/Requires_Configuration-981D20)](../../../docs/configuration/configuration.md#defender-configuration)
+
+<!--Policy: MS.DEFENDER.2.1v1; Criticality: SHOULD -->
+<!--ExclusionType: SensitiveUsers-->
+- _Rationale:_ User impersonation, especially of users with access to sensitive or high-value information and resources, has the potential to result in serious harm. Impersonation protection mitigates this risk. By configuring impersonation protection in both preset policies, administrators can help protect email recipients from impersonated emails, regardless of whether they are added to the standard or strict policy.
+- _Last modified:_ June 2023
+- _Note:_ The standard and strict preset security policies must be enabled to
+          protect accounts.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+  - [T1656: Impersonation](https://attack.mitre.org/techniques/T1656/)
+
+#### MS.DEFENDER.2.2v1
+Domain impersonation protection SHOULD be enabled for domains owned by the agency in both the standard and strict preset policies.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Requires Configuration](https://img.shields.io/badge/Requires_Configuration-981D20)](../../../docs/configuration/configuration.md#defender-configuration)
+
+<!--Policy: MS.DEFENDER.2.2v1; Criticality: SHOULD -->
+<!--ExclusionType: AgencyDomains-->
+- _Rationale:_ Configuring domain impersonation protection for all agency domains reduces the risk of a user being deceived by a look-alike domain. By configuring impersonation protection in both preset policies, administrators can help protect email recipients from impersonated emails, regardless of whether they are added to the standard or strict policy.
+- _Last modified:_ June 2023
+- _Note:_ The standard and strict preset security policies must be enabled to
+          protect agency domains.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+  - [T1656: Impersonation](https://attack.mitre.org/techniques/T1656/)
+
+#### MS.DEFENDER.2.3v1
+Domain impersonation protection SHOULD be added for key suppliers and partners in both the standard and strict preset policies.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Requires Configuration](https://img.shields.io/badge/Requires_Configuration-981D20)](../../../docs/configuration/configuration.md#defender-configuration)
+
+<!--Policy: MS.DEFENDER.2.3v1; Criticality: SHOULD -->
+<!--ExclusionType: PartnerDomains-->
+- _Rationale:_ Configuring domain impersonation protection for domains owned by important partners reduces the risk of a user being deceived by a look-alike domain. By configuring impersonation protection in both preset policies, administrators can help protect email recipients from impersonated emails, regardless of whether they are added to the standard or strict policy.
+- _Last modified:_ November 2025
+- _Note:_ The standard and strict preset security policies must be enabled to
+          protect partner domains.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+  - [T1656: Impersonation](https://attack.mitre.org/techniques/T1656/)
+
+### Resources
+
+- [Impersonation settings in anti-phishing policies in Microsoft Defender for Office 365 \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/anti-phishing-policies-about?view=o365-worldwide#impersonation-settings-in-anti-phishing-policies-in-microsoft-defender-for-office-365)
+- [Use the Microsoft 365 Defender portal to assign Standard and Strict preset security policies to users \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/preset-security-policies?view=o365-worldwide#use-the-microsoft-365-defender-portal-to-assign-standard-and-strict-preset-security-policies-to-users)
+
+### License Requirements
+
+- Impersonation protection and advanced phishing thresholds require
+  Defender for Office 365 Plan 1 or 2. These are included with E5 and G5
+  and are available as add-ons for E3 and G3. As of April 25, 2023,
+  anti-phishing for user and domain impersonation and spoof intelligence
+  are not yet available in M365 Government Community Cloud (GCC High) and Department of Defense (DoD) environments. See [Platform features \|
+  Microsoft
+  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/office-365-platform-service-description/office-365-us-government/office-365-us-government#platform-features)
+  for current offerings.
+
+### Implementation
+
+#### MS.DEFENDER.2.1v1 Instructions
+
+1. Sign in to **Microsoft 365 Defender**.
+2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.
+3. Select **Threat Policies**.
+4. From the **Templated policies** section, select **Preset Security Policies**.
+5. Under either **Standard protection** or **Strict protection**, select **Manage
+   protection settings**.
+6. Select **Next** until you reach the **Impersonation Protection** page, then
+   select **Next** once more.
+7. On the **Protected custom users** page, add a name and valid email address for each
+   sensitive account and click **Add** after each.
+8. Select **Next** until you reach the **Trusted senders and domains** page.
+9. (Optional) Add specific email addresses here to not flag as impersonation
+   when sending messages and prevent false positives. Click **Add** after each.
+10. Select **Next** on each page until the **Review and confirm your changes** page.
+11. On the **Review and confirm your changes** page, select **Confirm**.
+
+#### MS.DEFENDER.2.2v1 Instructions
+
+1. Sign in to **Microsoft 365 Defender**.
+2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.
+3. Select **Threat Policies**.
+4. From the **Templated policies** section, select **Preset Security Policies**.
+5. Under either **Standard protection** or **Strict protection**, select **Manage
+   protection settings**.
+6. Select **Next** until you reach the **Impersonation Protection** page, then
+   select **Next** once more.
+7. On the **Protected custom domains** page, add each agency domain
+   and click **Add** after each.
+8. Select **Next** until you reach the **Trusted senders and domains** page.
+9. (Optional) Add specific domains here to not flag as impersonation when
+   sending messages and prevent false positives. Click **Add** after each.
+10. Select **Next** on each page until the **Review and confirm your changes** page.
+11. On the **Review and confirm your changes** page, select **Confirm**.
+
+#### MS.DEFENDER.2.3v1 Instructions
+
+1. Sign in to **Microsoft 365 Defender**.
+2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.
+3. Select **Threat Policies**.
+4. From the **Templated policies** section, select **Preset Security Policies**.
+5. Under either **Standard protection** or **Strict protection**, select **Manage
+   protection settings**.
+6. Select **Next** until you reach the **Impersonation Protection** page, then
+   select **Next** once more.
+7. On the **Protected custom domains** page, add each partner domain
+   and click **Add** after each.
+8. Select **Next** on each page until the **Review and confirm your changes** page.
+9. On the **Review and confirm your changes** page, select **Confirm**.
+
+## 3. Safe Attachments
+
+The Safe Attachments feature will scan messages for attachments with malicious
+content. All messages with attachments not already flagged by anti-malware
+protections in EOP are downloaded to a Microsoft virtual environment for
+further analysis. Safe Attachments then uses machine learning and other
+analysis techniques to detect malicious intent. While Safe Attachments for
+Exchange Online is automatically configured in the preset policies, separate
+action is needed to enable it for other products.
+
+### Policies
+#### MS.DEFENDER.3.1v1
+Safe attachments SHOULD be enabled for SharePoint, OneDrive, and Microsoft Teams.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.DEFENDER.3.1v1; Criticality: SHOULD -->
+- _Rationale:_ Clicking malicious links makes users vulnerable to attacks, and this danger is not limited to links in emails. Other Microsoft products, such as Microsoft Teams, can be used to present users with malicious links. As such, it is important to protect users on these other Microsoft products as well.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3a
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+  - [T1204.001: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204.001: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+    - [T1204.002: Malicious File](https://attack.mitre.org/techniques/T1204/002/)
+
+### Resources
+
+- [Safe Attachments in Microsoft Defender for Office 365 \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/safe-attachments-about?view=o365-worldwide#safe-attachments-policy-settings)
+
+- [Turn on Safe Attachments for SharePoint, OneDrive, and Microsoft
+  Teams \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/safe-attachments-for-spo-odfb-teams-configure?view=o365-worldwide)
+
+### License Requirements
+
+- Safe attachments require Defender for Office 365 Plan 1 or 2. These are included with
+  E5 and G5 and are available as add-ons for E3 and G3.
+
+### Implementation
+
+#### MS.DEFENDER.3.1v1 Instructions
+To enable Safe Attachments for SharePoint, OneDrive, and Microsoft
+Teams, follow the instructions listed at [Turn on Safe Attachments for
+SharePoint, OneDrive, and Microsoft Teams \| Microsoft
+Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/safe-attachments-for-spo-odfb-teams-configure?view=o365-worldwide).
+
+1.  Sign in to **Microsoft 365 Defender**.
+
+2.  Under **Email & collaboration**, select **Policies & rules**.
+
+3.  Select **Threat policies**.
+
+4.  Under **Policies**, select **Safe Attachments**.
+
+5.  Select **Global settings**.
+
+6.  Toggle the **Turn on Defender for Office 365 for SharePoint, OneDrive, and
+    Microsoft Teams** slider to **On**.
+
+## 4. Data Loss Prevention
+
+There are several approaches to securing sensitive information, such
+as warning users, encryption, or blocking attempts to share. Agency
+policies for sensitive information, such as personally identifiable
+information (PII), should dictate how that information is handled and
+inform associated data loss prevention (DLP) policies. Defender can detect
+sensitive information and associates a default confidence level with
+this detection based on the sensitive information type matched.
+Confidence levels are used to reduce false positives in detecting access
+to sensitive information. Agencies may choose to use the default
+confidence levels or adjust the levels in custom DLP policies to fit
+their environment and needs.
+
+### Policies
+#### MS.DEFENDER.4.1v2
+A custom policy SHALL be configured to protect PII and sensitive information, as defined by the agency, blocking at a minimum: credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN).
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.DEFENDER.4.1v2; Criticality: SHALL -->
+- _Rationale:_ Users may inadvertently share sensitive information with
+               others who should not have access to it. DLP policies
+               provide a way for agencies to detect and prevent
+               unauthorized disclosures.
+- _Last modified:_ November 2024
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+
+#### MS.DEFENDER.4.2v1
+The custom policy SHOULD be applied to Exchange, OneDrive, SharePoint, Teams chat, and Devices.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.DEFENDER.4.2v1; Criticality: SHOULD -->
+- _Rationale:_ Unauthorized disclosures may happen through M365 services
+               or endpoint devices. DLP policies should cover all
+               affected locations to be effective.
+- _Last modified:_ June 2023
+- _Note:_ The custom policy referenced here is the same policy
+          configured in [MS.DEFENDER.4.1v2](#msdefender41v2).
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+    - [T1213.002: Sharepoint](https://attack.mitre.org/techniques/T1213/002/)
+
+#### MS.DEFENDER.4.3v1
+The action for the custom policy SHOULD be set to block sharing sensitive information with everyone.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.DEFENDER.4.3v1; Criticality: SHOULD -->
+- _Rationale:_ Access to sensitive information should be prohibited unless
+               explicitly allowed. Specific exemptions can be made based
+               on agency policies and valid business justifications.
+- _Last modified:_ June 2023
+- _Note:_ The custom policy referenced here is the same policy
+          configured in [MS.DEFENDER.4.1v2](#msdefender41v2).
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, SC-7(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+
+#### MS.DEFENDER.4.4v1
+Notifications to inform users and help educate them on the proper use of sensitive information SHOULD be enabled in the custom policy.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.DEFENDER.4.4v1; Criticality: SHOULD -->
+- _Rationale:_ Some users may not be aware of agency policies on
+               proper use of sensitive information. Enabling
+               notifications provides positive feedback to users when
+               accessing sensitive information.
+- _Last modified:_ June 2023
+- _Note:_ The custom policy referenced here is the same policy
+          configured in [MS.DEFENDER.4.1v2](#msdefender41v2).
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AT-2b
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+#### MS.DEFENDER.4.5v1
+A list of apps that are restricted from accessing files protected by DLP policy SHOULD be defined.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#msdefender45v1-instructions)
+
+<!--Policy: MS.DEFENDER.4.5v1; Criticality: SHOULD -->
+- _Rationale:_ Some apps may inappropriately share accessed files or not
+               conform to agency policies for access to sensitive
+               information. Defining a list of those apps makes it
+               possible to use DLP policies to restrict those apps' access
+               to sensitive information on endpoints using Defender.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+  - [T1485: Data Destruction](https://attack.mitre.org/techniques/T1485/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+#### MS.DEFENDER.4.6v1
+The custom policy SHOULD include an action to block access to sensitive
+information by restricted apps and unwanted Bluetooth applications.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#msdefender46v1-instructions)
+
+<!--Policy: MS.DEFENDER.4.6v1; Criticality: SHOULD -->
+- _Rationale:_ Some apps may inappropriately share accessed files
+               or not conform to agency policies for access to sensitive
+               information. Defining a DLP policy with an action to block
+               access from restricted apps and unwanted Bluetooth
+               applications prevents unauthorized disclosure by those
+               programs.
+- _Last modified:_ June 2023
+- _Note:_
+  - The custom policy referenced here is the same policy
+    configured in [MS.DEFENDER.4.1v2](#msdefender41v2).
+  - This action can only be included if at least one device is onboarded
+    to the agency tenant. Otherwise, the option to block restricted apps will
+    not be available.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-19a
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+  - [T1485: Data Destruction](https://attack.mitre.org/techniques/T1485/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1486: Data Encrypted for Impact](https://attack.mitre.org/techniques/T1486/)
+
+### Resources
+
+- [Plan for data loss prevention (DLP) \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/purview/dlp-overview-plan-for-dlp?view=o365-worldwide)
+
+- [Data loss prevention in Exchange Online \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/exchange/security-and-compliance/data-loss-prevention/data-loss-prevention)
+
+- [Personally identifiable information (PII) \|
+  NIST](https://csrc.nist.gov/glossary/term/personally_identifiable_information#:~:text=NISTIR%208259,2%20under%20PII%20from%20EGovAct)
+
+- [Sensitive information \|
+  NIST](https://csrc.nist.gov/glossary/term/sensitive_information)
+
+- [Get started with Endpoint data loss prevention - Microsoft Purview
+  (compliance) \| Microsoft Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)
+
+### License Requirements
+
+- DLP for Teams requires an E5 or G5 license. See [Microsoft Purview Data Loss Prevention: Data Loss Prevention for Teams \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#microsoft-purview-data-loss-prevention-data-loss-prevention-dlp-for-teams)
+  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.
+
+
+- DLP for Endpoint requires an E5 or G5 license. See [Get started with
+  Endpoint data loss prevention - Microsoft Purview (compliance) \|
+  Microsoft
+  Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)
+  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.
+
+
+### Implementation
+
+#### MS.DEFENDER.4.1v2 Instructions
+
+1. Sign in to the **Microsoft Purview portal**.
+
+2. Under the **Solutions** section on the left-hand menu, select **Data loss
+   prevention**.
+
+3. Select **Policies** from the top of the page.
+
+4. Select **Create policy**.
+
+5. From the **Categories** list, select **Custom**.
+
+6. From the **Regulations** list, select **Custom policy** and then click
+   **Next**.
+
+7. Edit the name and description of the policy if desired, then click
+   **Next**.
+
+8. Under **Assign admin units**,  ensure **Admin units** is set to **Full directory** by default, then click **Next**.
+
+9. Under **Choose where to apply the policy**, set **Status** to **On**
+   for at least the Exchange email, OneDrive accounts, SharePoint
+   sites, Teams chat and channel messages, and Devices locations, then
+   click **Next**.
+
+10. Under **Define policy settings**, select **Create or customize advanced
+   DLP rules**, and then click **Next**.
+
+11. Click **Create rule**. Assign the rule an appropriate name and
+   description.
+
+12. Click **Add condition**, then **Content contains**.
+
+13. Click **Add**, then **Sensitive info types**.
+
+14. Add information types that protect information sensitive to the agency.
+    At a minimum, the agency should protect:
+
+    - Credit card numbers
+    - U.S. Individual Taxpayer Identification Numbers (ITIN)
+    - U.S. Social Security Numbers (SSN)
+    - All agency-defined PII and sensitive information
+
+15. Click **Add**.
+
+16. Under **Actions**, click **Add an action**.
+
+17. Check **Restrict Access or encrypt the content in Microsoft 365
+    locations**.
+
+18. Under this action, select **Block Everyone**.
+
+19. Under **User notifications**, turn on **Use notifications to inform your users and help educate them on the proper use of sensitive info**.
+
+20. Under **Microsoft 365 services** if using a GCC environment or under **Microsoft 365 files and Microsoft Fabric items** if using a Commercial environment, a section that appears after user notifications are turned on, check the box next to **Notify users in Office 365 service with a policy tip or email notifications**.
+
+21. Click **Save**, then **Next**.
+
+22. Select **Turn the policy on immediately**, then click **Next**.
+
+23. Click **Submit**.
+
+#### MS.DEFENDER.4.2v1 Instructions
+
+See [MS.DEFENDER.4.1v2 Instructions](#msdefender41v2-instructions) step 8
+   for details on enforcing DLP policy in specific M365 service locations.
+
+#### MS.DEFENDER.4.3v1 Instructions
+
+See [MS.DEFENDER.4.1v2 Instructions](#msdefender41v2-instructions) steps
+   15-17 for details on configuring DLP policy to block sharing sensitive
+   information with everyone.
+
+#### MS.DEFENDER.4.4v1 Instructions
+
+See [MS.DEFENDER.4.1v2 Instructions](#msdefender41v2-instructions) steps
+   18-19 for details on configuring DLP policy to notify users when accessing
+   sensitive information.
+
+#### MS.DEFENDER.4.5v1 Instructions
+
+1. Sign in to the **Microsoft Purview portal**.
+
+2. Go to **Settings**, under **Solution Settings** select **Data loss prevention**.
+
+3. Go to **Endpoint DLP Settings**.
+
+4. Go to **Restricted apps and app groups**.
+
+5. Click **Add or edit Restricted Apps**.
+
+6. Enter an app and executable name to disallow said app from
+   accessing protected files, and log the incident.
+
+7. Return and click **Unallowed Bluetooth apps**.
+
+8. Click **Add or edit unallowed Bluetooth apps**.
+
+9. Enter an app and executable name to disallow said app from
+   accessing protected files, and log the incident.
+
+#### MS.DEFENDER.4.6v1 Instructions
+
+If restricted app and unwanted Bluetooth app restrictions are desired,
+associated devices must be onboarded with Defender for Endpoint
+before the instructions below can be completed.
+
+1. Sign in to the **Microsoft Purview portal**.
+
+2. Under **Solutions**, select **Data loss prevention**.
+
+3. Select **Policies** from the top of the page.
+
+4. Find the custom DLP policy configured under
+   [MS.DEFENDER.4.1v2 Instructions](#msdefender41v2-instructions) in the list
+   and click the Policy name to select.
+
+5. Select **Edit Policy**.
+
+6. Click **Next** on each page in the policy wizard until you reach the
+   Advanced DLP rules page.
+
+7. Select the relevant rule and click the pencil icon to edit it.
+
+8. Under **Actions**, click **Add an action**.
+
+9. Choose **Audit or restrict activities on device**
+
+10. Under **File activities for all apps**, select
+    **Apply restrictions to specific activity**.
+
+11. Check the box next to **Copy or move using unallowed Bluetooth app**
+    and set its action to **Block**.
+
+12. Under **Restricted app activities**, check the **Access by restricted apps** box
+   and set the action drop-down to **Block**.
+
+13. Click **Save** to save the changes.
+
+14. Click **Next** on each page until reaching the
+    **Review your policy and create it** page.
+
+15. Review the policy and click **Submit** to complete the policy changes.
+
+## 5. Alerts
+
+There are several pre-built alert policies available pertaining to
+various apps in the M365 suite. These alerts give administrators better
+real-time insight into possible security incidents. Guidance on specific alerts to configure can be found in the linked section of the CISA M365 Secure Configuration Baseline for Exchange Online.
+
+- [MS.EXO.16.1v1 \| CISA M365 Secure Configuration Baseline for Exchange Online](./exo.md#msexo161v1)
+
+### Policies
+#### MS.DEFENDER.5.1v1
+At a minimum, the alerts required by the CISA M365 Secure Configuration Baseline for Exchange Online SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.DEFENDER.5.1v1; Criticality: SHALL -->
+- _Rationale:_ Potentially malicious or service-impacting events may go undetected without a means of detecting these events. Administrators are alerted to these events when they occur, minimizing potential user or agency impact.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-4(5)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562.006: Indicator Blocking](https://attack.mitre.org/techniques/T1562/006/)
+
+#### MS.DEFENDER.5.2v1
+The alerts SHOULD be sent to a monitored address or incorporated into a Security Information and Event Management (SIEM).
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#msdefender52v1-instructions)
+
+<!--Policy: MS.DEFENDER.5.2v1; Criticality: SHOULD -->
+- _Rationale:_ Suspicious or malicious events, if not resolved promptly, may have a greater impact to users and the agency. Sending alerts to a monitored email address or SIEM system helps ensure events are acted upon in a timely manner to limit overall impact.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-4(5)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562.006: Indicator Blocking](https://attack.mitre.org/techniques/T1562/006/)
+
+### Resources
+
+- [Alert policies in Microsoft 365 \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/purview/alert-policies?view=o365-worldwide)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.DEFENDER.5.1v1 Instructions
+
+1. Sign in to **Microsoft 365 Defender**.
+
+2. Under **Email & collaboration**, select **Policies & rules**.
+
+3. Select **Alert Policy**.
+
+4. Select the checkbox next to each alert to enable as determined by the
+   agency and at a minimum those referenced in the
+   [_CISA M365 Secure Configuration Baseline for Exchange Online_](./exo.md#msexo161v1) which are:
+
+   a. **Suspicious email sending patterns detected.**
+
+   b. **Suspicious connector activity.**
+
+   c. **Suspicious Email Forwarding Activity.**
+
+   d. **Messages have been delayed.**
+
+   e. **Tenant restricted from sending unprovisioned email.**
+
+   f. **Tenant restricted from sending email.**
+
+   g. **A potentially malicious URL click was detected.**
+
+5. Click the pencil icon from the top menu.
+
+6. Select the **Enable selected policies** action from the **Bulk actions**
+   menu.
+
+#### MS.DEFENDER.5.2v1 Instructions
+
+For each enabled alert, to add one or more email recipients:
+
+1. Sign in to **Microsoft 365 Defender**.
+
+2. Under **Email & collaboration**, select **Policies & rules**.
+
+3. Select **Alert Policy**.
+
+4. Click the alert policy to modify.
+
+5. Click the pencil icon next to **Set your recipients**.
+
+6. Check the **Opt-In for email notifications** box.
+
+7. Add one or more email addresses to the **Email recipients** text box.
+
+8. Click **Next**.
+
+9. On the **Review** page, click **Submit** to save the notification settings.
+
+## 6. Audit Logging
+
+User activity from M365 services is captured in the organization's unified
+audit log. These logs are essential for conducting incident response and
+threat detection activity.
+
+By default, Microsoft retains the audit logs for 180 days. Activity
+by users with E5 licenses is logged for one year.
+
+However, in accordance with Office of Management and Budget (OMB) Memorandum
+21-31, _Improving the Federal Government's Investigative and Remediation
+Capabilities Related to Cybersecurity Incidents_, M365 audit logs are to be
+retained for at least 12 months in active storage and an additional 18 months
+in cold storage. This can be accomplished either by offloading the logs out of
+the cloud environment or natively through Microsoft by creating an [audit log
+retention policy](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies?view=o365-worldwide#create-an-audit-log-retention-policy).
+
+OMB M-21-13 requires Advanced Audit Features be configured in M365.
+Advanced Audit, now Microsoft Purview Audit (Premium), adds additional event
+types to the Unified Audit Log.
+
+### Policies
+#### MS.DEFENDER.6.1v1
+Unified Audit logging SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.DEFENDER.6.1v1; Criticality: SHALL -->
+- _Rationale:_ Responding to incidents without detailed information about activities that took place slows response actions. Enabling Unified Audit logging helps ensure agencies have visibility into user actions. Furthermore, enabling the Unified Audit log is required for government agencies by OMB M-21-31.
+- _Last modified:_ March 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AU-12
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562.008: Disable or Modify Cloud Logs](https://attack.mitre.org/techniques/T1562/008/)
+
+#### MS.DEFENDER.6.3v1
+Audit logs SHALL be maintained for at least the minimum duration dictated by OMB M-21-31.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#msdefender63v1-instructions)
+
+<!--Policy: MS.DEFENDER.6.3v1; Criticality: SHALL -->
+- _Rationale:_ Audit logs may no longer be available when needed if they are not retained for a sufficient time. Increased log retention time gives an agency the necessary visibility to investigate incidents that occurred some time ago.
+- _Last modified:_ June 2023
+- _Note_: Purview Audit (Premium) provides a default audit log retention policy,
+          retaining Exchange Online, SharePoint Online, OneDrive for
+          Business, and Microsoft Entra ID audit records for one year.
+          Additional record types require custom audit retention policies.
+          Agencies may also consider alternate storage locations and services
+          to meet audit log retention needs.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AU-11
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1070: Indicator Removal](https://attack.mitre.org/techniques/T1070/)
+
+### Resources
+
+- [OMB M-21-31, Improving the Federal Government's Investigative and Remediation Capabilities
+Related to Cybersecurity Incidents \| Office of Management and
+  Budget](https://www.whitehouse.gov/wp-content/uploads/2021/08/M-21-31-Improving-the-Federal-Governments-Investigative-and-Remediation-Capabilities-Related-to-Cybersecurity-Incidents.pdf)
+
+- [Turn auditing on or off \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/purview/audit-log-enable-disable?view=o365-worldwide)
+
+- [Create an audit log retention policy \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies?view=o365-worldwide#create-an-audit-log-retention-policy)
+
+- [Search the audit log in the compliance center \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/purview/audit-log-search?view=o365-worldwide)
+
+- [Audit log activities \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/purview/audit-log-activities)
+
+- [Expanding cloud logging to give customers deeper security visibility \|
+  Microsoft Security Blog](https://www.microsoft.com/en-us/security/blog/2023/07/19/expanding-cloud-logging-to-give-customers-deeper-security-visibility/)
+
+- [Export, configure, and view audit log records | Microsoft Learn](https://learn.microsoft.com/en-us/purview/audit-log-export-records)
+
+- [Untitled Goose Tool Fact Sheet | CISA.](https://www.cisa.gov/resources-tools/resources/untitled-goose-tool-fact-sheet)
+
+- [Manage audit log retention policies | Microsoft Learn](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies?tabs=microsoft-purview-portal#before-you-create-an-audit-log-retention-policy)
+
+### License Requirements
+
+- Microsoft Purview Audit (Premium) logging capabilities, including the creation of a custom audit
+  log retention policy, requires E5/G5 licenses or E3/G3 licenses with
+  add-on compliance licenses.
+
+- Additionally, maintaining logs in the M365 environment for longer than
+  one year requires an add-on license. For more information, see
+  [Manage audit log retention policies | Microsoft Learn](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies?tabs=microsoft-purview-portal#before-you-create-an-audit-log-retention-policy). However, this requirement can also be met by exporting the logs from M365 and storing them with your solution of choice, in which case audit log retention policies are not necessary.
+
+### Implementation
+
+#### MS.DEFENDER.6.1v1 Instructions
+
+To enable auditing via the **Microsoft Purview portal**:
+
+1. Sign in to the **Microsoft Purview portal**.
+
+2. Under **Solutions**, select **Audit**.
+
+3. If auditing is not enabled, a banner is displayed to notify the
+administrator to start recording user and admin activity.
+
+4. Click the **Start recording user and admin activity**.
+
+#### MS.DEFENDER.6.3v1 Instructions
+To create one or more custom audit retention policies, if the default retention policy is not sufficient for agency needs, follow [Create an audit log retention policy](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies?view=o365-worldwide#create-an-audit-log-retention-policy) instructions.
+Ensure the duration selected in the retention policies is at least one year, in accordance with OMB M-21-31.
+
+As noted in the [License Requirements](https://github.com/cisagov/ScubaGear/baselines/defender.md#license-requirements-1) section above, the creation of a custom audit log retention policy and its retention in the M365 environment requires E5/G5 licenses or E3/G3 licenses with add-on compliance licenses. No additional license is required to view and export logs. To view and export audit logs follow [Export, configure, and view audit log records | Microsoft Learn](https://learn.microsoft.com/en-us/purview/audit-log-export-records) and/or [Untitled Goose Tool Fact Sheet | CISA.](https://www.cisa.gov/resources-tools/resources/untitled-goose-tool-fact-sheet)
+
+**`TLP:CLEAR`**

--- a/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md
+++ b/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/exo.md
@@ -1,0 +1,678 @@
+**`TLP:CLEAR`**
+
+# CISA M365 Secure Configuration Baseline for Exchange Online
+
+Microsoft 365 (M365) Exchange Online is a cloud-based messaging platform that gives users easy access to their email and supports organizational meetings, contacts, and calendars. This Secure Configuration Baseline (SCB) provides specific policies to strengthen Exchange Online security.
+
+Many admin controls for Exchange Online are found in the **Exchange admin center**.
+However, several essential security functions for Exchange Online require a dedicated security
+tool, e.g., for data loss prevention. M365 provides these security functions
+natively via Defender for Office 365. Notably, Defender for Office 365 capabilities
+require Defender for Office 365 Plan 1 or 2. These are included with E5 and G5
+and are available as add-ons for E3 and G3. However, third-party solutions that
+offer comparable security functions can be used in lieu of Defender.
+Refer to the [CISA M365 Secure Configuration Security Suite Baseline](securitysuite.md)
+for additional guidance.
+
+The Secure Cloud Business Applications (SCuBA) project, run by the Cybersecurity and Infrastructure Security Agency (CISA), provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies’ cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for M365 help secure federal information assets stored within M365 cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government’s threats and risk tolerance with the knowledge that every organization has different threat models and risk tolerance. While use of these baselines will be mandatory for civilian Federal Government agencies, organizations outside of the Federal Government may also find these baselines to be useful references to help reduce risks.
+
+For non-Federal users, the information in this document is being provided "as is" for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products; CISA has no control over vendor changes to products offerings or features.  Accordingly, these SCuBA SCBs for M365 may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+> This document is marked TLP:CLEAR. Recipients may share this information without restriction. Information is subject to standard copyright rules. For more information on the Traffic Light Protocol, see https://www.cisa.gov/tlp.
+
+## License Compliance and Copyright
+
+Portions of this document are adapted from documents in Microsoft's
+[M365](https://github.com/MicrosoftDocs/microsoft-365-docs/blob/public/LICENSE)
+and
+[Azure](https://github.com/MicrosoftDocs/azure-docs/blob/main/LICENSE)
+GitHub repositories. The respective documents are subject to copyright
+and are adapted under the terms of the Creative Commons Attribution 4.0
+International license. Sources are linked throughout this
+document. The United States government has adapted selections of these
+documents to develop innovative and scalable configuration standards to
+strengthen the security of widely used cloud-based software services.
+
+## Assumptions
+
+The **License Requirements** sections of this document assume the
+organization is using an [M365
+E3](https://www.microsoft.com/en-us/microsoft-365/compare-microsoft-365-enterprise-plans)
+or [G3](https://www.microsoft.com/en-us/microsoft-365/government)
+license level at a minimum. Therefore, only licenses not included in E3/G3 are
+listed.
+
+## Key Terminology
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in
+[RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+**BOD 25-01 Requirement**: This indicator means that the policy is required under CISA BOD 25-01.
+
+**Automated Check**: This indicator means that the policy can be automatically checked via ScubaGear. See the [Quick Start Guide](../../../README.md#quick-start-guide) for help getting started.
+
+**Configurable**: This indicator means that the policy can be customized via config file.
+
+**Manual**: This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. Automatic Forwarding to External Domains
+
+This control is intended to prevent bad actors from using client-side
+forwarding rules to exfiltrate data to external recipients.
+
+### Policies
+
+#### MS.EXO.1.1v2
+Automatic forwarding to external domains SHALL be disabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/configuration.md#automatic-forwarding-to-remote-domains)
+
+<!--Policy: MS.EXO.1.1v2; Criticality: SHALL -->
+<!--ExclusionType: AllowedForwardingDomains-->
+- _Rationale:_ Adversaries can use automatic forwarding to gain
+persistent access to a victim's email. Disabling forwarding to
+external domains prevents this technique when the adversary is
+external to the organization but does not impede legitimate
+internal forwarding.
+- _Last modified:_ March 2025
+- _Note:_ Automatic forwarding MAY be enabled with specific, agency-approved domains.
+There may be cases where an external domain is operationally needed and has an acceptable
+degree of risk, e.g., a domain controlled by the same agency that hasn't been added
+as an accepted domain in M365.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-4
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+
+### Resources
+
+- [Reducing or increasing information flow to another company \|
+  Microsoft
+  Learn](https://learn.microsoft.com/en-us/exchange/mail-flow-best-practices/remote-domains/remote-domains#reducing-or-increasing-information-flow-to-another-company)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.EXO.1.1v2 Instructions
+To disallow automatic forwarding to external domains:
+
+1.  Sign in to the **Exchange admin center**.
+
+2.  Select **Mail flow**, then **Remote domains**.
+
+3.  Select **Default**.
+
+4.  Under **Email reply types**, select **Edit reply types**.
+
+5.  Clear the checkbox next to **Allow automatic forwarding**, then
+    click **Save**.
+
+6.  Return to **Remote domains** and review each
+    additional remote domain in the list, ensuring that automatic forwarding
+    is only allowed for approved domains.
+
+## 2. Sender Policy Framework
+
+The Sender Policy Framework (SPF) is a mechanism allowing domain
+administrators to specify which IP addresses are explicitly approved to
+send email on behalf of the domain, facilitating detection of spoofed
+emails. SPF is not configured through the Exchange admin center, but
+rather via Domain Name System (DNS) records hosted by the agency's
+domain. Thus, the exact steps needed to set up SPF vary from agency to
+agency, but Microsoft's documentation provides some helpful starting
+points.
+
+### Policies
+
+#### MS.EXO.2.2v3
+An SPF policy SHALL be published for each domain that fails all non-approved senders.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/parameters.md#preferreddnsresolvers)
+
+<!--Policy: MS.EXO.2.2v3; Criticality: SHALL -->
+- _Rationale:_ An adversary may modify the `FROM` field
+of an email such that it appears to be a legitimate email sent by an
+agency, facilitating phishing attacks. Publishing an SPF policy for each agency domain mitigates forged `FROM` fields by providing a means for recipients to detect emails spoofed in this way.  SPF is required for FCEB departments and agencies by Binding Operational Directive (BOD) 18-01, "Enhance Email and Web Security".
+- _Last modified:_ October 2025
+- _Note:_ SPF defines two different "fail" mechanisms: fail (indicated by `-`, sometimes referred to as hardfail) and softfail (indicated by `~`). Either hard or soft fail may be used to comply with this baseline policy.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-2d
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1656: Impersonation](https://attack.mitre.org/techniques/T1656/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+
+
+### Resources
+
+- [Binding Operational Directive 18-01 - Enhance Email and Web Security
+  \| DHS](https://cyber.dhs.gov/bod/18-01/)
+
+- [Trustworthy Email \| NIST 800-177 Rev.
+  1](https://csrc.nist.gov/publications/detail/sp/800-177/rev-1/final)
+
+- [Set up SPF to help prevent spoofing \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-spf-configure?view=o365-worldwide)
+
+- [How Microsoft 365 uses Sender Policy Framework (SPF) to prevent
+  spoofing \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-anti-spoofing?view=o365-worldwide)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.EXO.2.2v3 Instructions
+First, identify any approved senders specific to your agency, e.g., any on-premises mail servers. SPF allows you to indicate approved senders by IP address or CIDR range. However, note that SPF allows you to [include](https://www.rfc-editor.org/rfc/rfc7208#section-5.2) the IP addresses indicated by a separate SPF policy, referred to by domain name. See [External DNS records required for SPF](https://learn.microsoft.com/en-us/microsoft-365/enterprise/external-domain-name-system-records?view=o365-worldwide#external-dns-records-required-for-spf) for inclusions required for M365 to send email on behalf of your domain.
+
+SPF is not configured through the Exchange admin center, but rather via
+DNS records hosted by the agency's domain. Thus, the exact steps needed
+to set up SPF varies from agency to agency. See [Add or edit an SPF TXT record to help prevent email spam (Outlook, Exchange Online) \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/admin/get-help-with-domains/create-dns-records-at-any-dns-hosting-provider?view=o365-worldwide#add-or-edit-an-spf-txt-record-to-help-prevent-email-spam-outlook-exchange-online) for more details.
+
+To test your SPF configuration, consider using a web-based tool, such as
+those listed under [How can I validate SPF records for my domain? \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/admin/setup/domains-faq?view=o365-worldwide#how-can-i-validate-spf-records-for-my-domain).
+Additionally, SPF records can be requested using the
+PowerShell tool `Resolve-DnsName`. For example:
+
+```
+Resolve-DnsName example.onmicrosoft.com txt
+```
+
+If SPF is configured, you will see a response resembling `v=spf1 include:spf.protection.outlook.com -all`
+returned; though by necessity, the contents of the SPF
+policy may vary by agency. In this example, the SPF policy indicates
+the IP addresses listed by the policy for "spf.protection.outlook.com" are
+the only approved senders for "example.onmicrosoft.com." These IPs can be determined
+via an additional SPF lookup, this time for "spf.protection.outlook.com." Ensure the IP addresses listed as approved senders for your domains are correct. Additionally, ensure that each policy either ends in `-all` or `~all` or [redirects](https://www.rfc-editor.org/rfc/rfc7208#section-6.1) to one that does; these directives indicates that all IPs that don't match the policy should fail. See [SPF TXT record syntax for Microsoft 365 \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-anti-spoofing?view=o365-worldwide#spf-txt-record-syntax-for-microsoft-365) for a more in-depth discussion
+of SPF record syntax.
+
+## 3. DomainKeys Identified Mail
+
+DomainKeys Identified Mail (DKIM) allows digital signatures to be added
+to email messages in the message header, providing a layer of both
+authenticity and integrity to emails. As with SPF, DKIM relies on DNS
+records; thus, its deployment depends on how an agency manages its DNS.
+Exchange Online Protection (EOP) features include DKIM signing capabilities.
+
+### Policies
+
+#### MS.EXO.3.1v1
+DKIM SHOULD be enabled for all domains.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/parameters.md#preferreddnsresolvers)
+
+<!--Policy: MS.EXO.3.1v1; Criticality: SHOULD -->
+- _Rationale:_ An adversary may modify the `FROM` field
+of an email such that it appears to be a legitimate email sent by an
+agency, facilitating phishing attacks. Enabling DKIM is another means for
+recipients to detect spoofed emails and verify the integrity of email content.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1598: Phishing for Information](https://attack.mitre.org/techniques/T1598/)
+  - [T1656: Impersonation](https://attack.mitre.org/techniques/T1656/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+
+### Resources
+
+- [Binding Operational Directive 18-01 - Enhance Email and Web Security
+  \| DHS](https://cyber.dhs.gov/bod/18-01/)
+
+- [Trustworthy Email \| NIST 800-177 Rev.
+  1](https://csrc.nist.gov/publications/detail/sp/800-177/rev-1/final)
+
+- [Use DKIM to validate outbound email sent from your custom domain \|
+  Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-dkim-configure?view=o365-worldwide)
+
+- [Support for validation of DKIM signed messages \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-dkim-support-about?view=o365-worldwide)
+
+- [What is EOP? \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/eop-faq?view=o365-worldwide#what-is-eop-)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.EXO.3.1v1 Instructions
+1. To enable DKIM, follow the instructions listed on [Steps to Create,
+enable and disable DKIM from Microsoft 365 Defender portal \| Microsoft
+Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-dkim-configure?view=o365-worldwide#steps-to-create-enable-and-disable-dkim-from-microsoft-365-defender-portal).
+
+## 4. Domain-Based Message Authentication, Reporting, and Conformance (DMARC)
+Domain-based Message Authentication, Reporting, and Conformance (DMARC)
+works with SPF and DKIM to authenticate mail senders and helps ensure
+destination email systems can validate messages sent from your domain.
+DMARC helps receiving mail systems determine what to do with messages
+sent from your domain that fail SPF and DKIM checks.
+
+### Policies
+
+#### MS.EXO.4.1v1
+A DMARC policy SHALL be published for every second-level domain.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/parameters.md#preferreddnsresolvers)
+
+<!--Policy: MS.EXO.4.1v1; Criticality: SHALL -->
+- _Rationale:_ Without a DMARC policy available for each domain, recipients
+may improperly handle SPF and DKIM failures, possibly enabling spoofed
+emails to reach end users' mailboxes. Publishing DMARC records at the
+second-level domain protects the second-level domains and all subdomains.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1598: Phishing for Information](https://attack.mitre.org/techniques/T1598/)
+  - [T1656: Impersonation](https://attack.mitre.org/techniques/T1656/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+
+#### MS.EXO.4.2v1
+The DMARC message rejection option SHALL be p=reject.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/parameters.md#preferreddnsresolvers)
+
+<!--Policy: MS.EXO.4.2v1; Criticality: SHALL -->
+- _Rationale:_ Of the three policy options (i.e., none, quarantine, and reject),
+reject provides the strongest protection. Reject is the level of protection
+required by BOD 18-01 for FCEB departments and agencies.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1598: Phishing for Information](https://attack.mitre.org/techniques/T1598/)
+  - [T1656: Impersonation](https://attack.mitre.org/techniques/T1656/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+
+#### MS.EXO.4.3v1
+The DMARC point of contact for aggregate reports SHALL include `reports@dmarc.cyber.dhs.gov`.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/parameters.md#preferreddnsresolvers)
+
+<!--Policy: MS.EXO.4.3v1; Criticality: SHALL -->
+- _Rationale:_ Email spoofing attempts are not inherently visible to domain
+owners. DMARC provides a mechanism to receive reports of spoofing attempts.
+Including <reports@dmarc.cyber.dhs.gov> as a point of contact for these reports gives CISA insight into spoofing attempts and is required by BOD 18-01 for FCEB departments and agencies.
+- _Last modified:_ June 2023
+- _Note:_ Only federal, executive branch, departments and agencies should
+          include this email address in their DMARC record.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-4(5)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+
+#### MS.EXO.4.4v1
+An agency point of contact SHOULD be included for aggregate and failure reports.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/parameters.md#preferreddnsresolvers)
+
+<!--Policy: MS.EXO.4.4v1; Criticality: SHOULD -->
+- _Rationale:_ Email spoofing attempts are not inherently visible to domain
+owners. DMARC provides a mechanism to receive reports of spoofing attempts.
+Including an agency point of contact gives the agency insight into attempts
+to spoof their domains.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-4(5)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+
+### Resources
+
+- [Binding Operational Directive 18-01 - Enhance Email and Web Security
+  \| DHS](https://cyber.dhs.gov/bod/18-01/)
+
+- [Trustworthy Email \| NIST 800-177 Rev.
+  1](https://csrc.nist.gov/publications/detail/sp/800-177/rev-1/final)
+
+- [Domain-based Message Authentication, Reporting, and Conformance
+  (DMARC) \| RFC 7489](https://datatracker.ietf.org/doc/html/rfc7489)
+
+- [Best practices for implementing DMARC in Office 365 \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-dmarc-configure?view=o365-worldwide#best-practices-for-implementing-dmarc-in-microsoft-365)
+
+- [How Office 365 handles outbound email that fails DMARC \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-dmarc-configure?view=o365-worldwide#how-microsoft-365-handles-inbound-email-that-fails-dmarc)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.EXO.4.1v1 Instructions
+DMARC is not configured through the Exchange admin center, but rather via
+DNS records hosted by the agency's domain. As such, implementation varies
+depending on how an agency manages its DNS records. See [Form the DMARC TXT record for your domain \| Microsoft
+Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-dmarc-configure?view=o365-worldwide#step-4-form-the-dmarc-txt-record-for-your-domain)
+for Microsoft guidance.
+
+A DMARC record published at the second-level domain will protect all subdomains.
+In other words, a DMARC record published for `example.com` will protect both
+`a.example.com` and `b.example.com`, but a separate record would need to be
+published for `c.example.gov`.
+
+To test your DMARC configuration, consider using one of many publicly available
+web-based tools. Additionally, DMARC records can be requested using the
+PowerShell tool `Resolve-DnsName`. For example:
+
+```
+Resolve-DnsName _dmarc.example.com txt
+```
+
+If DMARC is configured, a response resembling `v=DMARC1; p=reject; pct=100; rua=mailto:reports@dmarc.cyber.dhs.gov, mailto:reports@example.com; ruf=mailto:reports@example.com`
+will be returned, though by necessity, the contents of the record will vary
+by agency. In this example, the policy indicates all emails failing the
+SPF/DKIM checks are to be rejected and aggregate reports sent to
+reports@dmarc.cyber.dhs.gov and reports@example.com. Failure reports will be
+sent to reports@example.com.
+
+#### MS.EXO.4.2v1 Instructions
+See [MS.EXO.4.1v1 Instructions](#msexo41v1-instructions) for an overview of how to publish and check a DMARC record. Ensure the record published includes `p=reject`.
+
+#### MS.EXO.4.3v1 Instructions
+See [MS.EXO.4.1v1 Instructions](#msexo41v1-instructions) for an overview of how to publish and check a DMARC record. Ensure the record published includes <reports@dmarc.cyber.dhs.gov>
+as one of the emails for the RUA field.
+
+#### MS.EXO.4.4v1 Instructions
+See [MS.EXO.4.1v1 Instructions](#msexo41v1-instructions) for an overview of how to publish and check a DMARC record. Ensure the record published includes:
+- A point of contact specific to your agency in the RUA field.
+- <reports@dmarc.cyber.dhs.gov> as one of the emails in the RUA field.
+- One or more agency-defined points of contact in the RUF field.
+
+## 5. Simple Mail Transfer Protocol Authentication
+
+Modern email clients that connect to Exchange Online mailboxes—including
+Outlook, Outlook on the web, iOS Mail, and Outlook for iOS and
+Android—do not use Simple Mail Transfer Protocol Authentication (SMTP
+AUTH) to send email messages. SMTP AUTH is only needed for applications
+outside of Outlook that send email messages. Multi-factor authentication
+(MFA) cannot be enforced while using SMTP Auth. Proceed with caution if
+SMTP Auth needs to be enabled for any use case.
+
+### Policies
+
+#### MS.EXO.5.1v1
+SMTP AUTH SHALL be disabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.EXO.5.1v1; Criticality: SHALL -->
+- _Rationale:_ SMTP AUTH is not used or needed by modern email clients.
+Therefore, disabling it as the global default conforms to the principle of
+least functionality.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+### Resources
+
+- [Enable or disable authenticated client SMTP submission (SMTP AUTH) in
+  Exchange Online \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/authenticated-client-smtp-submission)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.EXO.5.1v1 Instructions
+
+To disable SMTP AUTH for the organization:
+
+1. Sign in to the **Exchange admin center**.
+
+2. On the left hand pane, select **Settings**; then from the settings list, select **Mail Flow**.
+
+3. Make sure the setting **Turn off SMTP AUTH protocol for your organization** is checked.
+
+## 6. Calendar and Contact Sharing
+
+Exchange Online allows creation of sharing polices that soften default restrictions on contact and calendar details sharing. These policies should be enabled with caution and only after considering the following policies.
+
+### Policies
+
+#### MS.EXO.6.1v1
+Contact folders SHALL NOT be shared with all domains.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.EXO.6.1v1; Criticality: SHALL -->
+- _Rationale:_ Contact folders may contain information that should not be shared by default with all domains. Disabling sharing with all domains closes an avenue for data exfiltration while still allowing
+for specific legitimate use as needed.
+- _Last modified:_ June 2023
+- _Note:_ Contact folders MAY be shared with specific domains.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, SC-7(10)(a)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+
+
+#### MS.EXO.6.2v1
+Calendar details SHALL NOT be shared with all domains.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.EXO.6.2v1; Criticality: SHALL -->
+- _Rationale:_ Calendar details may contain information that should not be shared by default with all domains. Disabling sharing with all domains closes an avenue for data exfiltration while still allowing
+for legitimate use as needed.
+- _Last modified:_ June 2023
+- _Note:_ Calendar details MAY be shared with specific domains.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, SC-7(10)(a)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+
+### Resources
+
+- [Sharing in Exchange Online \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/exchange/sharing/sharing)
+
+- [Organization relationships in Exchange Online \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/exchange/sharing/organization-relationships/organization-relationships)
+
+- [Sharing policies in Exchange Online \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/exchange/sharing/sharing-policies/sharing-policies)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.EXO.6.1v1 Instructions
+To restrict sharing with all domains:
+
+1. Sign in to the **Exchange admin center**.
+
+2. On the left-hand pane under **Organization**, select **Sharing**.
+
+3. Select **Individual Sharing**.
+
+4. For all existing policies, select the policy, then select **Manage domains**.
+
+5. For all sharing rules under all existing policies, ensure **Sharing with all domains** is not selected.
+
+#### MS.EXO.6.2v1 Instructions
+
+To restrict sharing calendar details with all domains:
+
+1. Refer to step 5 in [MS.EXO.6.1v1 Instructions](#msexo61v1-instructions) to implement
+this policy.
+
+## 7. External Sender Warnings
+
+Mail flow rules allow incoming email modification, such that email from external users can be easily identified (e.g., by prepending the subject line with "\[External\]").
+
+### Policies
+
+#### MS.EXO.7.1v1
+External sender warnings SHALL be implemented.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.EXO.7.1v1; Criticality: SHALL -->
+- _Rationale:_ Alerting users when email originates from outside their organization can encourage them to exercise increased caution, especially if an email is one they expected from an internal sender.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+
+### Resources
+
+- [Mail flow rules (transport rules) in Exchange Online \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/exchange/security-and-compliance/mail-flow-rules/mail-flow-rules)
+
+- [Capacity Enhancement Guide: Counter-Phishing Recommendations for
+  Federal Agencies \|
+  CISA](https://www.cisa.gov/sites/default/files/publications/Capacity_Enhancement_Guide-Counter-Phishing_Recommendations_for_Federal_Agencies.pdf)
+
+- [Actions To Counter Email-Based Attacks On Election-Related Entities
+  \|
+  CISA](https://www.cisa.gov/sites/default/files/publications/CISA_Insights_Actions_to_Counter_Email-Based_Attacks_on_Election-Related_S508C.pdf)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.EXO.7.1v1 Instructions
+To create a mail flow rule to produce external sender warnings:
+
+1.  Sign in to the **Exchange admin center**.
+
+2.  Under **Mail flow**, select **Rules**.
+
+3.  Click the plus (**+**) button to create a new rule.
+
+4.  Select **Modify messages…**.
+
+5.  Give the rule an appropriate name.
+
+6.  Under **Apply this rule if…,** select **The sender is external/internal**.
+
+7.  Under **select sender location**, select **Outside the organization**, then click **OK**.
+
+8.  Under **Do the following…,** select **Prepend the subject of the message with…**.
+
+9.  Under **specify subject prefix**, enter a message such as
+    "\[External\]" (without the quotation marks), then click **OK**.
+
+10. Click **Next**.
+
+11. Under **Choose a mode for this rule**, select **Enforce**.
+
+12. Leave the **Severity** as **Not Specified**.
+
+13. Leave the **Match sender address in message** as **Header** and click **Next**.
+
+14. Click **Finish** and then **Done**.
+
+15. The new rule will be disabled.  Re-select the new rule to show its
+    settings and slide the **Enable or disable rule** slider to the right
+    until it shows as **Enabled**.
+
+## 13. Mailbox Auditing
+
+Mailbox auditing helps users investigate compromised accounts or
+discover illicit access to Exchange Online. As a feature of Exchange
+Online, mailbox auditing is enabled by default for all organizations.
+Microsoft defines a default audit policy that logs certain actions
+performed by administrators, delegates, and owners. While mailbox auditing is enabled by default,
+this policy helps avoid inadvertent disabling.
+### Policies
+
+#### MS.EXO.13.1v1
+Mailbox auditing SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.EXO.13.1v1; Criticality: SHALL -->
+- _Rationale:_ Exchange Online user accounts can be compromised or misused. Enabling mailbox auditing provides a valuable source of information to detect and respond to mailbox misuse.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AU-12c
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1070: Indicator Removal](https://attack.mitre.org/techniques/T1070/)
+    - [T1070.008: Clear Mailbox Data](https://attack.mitre.org/techniques/T1070/008/)
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.002: Additional Email Delegate Permissions](https://attack.mitre.org/techniques/T1098/002/)
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562.008: Disable or Modify Cloud Logs](https://attack.mitre.org/techniques/T1562/008/)
+  - [T1586: Compromise Accounts](https://attack.mitre.org/techniques/T1586/)
+    - [T1586.002: Email Accounts](https://attack.mitre.org/techniques/T1586/002/)
+  - [T1564: Hide Artifacts](https://attack.mitre.org/techniques/T1564/)
+  - [T1564.008: Email Hiding Rules](https://attack.mitre.org/techniques/T1564/008/)
+
+### Resources
+
+- [Manage mailbox auditing in Office 365 \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/compliance/audit-mailboxes?view=o365-worldwide)
+
+- [Supported mailbox types \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/compliance/audit-mailboxes?view=o365-worldwide&viewFallbackFrom=o365-worldwide%22%20%5Cl%20%22supported-mailbox-types)
+
+- [Microsoft Purview Compliance Manager - Microsoft 365 Compliance \|Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/compliance/compliance-manager?view=o365-worldwide)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.EXO.13.1v1 Instructions
+
+Mailbox auditing can be managed from the Exchange Online PowerShell.
+Follow the instructions listed on [Manage mailbox auditing in Office
+365](https://learn.microsoft.com/en-us/microsoft-365/compliance/audit-mailboxes?view=o365-worldwide).
+
+To check the current mailbox auditing status for your organization via PowerShell:
+
+1.  Connect to the Exchange Online PowerShell.
+
+2.  Run the following command:
+
+    `Get-OrganizationConfig | Format-List AuditDisabled`
+
+3.  An `AuditDisabled : False` result indicates mailbox auditing is enabled.
+
+To enable mailbox auditing by default for your organization via PowerShell:
+
+1.  Connect to the Exchange Online PowerShell.
+
+2.  Run the following command:
+
+    `Set-OrganizationConfig –AuditDisabled $false`
+
+
+**`TLP:CLEAR`**

--- a/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerbi.md
+++ b/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerbi.md
@@ -1,0 +1,861 @@
+**`TLP:CLEAR`**
+
+# CISA M365 Secure Configuration Baseline for Power BI
+
+Microsoft 365 (M365) Power BI is a cloud-based product that facilitates self-service business intelligence dashboards, reports, datasets, and visualizations. Power BI can connect to multiple different data sources, combine and shape data from those connections, then create reports and dashboards to share with others. This Secure Configuration Baseline (SCB) provides specific policies to strengthen Power BI security.
+
+The Secure Cloud Business Applications (SCuBA) project, run by the Cybersecurity and Infrastructure Security Agency (CISA), provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies’ cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for M365 help secure federal information assets stored within M365 cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government’s threats and risk tolerance with the knowledge that every organization has different threat models and risk tolerance. While use of these baselines will be mandatory for civilian Federal Government agencies, organizations outside of the Federal Government may also find these baselines to be useful references to help reduce risks.
+
+For non-Federal users, the information in this document is being provided “as is” for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products; CISA has no control over vendor changes to products offerings or features.  Accordingly, these SCuBA SCBs for M365 may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+> This document is marked TLP:CLEAR. Recipients may share this information without restriction. Information is subject to standard copyright rules. For more information on the Traffic Light Protocol, see https://www.cisa.gov/tlp.
+
+
+## License Compliance and Copyright
+Portions of this document are adapted from documents in Microsoft's [M365](https://github.com/MicrosoftDocs/microsoft-365-docs/blob/public/LICENSE) and [Azure](https://github.com/MicrosoftDocs/azure-docs/blob/main/LICENSE) GitHub repositories. The respective documents are subject to copyright and are adapted under the terms of the Creative Commons Attribution 4.0 International license. Sources are linked throughout this document. The United States government has adapted selections of these documents to develop innovative and scalable configuration standards to strengthen the security of widely used cloud-based software services.
+
+## Assumptions
+The **License Requirements** sections of this document assume the organization is using an [M365 E3](https://www.microsoft.com/en-us/microsoft-365/compare-microsoft-365-enterprise-plans) or [G3](https://www.microsoft.com/en-us/microsoft-365/government) license level at a minimum. Therefore, only licenses not included in E3/G3 are listed.
+
+
+Agencies using Power BI may have a data classification scheme in place for
+  the data entering Power BI.
+
+- Agencies may connect more than one data source to their Power BI
+  tenant.
+- All data sources use a secure connection for data transfer to and from
+  the Power BI tenant; the agency disallows non-secure connections.
+
+## Key Terminology
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+Access to PowerBI can be controlled by the user type. In this baseline,
+the types of users are defined as follows:
+
+1.  **Internal users**: Members of the agency's M365 tenant.
+2.  **External users**: Members of a different M365 tenant.
+3.  **Business to Business (B2B) guest users**: External users that are
+  formally invited to view and/or edit Power BI workspace content and
+  are added to the agency's Microsoft Entra ID as guest users. These users authenticate with their home organization/tenant and are granted access to Power BI
+  content by virtue of being listed as guest users in the tenant's Microsoft Entra ID.
+
+**Manual**: This indicator means that the policy requires manual verification of configuration settings.
+
+> Note:
+> These terms vary in use across Microsoft documentation.
+
+# Baseline Policies
+
+## 1. Publish to Web
+
+Power BI has a capability to publish reports and content to the web.
+This capability creates a publicly accessible web URL that does not
+require authentication or status as an Microsoft Entra ID user to view it. While this
+may be needed for a specific use case or collaboration scenario, it is a
+best practice to keep this setting off by default to prevent unintended
+and potentially sensitive data exposure.
+
+If it is deemed necessary to make an exception and enable the feature,
+administrators should limit the ability to publish to the web to only
+specific security groups, instead of allowing the entire agency to
+publish data to the web.
+
+### Policies
+#### MS.POWERBI.1.1v1
+The Publish to Web feature SHOULD be disabled unless the agency mission requires the capability.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.POWERBI.1.1v1; Criticality: SHOULD -->
+- _Rationale:_ A publicly accessible web URL can be accessed by everyone, including malicious actors. This policy limits information available on the public web that is not specifically allowed to be published.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7, SC-7(10)(a)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+### Resources
+
+- [About Power BI Tenant settings \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/admin/service-admin-portal-about-tenant-settings)
+
+- [Power BI Security Baseline v2.0 \| Microsoft benchmarks GitHub
+  repo](https://github.com/MicrosoftDocs/SecurityBenchmarks/blob/master/Azure%20Offer%20Security%20Baselines/2.0/power-bi-security-baseline-v2.0.xlsx)
+
+### License Requirements
+
+- N/A
+
+
+### Implementation
+#### MS.POWERBI.1.1v1 Instructions
+
+1. Navigate to the **PowerBI Admin Portal**
+
+2. Click on **Tenant Settings**
+
+3. Scroll to **Export and sharing settings**
+
+4. Click **Publish to web** set to **Disabled**
+
+## 2. Power BI Guest Access
+
+This section provides policies helping reduce guest user access risks related to Power BI data and resources. An agency with externally shareable Power BI resources and data must consider its unique risk tolerance when granting access to guest users.
+
+### Policies
+#### MS.POWERBI.2.1v1
+Guest user access to the Power BI tenant SHOULD be disabled unless the agency mission requires the capability.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.POWERBI.2.1v1; Criticality: SHOULD -->
+- _Rationale:_ Disabling external access to Power BI helps keep guest users from accessing potentially risky data and application programming interfaces (APIs). If an agency needs to allow guest access, this can be limited to users in specific security groups to curb risk.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7, AC-6
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1485: Data Destruction](https://attack.mitre.org/techniques/T1485/)
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+    - [T1565.001: Stored Data Manipulation](https://attack.mitre.org/techniques/T1565/001/)
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.001: Default Accounts](https://attack.mitre.org/techniques/T1078/001/)
+
+### Resources
+
+- [About Power BI Tenant settings \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/admin/service-admin-portal-about-tenant-settings)
+
+- [Power BI Security Baseline v2.0 \| Microsoft benchmarks GitHub
+  repo](https://github.com/MicrosoftDocs/SecurityBenchmarks/blob/master/Azure%20Offer%20Security%20Baselines/2.0/power-bi-security-baseline-v2.0.xlsx)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+#### MS.POWERBI.2.1v1 Instructions
+To Disable Completely:
+1. Navigate to the **PowerBI Admin Portal**
+
+2. Click on **Tenant Settings**
+
+3. Scroll to **Export and sharing settings**
+
+4. For **Commercial** tenants Click on **Guest users can access Microsoft Fabric** and set to **Disabled**
+
+5. For **GCC, GCC High and DoD** tenants Click on **Allow Azure Active Directory guest users to access Power BI** and set to **Disabled**
+
+To Enable with Security Group(s):
+1. Navigate to the **PowerBI Admin Portal**
+
+2. Click on **Tenant Settings**
+
+3. Scroll to **Export and sharing settings**
+
+4. For **Commercial** tenants Click on **Guest users can access Microsoft Fabric** and set to **Enabled**
+
+5. For **GCC, GCC High and DoD** tenants Click on **Allow Azure Active Directory guest users to access Power BI** and set to **Enabled**
+
+6. Select the security group(s) you want to have access to the PowerBI tenant.
+> Note:
+> You may need to make a specific security group(s)
+
+## 3. Power BI External Invitations
+
+This section provides policies that help reduce guest user invitation risks related to Power BI data and resources.
+The settings in this section control whether Power BI allows inviting external users to
+the agency's organization through Power BI's sharing workflows and
+experiences. After an external user accepts the invite, they become an
+Microsoft Entra ID B2B guest user in the organization. They will then appear in user
+pickers throughout the Power BI user experience.
+
+### Policies
+#### MS.POWERBI.3.1v1
+The Invite external users to your organization feature SHOULD be disabled unless agency mission requires the capability.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.POWERBI.3.1v1; Criticality: SHOULD -->
+- _Rationale:_ Disabling this feature keeps internal users from inviting guest users. Therefore guest users can be limited from accessing potentially risky data/APIs. If an agency needs to allow guest access, the agency can limit the invitation feature to users in specific security groups to help limit risk.
+- _Last modified:_ June 2023
+> Note:
+> If this feature is disabled, existing guest users in the tenant continue to have access to Power BI items they already had access to and continue to be listed in user picker experiences. After it is disabled, an external user who is not already a guest user cannot be added to the tenant through Power BI.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7, AC-6
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1485: Data Destruction](https://attack.mitre.org/techniques/T1485/)
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+    - [T1565.001: Stored Data Manipulation](https://attack.mitre.org/techniques/T1565/001/)
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.001: Default Accounts](https://attack.mitre.org/techniques/T1078/001/)
+  - [T1199: Trusted Relationship](https://attack.mitre.org/techniques/T1199/)
+
+### Resources
+
+- [About Power BI Tenant settings \| Microsoft
+  Docs](https://learn.microsoft.com/en-us/power-bi/admin/service-admin-portal-about-tenant-settings)
+
+- [Distribute Power BI content to external guest users with Microsoft Entra B2B \|
+  Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/enterprise/service-admin-azure-ad-b2b)
+
+- [Power BI Security Baseline v2.0 \| Microsoft benchmarks GitHub
+  repo](https://github.com/MicrosoftDocs/SecurityBenchmarks/blob/master/Azure%20Offer%20Security%20Baselines/2.0/power-bi-security-baseline-v2.0.xlsx)
+
+### License Requirements
+
+- N/A
+
+
+### Implementation
+#### MS.POWERBI.3.1v1 Instructions
+To disable completely:
+1. Navigate to the **PowerBI Admin Portal**
+
+2. Click on **Tenant Settings**
+
+3. Scroll to **Export and sharing settings**
+
+4. Click on **Users can invite guest users to collaborate through item sharing and permissions** and set to **Disabled**
+
+To enable with security groups:
+1. Navigate to the **PowerBI Admin Portal**
+
+2. Click on **Tenant Settings**
+
+3. Scroll to **Export and sharing settings**
+
+4. Click on **Users can invite guest users to collaborate through item sharing and permissions** and set to **Enabled**
+
+5. Select the security group(s) needed.
+> Note:
+> You may need to make a specific security group(s)
+
+## 4. Power BI Service Principals
+
+Service principals are an authentication method that can be used to let an Microsoft Entra ID application access Power BI service content and APIs. Power BI supports using service principals to manage application identities. Service principals use APIs to access tenant-level features, controlled by Power BI service administrators and enabled for the entire agency or for agency security groups. Accessing service principals can be controlled by creating dedicated security groups for them and using these groups in any Power BI tenant level-settings. If service principals are employed for Power BI, it is recommended that service principal credentials used for encrypting or accessing Power BI be stored in a key vault, with properly assigned access policies and regularly reviewed access permissions.
+
+Several high-level use cases for service principals:
+
+- Not possible to access a data source using service principals in Power BI (e.g., Azure Table storage).
+
+- A user's service principal for accessing the Power BI service (e.g., app.powerbi.com and app.powerbigov.us).
+
+- Power BI Embedded and other users of the Power BI REST APIs to interact with Power BI content.
+
+### Policies
+#### MS.POWERBI.4.1v1
+Service principals with access to APIs SHOULD be restricted to specific security groups.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.POWERBI.4.1v1; Criticality: SHOULD -->
+- _Rationale:_ With unrestricted service principals, unwanted access to APIs is possible. Allowing service principals through security groups, and only where necessary, mitigates this risk.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-4, AC-6(5)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1059: Command and Scripting Interpreter](https://attack.mitre.org/techniques/T1059/)
+    - [T1059.009: Cloud API](https://attack.mitre.org/techniques/T1059/009/)
+
+#### MS.POWERBI.4.2v1
+Service principals creating and using profiles SHOULD be restricted to specific security groups.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.POWERBI.4.2v1; Criticality: SHOULD -->
+- _Rationale:_ With unrestricted service principals creating/using profiles, there is risk of an unauthorized user using a profile with more permissions than they have. Allowing service principals through security groups will mitigate that risk.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-4, AC-6(5)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.003: Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003/)
+
+### Resources
+
+- [Automate Premium workspace and dataset tasks with service principal
+  \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/enterprise/service-premium-service-principal)
+
+- [Embed Power BI content with service principal and an application
+  secret \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/developer/embedded/embed-service-principal)
+
+- [Embed Power BI content with service principal and a certificate \|
+  Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/developer/embedded/embed-service-principal-certificate)
+
+- [Enable service principal authentication for read-only admin APIs \|
+  Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/enterprise/read-only-apis-service-principal-authentication)
+
+- [Microsoft Power BI Embedded Developer Code Samples \| Microsoft
+  GitHub](https://github.com/microsoft/PowerBI-Developer-Samples/blob/master/Python/Encrypt%20credentials/README.md)
+
+- [Azure security baseline for Power BI \|
+  Microsoft
+  Learn](https://learn.microsoft.com/en-us/security/benchmark/azure/baselines/power-bi-security-baseline)
+
+### License Requirements
+
+- N/A
+
+
+### Implementation
+#### MS.POWERBI.4.1v1 Instructions
+If your organization has service principals that need to access Power BI APIs, then you configure the setting per the instructions below.
+If you don't have service principals that need access then for step 4, configure the setting to Disabled.
+
+1. Navigate to the **PowerBI Admin Portal**
+
+2. Click on **Tenant settings**
+
+3. Scroll to **Developer settings**
+
+4. Click on **Service Principals can call Fabric public APIs**
+
+5. If don't have service principals that need access to Power BI APIs, then configure the setting to **Disabled** and you are finished. Otherwise go to step 6.
+
+6. If you have service principals that need to access Power BI APIs, then configure the setting to **Enabled**.
+
+7. Select the specific security groups that contain the service principals authorized to call the APIs.
+
+
+#### MS.POWERBI.4.2v1 Instructions
+1. Navigate to the **PowerBI Admin Portal**
+
+2. Click on **Tenant settings**
+
+3. Scroll to **Developer settings**
+
+4. Then, click on **Allow service principals to create and use profiles**
+
+5. If don't have service principals that need to create and use profiles, then configure the setting to **Disabled** and you are finished. Otherwise go to step 6.
+
+6. If you have service principals that need to create and use profiles, then configure the setting to **Enabled**.
+
+7. Select the specific security groups that contain the service principals authorized to to create and use profiles.
+
+
+## 5. Power BI ResourceKey Authentication
+
+
+This setting pertains to the security and development of Power BI
+Embedded content. The Power BI tenant states "For extra security,
+block using ResourceKey-based authentication." This baseline statement
+recommends, but does not mandate, setting ResourceKey-based
+authentication to the blocked state.
+
+For streaming datasets created using the Power BI service user interface, the dataset owner receives a URL including a resource key. This key authorizes the requestor to push data into the dataset without using an Microsoft Entra ID OAuth bearer token, so please keep in mind the implications of having a secret key in the URL when working with this type of dataset and method.
+
+This setting applies to streaming and PUSH datasets. If ResourceKey-based authentication is blocked, users with a resource key will not be allowed to send data to stream and PUSH datasets using the API. However, if developers have an approved need to leverage this feature, an exception to the policy can be investigated.
+
+
+### Policies
+#### MS.POWERBI.5.1v1
+ResourceKey-based authentication SHOULD be blocked unless a specific use case (e.g., streaming and/or PUSH datasets) merits its use.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.POWERBI.5.1v1; Criticality: SHOULD -->
+- _Rationale:_ If resource keys are allowed, someone can move data without Microsoft Entra ID OAuth bearer token, causing possibly malicious or junk data to be stored. Disabling resource keys reduces risk that an unauthorized individual will make changes.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7, IA-5g
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1134: Access Token Manipulation](https://attack.mitre.org/techniques/T1134/)
+    - [T1134.001: Token Impersonation/Theft](https://attack.mitre.org/techniques/T1134/001/)
+    - [T1134.003: Make and Impersonate Token](https://attack.mitre.org/techniques/T1134/003/)
+
+
+### Resources
+
+- [Power BI Tenant settings \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/admin/service-admin-portal-about-tenant-settings)
+
+- [Real-time streaming in Power BI \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/connect-data/service-real-time-streaming)
+
+### License Requirements
+
+- N/A
+
+
+### Implementation
+#### MS.POWERBI.5.1v1 Instructions
+1. Navigate to the **PowerBI Admin Portal**
+
+2. Click on **Tenant settings**
+
+3. Scroll to **Developer settings**
+
+4. Click on **Block ResourceKey Authentication** and set to **Enabled**
+
+## 6. Python and R Visual Sharing
+
+Power BI can interact with Python and R scripts to integrate
+visualizations from these languages. Python visuals are created from
+Python scripts, which could contain code with security or privacy risks.
+When attempting to view or interact with a Python visual for the first
+time, a user is presented with a security warning message. Python and R
+visuals should only be enabled if the author and source are trusted, or
+after a code review of the Python/R script(s) in question is conducted
+and the scripts are deemed free of security risks.
+
+
+### Policies
+#### MS.POWERBI.6.1v1
+Python and R interactions SHOULD be disabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.POWERBI.6.1v1; Criticality: SHOULD -->
+- _Rationale:_ External code poses a security and privacy risk as there is no good way to regulate use of  data or integrations. Disabling this feature reduces the risk of a data leak or malicious threat activity.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7, SI-3
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1059: Command and Scripting Interpreter](https://attack.mitre.org/techniques/T1059/)
+    - [T1059.009: Cloud API](https://attack.mitre.org/techniques/T1059/009/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+
+### Resources
+
+- [Create Power BI visuals with Python \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/connect-data/desktop-python-visuals)
+
+### License Requirements
+
+- N/A
+
+
+### Implementation
+#### MS.POWERBI.6.1v1 Instructions
+1. Navigate to the **PowerBI Admin Portal**
+
+2. Click on **Tenant settings**
+
+3. Scroll to **R and Python Visuals Settings**
+
+4. Click on **Interact with and share R and Python visuals** and set to **Disabled**
+
+## 7. Power BI Sensitive Data
+
+There are multiple ways to secure sensitive information, such as warning
+users, encryption, or blocking attempts to share. Use Microsoft
+Information Protection sensitivity labels on Power BI reports,
+dashboards, datasets, and dataflows guards sensitive content against
+unauthorized data access and leakage. This can also guard against
+unwanted aggregation and commingling.
+
+> Note:
+> At this baseline's time of writing, data loss prevention (DLP)
+profiles are in preview status for Power BI. Once released for general
+availability and government, DLP profiles represent another available
+tool for securing power Power BI datasets. Refer to the *Defender for
+Office 365 Minimum Viable Secure Configuration Baseline* for more on
+DLP.
+
+### Policies
+#### MS.POWERBI.7.1v1
+Sensitivity labels SHOULD be enabled for Power BI and employed for sensitive data per enterprise data protection policies.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.POWERBI.7.1v1; Criticality: SHOULD -->
+- _Rationale:_ A document without sensitivity labels may be opened unknowingly, potentially exposing data to someone who is not supposed to have access to it. This policy will help organize and classify data, making it easier to keep data out of the wrong hands.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-21b, SC-7(10)(a)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+    - [T1213.002: Sharepoint](https://attack.mitre.org/techniques/T1213/002/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+### Resources
+
+- [Enable sensitivity labels in Power BI \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/enterprise/service-security-enable-data-sensitivity-labels)
+
+- [Data loss prevention policies for Power BI \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/enterprise/service-security-dlp-policies-for-power-bi-overview)
+
+- [Data Protection in Power BI \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/enterprise/service-security-data-protection-overview)
+
+- [Power BI Security Baseline v2.0 \| Microsoft benchmarks GitHub
+  repo](https://github.com/MicrosoftDocs/SecurityBenchmarks/blob/master/Azure%20Offer%20Security%20Baselines/2.0/power-bi-security-baseline-v2.0.xlsx)
+
+### License Requirements
+
+- Microsoft Purview Information Protection Premium P1 or Premium P2 license is required to apply or view
+  Microsoft Information Protection sensitivity labels in Power BI. Azure Information Protection can be purchased either standalone or through one of the Microsoft licensing suites. See [Microsoft Purview Information Protection
+  service description](https://azure.microsoft.com/services/information-protection/) for
+  details.
+
+- Microsoft Purview Information Protection sensitivity labels need to be migrated to
+  the Microsoft Information Protection Unified Labeling platform to be
+  used in Power BI.
+
+- To apply labels to Power BI content and files, a user must
+  have a Power BI Pro or Premium Per User (PPU) license, in addition to
+  one of the previously mentioned Azure Information Protection licenses.
+
+- Before enabling sensitivity labels on the agency's tenant, ensure sensitivity labels have been defined and published for relevant
+  users and groups. See [Create and configure sensitivity labels and
+  their
+  policies](https://learn.microsoft.com/en-us/purview/create-sensitivity-labels)
+  for detail.
+
+
+### Implementation
+#### MS.POWERBI.7.1v1 Instructions
+1. Navigate to the **PowerBI Admin Portal**
+
+2. Click on **Tenant settings**
+
+3. Scroll to **Information protection**
+
+4. Click on **Allow users to apply sensitivity labels for content** and set to **Enabled**. Define who can apply and change sensitivity labels in Power BI assets.
+
+# Appendix A: Implementation Considerations
+
+## Information Protection Considerations
+
+Several best practices and approaches are available to protect sensitive
+data in Power BI:
+
+- Leverage sensitivity labels via Microsoft Purview Information Protection.
+
+- Power BI allows service users to bring their own key to protect data
+  at rest.
+
+- Customers have the option to keep data sources on-premises and
+  leverage Direct Query or Live Connect with an on-premises data gateway
+  to minimize data exposure to the cloud service.
+
+- Implement row-level security in Power BI datasets.
+
+**Implementation**
+
+**Apply sensitivity labels from data sources to their data in Power BI**
+
+When this setting is enabled, Power BI datasets that connect to
+sensitivity-labeled data in supported data sources can inherit those
+labels, so the data remains classified and secure when brought into
+Power BI. For details about sensitivity label inheritance from data
+sources, see below:
+
+***To enable sensitivity label inheritance from data sources:***
+
+1. Navigate to the **PowerBI Admin Portal**
+
+2. Click on **Tenant settings**
+
+3. Scroll to **Information protection**
+
+3. Click on **Apply sensitivity labels from data sources to their data in Power BI.** and set to **Enabled** for your organization, or select security groups.
+
+
+**Restrict content with protected labels from being shared via link with everyone in your agency**
+
+When this setting is enabled, users can't generate a sharing link for
+people in the agency for content with protection settings in the
+sensitivity label.
+
+Sensitivity labels with protection settings include encryption or
+content markings. For example, the agency may have a "Highly
+Confidential" label that includes encryption and applies a "Highly
+Confidential" watermark to content with this label. When this
+tenant setting is enabled and a report has a sensitivity label with
+protection settings, then users cannot create sharing links for people in
+the agency.
+
+1. Navigate to the **PowerBI Admin Portal**
+
+2. Click on **Tenant settings**
+
+3. Scroll to **Information protection**
+
+4. Click on **Restrict content with protected labels from being shared via link with everyone in your agency** and set to **Enabled**. 
+
+**Information Protection Prerequisites Specific to Power BI**
+
+- An Microsoft Purview Information Protection Premium P1 or Premium P2 license is
+  required to apply or view Microsoft Purview Information Protection sensitivity
+  labels in Power BI. Microsoft Purview Information Protection can be purchased
+  either standalone or through one of the Microsoft licensing suites.
+  See [Microsoft Purview Information Protection
+  service](https://learn.microsoft.com/en-us/office365/servicedescriptions/azure-information-protection) description for
+  details.
+
+- Microsoft Purview Information Protection sensitivity labels need to be migrated to
+  the Microsoft Information Protection Unified Labeling platform in
+  order for them to be used in Power BI.
+
+- To be able to apply labels to Power BI content and files, a user must
+  have a Power BI Pro or Premium Per User (PPU) license in addition to
+  one of the previously mentioned Azure Information Protection licenses.
+
+- Before enabling sensitivity labels on the agency's tenant, make sure
+  that sensitivity labels have been defined and published for relevant
+  users and groups. See [Create and configure sensitivity labels and
+  their
+  policies](https://learn.microsoft.com/en-us/purview/create-sensitivity-labels)
+  for detail.
+
+**High-Level Steps to Use Bring Your Own Key (BYOK) Feature in Power
+BI**
+
+First, confirm having the latest Power BI Management cmdlet. Install the
+latest version by running Install-Module -Name MicrosoftPowerBIMgmt.
+More information about the Power BI cmdlet and its parameters is
+available in [Power BI PowerShell cmdlet
+module](https://learn.microsoft.com/en-us/powershell/power-bi/overview?view=powerbi-ps).
+
+Follow steps in [Bring Your Own (encryption) Keys for Power BI](https://learn.microsoft.com/en-us/power-bi/enterprise/service-encryption-byok).
+
+**Row-Level Security Implementation**
+
+Row-Level Security (RLS) involves several configuration steps, which
+should be completed in the following order.
+
+1.  Create a report in Microsoft Power BI Desktop.
+
+2.  Import the data.
+
+3.  Confirm the data model between both tables.
+
+4.  Create the report visuals.
+
+5. Create RLS roles in Power BI Desktop by using Data Analysis Expressions (DAX).
+
+6. Test the roles in Power BI Desktop.
+
+7. Deploy the report to Microsoft Power BI service.
+
+8. Add members to the role in Power BI service.
+
+9. Test the roles in Power BI service.
+
+- Reference Microsoft Power BI documentation for additional detail on
+  [row-level security
+  configuration](https://learn.microsoft.com/en-us/power-bi/enterprise/service-admin-rls).
+
+**Related Resources**
+
+- [Sensitivity labels in Power BI \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/enterprise/service-security-sensitivity-label-overview)
+
+- [Bring your own encryption keys for Power BI \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/enterprise/service-encryption-byok)
+
+- [What is an on-premises data gateway? \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/data-integration/gateway/service-gateway-onprem)
+
+- [Row-level security (RLS) with Power BI \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/enterprise/service-admin-rls)
+
+- [Power BI PowerShell cmdlets and modules references \| Microsoft
+ Learn](https://learn.microsoft.com/en-us/powershell/power-bi/overview?view=powerbi-ps)
+
+# Appendix B: Source Code and Credential Security Considerations
+
+Exposing secrets via collaboration spaces is a security concern when
+using Power BI.
+
+For Power BI embedded applications, it is recommended to implement a
+source code scanning solution to identify credentials within the code of
+any app housing embedded Power BI report(s). A source code scanner can
+also encourage moving discovered credentials to more secure locations,
+such as Azure key vault.
+
+Store encryption keys or service principal credentials used for
+encrypting or accessing Power BI in a Key Vault, assign proper access
+policies to the vault, and regularly review access permissions.
+
+For regulatory or other compliance reasons, some agencies may need to
+use BYOK, which is supported by Power BI. By default,
+Power BI uses Microsoft-managed keys to encrypt the data. In Power BI
+Premium, users can use their own keys for data at-rest imported
+into a dataset. See [Data source and storage
+considerations](https://learn.microsoft.com/en-us/power-bi/enterprise/service-encryption-byok#data-source-and-storage-considerations)
+for more information.
+
+- For Power BI embedded applications, a best practice is to implement a
+  source code scanning solution to identify credentials within the code
+  of the app housing the embedded Power BI report(s).
+
+- If required under specific regulations, agencies need a strategy for
+  maintaining control and governance of their keys. The BYOK functionality is one option.
+
+**Prerequisites**
+
+- Implementers must do their own due diligence in selecting a source
+  code scanner that integrates with their specific environment.
+  Microsoft documentation references an Open Web Application Security Project, [Source Code Analysis Tools](https://owasp.org/www-community/Source_Code_Analysis_Tools); which is a guide to
+  third-party scanners. This baseline does not endorse or advise on the selection or
+  use of any specific third-party tool.
+
+- If BYOK is deemed to be a requirement:
+
+  - Power BI Premium is required for BYOK.
+
+  - To use BYOK, the Power BI tenant admin must upload data to the Power
+  BI service from a Power BI Desktop (PBIX) file.
+
+  - RSA keys must be 4096-bit.
+
+  - Enable BYOK in the tenant.
+
+**BYOK Implementation High-Level Steps**
+
+Enable BYOK at the tenant level via PowerShell by first introducing the
+encryption keys created and stored in Azure Key Vault to the Power BI
+tenant.
+
+Then assign these encryption keys per Premium capacity for encrypting
+content in the capacity.
+
+To enable bringing the agency's key for Power BI, the high-level
+configuration steps are as follows:
+
+1.  Add the Power BI service as a service principal for the key vault,
+    with wrap and unwrap permissions.
+
+2. Create an RSA key with a 4096-bit length (or use an existing key of
+    this type), with wrap and unwrap permissions.
+
+3. To turn on BYOK, Power BI Tenant administrators must use a set of
+    Power BI [Admin PowerShell
+    Cmdlets](https://learn.microsoft.com/en-us/powershell/module/microsoftpowerbimgmt.admin/?view=powerbi-ps)
+    added to the Power BI Admin Cmdlets.
+
+    Follow detailed steps in Microsoft's [Bring your own encryption keys for Power BI](https://learn.microsoft.com/en-us/power-bi/enterprise/service-encryption-byok)
+    from Microsoft.
+
+**Related Resources**
+
+- [Bring your own encryption keys for Power BI \| Microsoft
+ Learn](https://learn.microsoft.com/en-us/power-bi/enterprise/service-encryption-byok)
+
+- [Microsoft Security DevOps Azure DevOps extension](https://learn.microsoft.com/en-us/azure/defender-for-cloud/azure-devops-extension)
+
+- For GitHub, the agency can use the native secret scanning feature to
+  identify credentials or other form of secrets within code at [About
+  secret scanning \| GitHub
+  docs](https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning)
+
+- [Announcing General Availability of Bring Your Own Key (BYOK) for
+  Power BI
+  Premium](https://powerbi.microsoft.com/en-us/blog/announcing-general-availability-of-bring-your-own-key-byok-for-power-bi-premium/)
+
+# Appendix C: File Export and Visual Artifact Considerations
+
+Exporting data from Power BI to image files and comma-separated value
+(.csv) file format has data security implications. For example, if
+row-level security (RLS) features are in use in Power BI, an export to
+image or .csv could allow a user to inadvertently decouple that setting
+and expose data to a party who does not have permissions or a need to
+know that previously secured data. A similar scenario applies for
+information protection sensitivity labels.
+
+A message regarding this condition is provided in the Power BI tenant
+settings for the particular types of exports.
+
+In contrast to this, Power BI applies these protection settings (RLS,
+sensitivity labels) when the report data leaves Power BI via a supported
+export method, such as export to Excel, PowerPoint, or PDF, download to
+.pbix, and Save (Desktop). In this case, only authorized users will be
+able to open protected files.
+
+**Copy and Paste Visuals**
+
+Power BI can allow users to copy and paste visuals from Power BI reports
+as static images into external applications. This could represent a data
+security risk in some contexts. The agency must evaluate whether this
+represents risk for its data artifacts and whether to turn this off in
+the Export and Sharing Settings.
+
+**Related Resources**
+
+- [Sensitivity labels in Power BI \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/enterprise/service-security-sensitivity-label-overview)
+
+- [Say No to Export Data, Yes to Analyze in
+  Excel](https://radacad.com/say-no-to-export-data-yes-to-analyze-in-excel-power-bi-and-excel-can-talk)
+
+- [Power BI Governance – Why you should consider disabling Export to
+  Excel](https://data-marc.com/2020/04/13/power-bi-governance-why-you-should-consider-to-disable-export-to-excel/)
+
+**Implementation settings**
+
+1.  In the **Power BI tenant** settings, under **Export and sharing
+    settings**, administrators can opt to toggle off both **Export reports as
+    image files** and **Export to .csv**.
+
+2. In the **Power BI tenant** settings, under **Export and sharing
+    settings**, administrators can opt to toggle off **Copy and paste visuals**.
+
+**Establishing Private Network Access Connections Using Azure Private Link:**
+
+When connecting to Azure services intended to supply Power BI datasets,
+agencies should consider connecting their Power BI tenant to an Azure
+Private Link endpoint and disable public internet access.
+
+In this configuration, Azure Private Link and Azure Networking private
+endpoints are used to send data traffic privately using Microsoft's
+backbone network infrastructure. The data travels the Microsoft private
+network backbone instead of going across the Internet.
+
+Using private endpoints with Power BI ensures that traffic will flow
+over the Azure backbone to a private endpoint for Azure cloud-based
+resources.
+
+Within this configuration, there is also the capability to disable
+public access to Power BI datasets.
+
+**High-Level Implementation Steps**
+
+> Note:
+> It is imperative that the VNET and VM are configured before
+disabling public internet access.
+
+1.  Enable private endpoints for Power BI.
+
+2. Create a Power BI resource in the Azure portal.
+
+3. Create a virtual network.
+
+4. Create a virtual machine (VM).
+
+5. Create a private endpoint.
+
+6. Connect to a VM using Remote Desktop (RDP).
+
+7. Access Power BI privately from the virtual machine.
+
+8. Disable public access for Power BI.
+
+**Related Resources**
+
+- [Private endpoints for secure access to Power BI  \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-bi/enterprise/service-security-private-links)
+
+- [Azure security baseline for Power BI](https://learn.microsoft.com/en-us/security/benchmark/azure/baselines/power-bi-security-baseline)
+
+## Best Practices for Service Principals
+
+- Evaluate whether certificates or secrets are a more secure option for
+  the implementation.
+  > Note:
+  > Microsoft recommends certificates over secrets.
+
+- Use the principle of least privilege in implementing service
+  principals; only provide the ability to create app registrations to
+  entities requiring it.
+
+- Instead of enabling service principals for the entire agency,
+  implement for a dedicated security group.
+
+> Note:
+> This policy is only applicable if the setting **Allow service principals to use Power BI APIs** is enabled.
+
+**`TLP:CLEAR`**

--- a/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerplatform.md
+++ b/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/powerplatform.md
@@ -1,0 +1,486 @@
+**`TLP:CLEAR`**
+
+# CISA M365 Secure Configuration Baseline for Power Platform
+
+Microsoft 365 (M365) Power Platform is a cloud-based enterprise group of applications comprised of a low-code application development toolkit, business intelligence software, a custom chat bot creator, and app connectivity software.  This Secure Configuration Baseline (SCB) provides specific policies to help secure Power Platform security.
+
+The Secure Cloud Business Applications (SCuBA) project, run by the Cybersecurity and Infrastructure Security Agency (CISA), provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies’ cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for M365 help secure federal information assets stored within M365 cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government’s threats and risk tolerance with the knowledge that every organization has different threat models and risk tolerance. While use of these baselines will be mandatory for civilian Federal Government agencies, organizations outside of the Federal Government may also find these baselines to be useful references to help reduce risks.
+
+For non-Federal users, the information in this document is being provided “as is” for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products; CISA has no control over vendor changes to products offerings or features.  Accordingly, these SCuBA SCBs for M365 may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+> This document is marked TLP:CLEAR. Recipients may share this information without restriction. Information is subject to standard copyright rules. For more information on the Traffic Light Protocol, see https://www.cisa.gov/tlp.
+
+
+## License Compliance and Copyright
+
+Portions of this document are adapted from documents in Microsoft’s [Microsoft 365](https://github.com/MicrosoftDocs/microsoft-365-docs/blob/public/LICENSE) and [Azure](https://github.com/MicrosoftDocs/azure-docs/blob/main/LICENSE) GitHub repositories. The respective documents are subject to copyright and are adapted under the terms of the Creative Commons Attribution 4.0 International license. Source documents are linked throughout this document. The United States Government has adapted selections of these documents to develop innovative and scalable configuration standards to strengthen the security of widely used cloud-based software services.
+
+## Assumptions
+
+The **License Requirements** sections of this document assume the organization is using an [M365 E3](https://www.microsoft.com/en-us/microsoft-365/compare-microsoft-365-enterprise-plans) or [G3](https://www.microsoft.com/en-us/microsoft-365/government) license level at a minimum. Therefore, only licenses not included in E3/G3 are listed.
+
+## Key Terminology
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in
+[RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+
+The following section summarizes the various Power Platform applications referenced in this baseline:
+
+1. **Power Apps**: Low-code application development software used
+to create custom business applications. The apps can be developed as desktop,
+mobile, and even web apps. Three different types of Power Apps can be
+created:
+
+   1. [**Canvas Apps**](https://learn.microsoft.com/en-us/power-apps/maker/canvas-apps/): These are drag and
+    drop style developed apps, where
+    users drag and add User Interface (UI) components to the screen.
+    Users can then connect the components to data sources to display
+    data in the canvas app.
+
+   2. [**Model-Driven Apps**](https://learn.microsoft.com/en-us/power-apps/maker/model-driven-apps/): These are apps developed from an existing
+    data source. They can be thought of as the inverse of a Canvas App.
+    Since, you build the app from the source rather than building the UI and then connecting to the source like
+    Canvas apps.
+
+   3. [**Power Pages**](https://learn.microsoft.com/en-us/power-pages/): These apps that are developed to function as either internal or external facing websites.
+
+2. [**Power Automate**](https://learn.microsoft.com/en-us/power-automate/): This is an online tool within Microsoft 365 and add-ins used to create automated workflows between apps
+and services to synchronize files, get notifications, and collect data.
+
+3. [**Power Virtual Agents**](https://learn.microsoft.com/en-us/power-virtual-agents/): These are custom chat bots for use in the stand-alone Power Virtual Agents web app or in a Microsoft Teams
+channel.
+
+4. [**Connectors**](https://learn.microsoft.com/en-us/connectors/connector-reference/): These are proxies or wrappers around an API that allow the underlying service to be accessed from Power Automate Workflows, Power Apps, or Azure Logic Apps.
+
+5. [**Microsoft Dataverse**](https://learn.microsoft.com/en-us/power-apps/maker/data-platform/): This is a cloud database management system most
+often used to store data in SQL-like tables. A Power App would then use
+a connector to connect to the Dataverse table and perform create, read,
+update, and delete (CRUD) operations.
+
+**BOD 25-01 Requirement**: This indicator means that the policy is required under CISA BOD 25-01.
+
+**Automated Check**: This indicator means that the policy can be automatically checked via ScubaGear. See the [Quick Start Guide](../../../README.md#quick-start-guide) for help getting started.
+
+**Manual**: This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+Baseline Policies in this document are targeted towards administrative controls that apply to
+Power Platform applications at either the tenant or Power Platform
+environment level. Additional Power Platform security settings can be
+implemented at the app level, connector level, or Dataverse table level.
+Refer to [Power Platform Microsoft Learn documentation](https://learn.microsoft.com/en-us/power-platform/) for those additional controls.
+
+## 1. Creation of Power Platform Environments
+
+By default, any user in the Microsoft Entra ID Tenant can create additional environments. Enabling these controls will restrict the creation of new environments to users with the following admin roles: Global admins, Dynamics 365 admins, and Power Platform admins.
+
+### Policies
+
+#### MS.POWERPLATFORM.1.1v1
+The ability to create production and sandbox environments SHALL be restricted to admins.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+<!--Policy: MS.POWERPLATFORM.1.1v1; Criticality: SHALL -->
+- _Rationale:_ Users creating new Power Platform environments may inadvertently bypass data loss prevention (DLP) policy settings or misconfigure the security settings of their environment.
+- _Last Modified:_ June 2023
+- Note: This control restricts creating environments to users with Global admin, Dynamics 365 service admin, Power Platform service admins, or Delegated admin roles.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+
+#### MS.POWERPLATFORM.1.2v1
+The ability to create trial environments SHALL be restricted to admins.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.POWERPLATFORM.1.2v1; Criticality: SHALL -->
+- _Rationale:_ Users creating new Power Platform environments may inadvertently bypass DLP policy settings or misconfigure the security settings of their environment.
+- _Last Modified:_ June 2023
+- Note: This control restricts creating environments to users with Global admin, Dynamics 365 service admin, Power Platform service admins, or Delegated admin roles.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+### Resources
+
+- [Control who can create and manage environments in the Power Platform
+  admin center \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-platform/admin/control-environment-creation)
+
+- [Power Platform \| Digital Transformation Agency of
+  Australia](https://desktop.gov.au/blueprint/office-365.html#power-platform)
+
+- [Microsoft Power Apps Documentation \| Power
+  Apps](https://learn.microsoft.com/en-us/power-apps/)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.POWERPLATFORM.1.1v1 Instructions
+1.  Sign in to your tenant environment's respective [Power Platform admin
+    center](https://learn.microsoft.com/en-us/power-platform/admin/powerapps-us-government#power-apps-us-government-service-urls).
+
+2.  In the upper-right corner of the Microsoft Power Platform site,
+    select the **Gear icon** (Settings icon).
+
+3.  Select **Power Platform settings**.
+
+4.  Under **Production environment assignments**, select
+    **Only specific admins.**
+
+#### MS.POWERPLATFORM.1.2v1 Instructions
+1.  Follow the MS.POWERPLATFORM.1.1v1 instructions up to step **3**.
+
+2.  Under **Trial environment assignments**, select **Only specific admins.**
+
+## 2. Power Platform Data Loss Prevention Policies
+
+To secure Power Platform environments, DLP
+policies can be created to restrict the connectors used with
+Power Apps created in an environment. A DLP policy can be created to
+affect all or some environments or exclude certain environments. The
+more restrictive policy will be enforced when there is a conflict.
+
+Connectors can be separated by creating a DLP policy assigning them
+to one of three groups: Business, Non-Business, and Blocked. Connectors
+in different groups cannot be used in the same Power App. Connectors in
+the Blocked group cannot be used at all. (Note: Some M365 connectors
+cannot be blocked, such as Teams and SharePoint connectors).
+
+In the DLP policy, connectors can be configured to restrict read
+and write permissions to the data source/service. Connectors that cannot
+be blocked cannot be configured. Agencies should evaluate the
+connectors and configure them to fit agency needs and security
+requirements. The agency should then create a DLP policy to only allow
+those connectors to be used in Power Platform.
+
+When the Microsoft Entra ID tenant is created, by default, a Power Platform
+environment is created in Power Platform. This Power Platform
+environment will bear the name of the tenant. There is no way to
+restrict users in the Microsoft Entra ID tenant from creating Power Apps in the
+default Power Platform environment. Admins can restrict users from
+creating apps in all other created environments.
+
+### Policies
+
+#### MS.POWERPLATFORM.2.1v1
+A DLP policy SHALL be created to restrict connector access in the default Power Platform environment.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.POWERPLATFORM.2.1v1; Criticality: SHALL -->
+- _Rationale:_ All users in the tenant have access to the default Power Platform environment. Those users may inadvertently use connectors that share sensitive information with others who should not have access to it. Users requiring Power Apps should be directed to conduct development in other Power Platform environments with DLP connector policies customized to suit the user's needs while also maintaining the agency's security posture.
+- _Last Modified:_ June 2023
+- _Note:_ The following connectors drive core Power Platform functionality and enable core Office customization scenarios: Approvals, Dynamics 365 Customer Voice, Excel Online (Business), Microsoft Dataverse (legacy), Microsoft Teams, Microsoft To-Do (Business), Office 365 Groups, Office 365 Outlook, Office 365 Users, OneDrive for Business, OneNote (Business), Planner, Power Apps Notification, Power BI, SharePoint, Shifts for Microsoft Teams, and Yammer. As such these connectors remain non-blockable to maintain core user scenario functions.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+
+#### MS.POWERPLATFORM.2.2v1
+Non-default environments SHOULD have at least one DLP policy affecting them.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.POWERPLATFORM.2.2v1; Criticality: SHOULD -->
+- _Rationale:_ Users may inadvertently use connectors that share sensitive information with others who should not have access to it. DLP policies provide a way for agencies to detect and prevent unauthorized disclosures.
+- _Last Modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+
+### Resources
+
+- [Data Policies for Power Automate and Power Apps \| Digital
+  Transformation Agency of
+  Australia](https://desktop.gov.au/blueprint/office-365.html#power-apps-and-power-automate)
+
+- [Create a data loss prevention (DLP) policy \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-platform/admin/create-dlp-policy)
+
+- [DLP connector classification \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-platform/admin/dlp-connector-classification?source=recommendations)
+
+- [DLP for custom connectors \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-platform/admin/dlp-custom-connector-parity?WT.mc_id=ppac_inproduct_datapol)
+  
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.POWERPLATFORM.2.1v1 Instructions
+1.  Sign in to your tenant environment's respective [Power Platform admin
+    center](https://learn.microsoft.com/en-us/power-platform/admin/powerapps-us-government#power-apps-us-government-service-urls).
+
+2.  On the left pane, select **Security** -\> **Data and privacy.**
+
+3.   Select **Data policy,** then select **+ New Policy** icon to create a new policy.
+
+4.  Give the policy a suitable agency name and click **Next.**
+
+5.  At the **Prebuilt connectors** section, search and select the connectors currently in the **Non-business | default** tab containing sensitive data that can be utilized to create flows and apps.
+
+6.  Click **Move to Business.** Connectors added to this group can not share data with connectors in other groups because connectors can reside in only one data group at a time. 
+
+7.  If necessary (and possible) for the connector, click **Configure connector** at the top of the screen to change connector permissions. This allows greater flexibility for the agency to allow and block certain connector actions for additional customization. 
+
+8.  For the default environment, move all other connectors to the **Blocked** category. For non-blockable connectors noted above, the Block action will be grayed out and a warning will appear.
+
+9.  At the bottom of the screen, select **Next** to move on.
+
+10.  Add a custom connector pattern. Custom connectors allow admins to specify an ordered list of Allow and Deny URL patterns for custom connectors.  View [DLP for custom connectors \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-platform/admin/dlp-custom-connector-parity?WT.mc_id=ppac_inproduct_datapol) for more information.
+
+11.  Click **Next**.
+
+12.  At the **Scope** section for the default environment, select **Add multiple environments** then click **Next**.
+
+13.  Select the default environment, then select the **+ Add to policy** button at the top of the screen, then select **Next**.
+
+14. Select **Next**-\> **Create Policy** to finish.
+
+#### MS.POWERPLATFORM.2.2v1 Instructions
+1.  Repeat steps 1 to 11 in the MS.POWERPLATFORM.2.1v1 instructions.
+
+2.  At the **Scope** section for the default environment, select **Add multiple environments** and select the non-default environments where you wish to enforce a DLP policy upon. If you wish to apply the DLP policy for all environments including environments created in the future select **Add all environments**.
+
+4.  Select **Next**-\> **Create Policy** to finish.
+
+
+## 3. Power Platform Tenant Isolation
+
+Power Platform tenant isolation is different from Microsoft Entra ID wide tenant
+restriction. It does not impact Microsoft Entra-based access outside of Power
+Platform. Power Platform tenant isolation only works for connectors
+using Microsoft Entra-based authentication, such as Office 365 Outlook or
+SharePoint. The default configuration in Power Platform has tenant
+isolation set to **Off**, allowing for cross-tenant connections to
+be established. A user from tenant A using a Power App with a connector
+can seamlessly establish a connection to tenant B if using appropriate
+Microsoft Entra ID credentials.
+
+If admins want to allow only a select set of tenants to establish
+connections to or from their tenant, they can turn on tenant isolation.
+Once tenant isolation is turned on, inbound (connections to the tenant
+from external tenants) and outbound (connections from the tenant to
+external tenants) cross-tenant connections are blocked by Power Platform
+even if the user presents valid credentials to the Microsoft Entra-secured data
+source.
+
+### Policies
+
+#### MS.POWERPLATFORM.3.1v1
+Power Platform tenant isolation SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.POWERPLATFORM.3.1v1; Criticality: SHALL -->
+- _Rationale:_ Provides an additional tenant isolation control on top of Microsoft Entra ID tenant isolation specifically for Power Platform applications to prevent accidental or malicious cross tenant information sharing.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, SC-7(5)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.004: Cloud Accounts](https://attack.mitre.org/techniques/T1078/004/)
+  - [T1190: Exploit Public-Facing Application](https://attack.mitre.org/techniques/T1190/)
+
+#### MS.POWERPLATFORM.3.2v1
+An inbound/outbound connection allowlist SHOULD be configured.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#mspowerplatform32v1-instructions)
+
+
+
+<!--Policy: MS.POWERPLATFORM.3.2v1; Criticality: SHOULD -->
+- _Rationale:_ Depending on agency needs an allowlist can be configured to allow cross tenant collaboration via connectors.
+- _Last modified:_ June 2023
+- Note: The allowlist may be empty if the agency has no need for cross tenant collaboration.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, SC-7(5)
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+### Resources
+
+- [Enable tenant isolation and configure allowlist \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-platform/admin/cross-tenant-restrictions#enable-tenant-isolation-and-configure-allowlist)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.POWERPLATFORM.3.1v1 Instructions
+1.  Sign in to your tenant environment's respective [Power Platform admin
+    center](https://learn.microsoft.com/en-us/power-platform/admin/powerapps-us-government#power-apps-us-government-service-urls).
+
+2.  On the left pane, select **Security -\> Identity and access -\> Tenant Isolation**.
+
+3.  Set the slider **Restrict cross-tenant connections** to **On,** then click **Save**
+    on the bottom of the screen.
+
+#### MS.POWERPLATFORM.3.2v1 Instructions
+1.  Follow steps **1 and 2** in **MS.POWERPLATFORM.3.1v1 instructions** to
+arrive at the same page.
+
+2.  The tenant isolation exceptions can be configured by clicking **+ Add exceptions**
+on the Tenant Isolation page.
+
+3.  Select the **Direction** of the rule and add the **Tenant Domain or ID** this rule applies to.
+
+4.  If Tenant Isolation is switched **Off**, these rules will not be enforced until tenant
+isolation is turned **On**.
+
+## 4. Power Apps Content Security Policy
+
+Content Security Policy (CSP) is an added security layer that helps
+to detect and mitigate certain types of attacks, including Cross-Site
+Scripting (XSS), clickjacking, and data injection attacks. When enabled, this setting can apply to all
+current canvas apps and model-driven apps at the Power Platform environment level.
+
+### Policies
+
+#### MS.POWERPLATFORM.4.1v1
+Content Security Policy (CSP) SHALL be enforced for model-driven and canvas Power Apps.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#mspowerplatform41v1-instructions)
+
+<!--Policy: MS.POWERPLATFORM.4.1v1; Criticality: SHALL -->
+- _Rationale:_ Adds CSP as a defense mechanism for Power Apps against common website attacks.
+- _Last Modified:_ March 2025
+- _Note:_ This policy is only applicable to environments using Dataverse.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-10
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1190: Exploit Public-Facing Application](https://attack.mitre.org/techniques/T1190/)
+
+### Resources
+
+- [Content Security Policy \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-platform/admin/content-security-policy)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.POWERPLATFORM.4.1v1 Instructions
+1.  Sign in to your tenant environment's respective [Power Platform admin
+center](https://learn.microsoft.com/en-us/power-platform/admin/powerapps-us-government#power-apps-us-government-service-urls).
+
+2.  On the left-hand pane click on **Manage -\> Environments** and then select an environment from the list.
+
+3.  Select the **Settings** icon at the top of the page.
+
+4.  Click on **Product** then click on **Privacy + Security** from the options that appear.
+
+5.  At the bottom of the page under the **Content security policy** section, set **Enforce content security policy** to **On** for **Model-driven** and **Canvas**.
+
+6.  At the same location, set **Enable reporting**  to **On** and add an appropriate endpoint for reporting CSP violations can be reported to.
+
+7.  Repeat steps 2 to 6 for all active Power Platform environments.
+
+## 5. Power Pages Creation
+
+Power Pages formerly known as Power Portals are Power Apps specifically designed to act as external facing websites. By default any user in the tenant can create a Power Page. Admins can restrict the creation of new Power Pages to only admins.
+
+### Policies
+
+#### MS.POWERPLATFORM.5.1v1
+The ability to create Power Pages sites SHOULD be restricted to admins.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.POWERPLATFORM.5.1v1; Criticality: SHOULD -->
+- _Rationale:_ Users may unintentionally misconfigure their Power Pages to expose sensitive information or leave the website in a vulnerable state.
+- _Last Modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1190: Exploit Public-Facing Application](https://attack.mitre.org/techniques/T1190/)
+
+### Resources
+- [Control Portal Creation \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-apps/maker/portals/control-portal-creation)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.POWERPLATFORM.5.1v1 Instructions
+1.  This setting currently can only be enabled through the [Power Apps PowerShell modules](https://learn.microsoft.com/en-us/power-platform/admin/powerapps-powershell#installation).
+
+2. After installing the Power Apps PowerShell modules, run `Add-PowerAppsAccount -Endpoint $YourTenantsEndpoint`. To authenticate to your tenant's Power Platform.
+Discover the valid endpoint parameter [here](https://learn.microsoft.com/en-us/powershell/module/microsoft.powerapps.administration.powershell/add-powerappsaccount?view=pa-ps-latest#-endpoint). Commercial tenants use `-Endpoint prod`, GCC tenants use `-Endpoint usgov` and so on.
+
+3. Then run the following PowerShell command to disable the creation of Power Pages sites by non-administrative users.
+
+    ```
+    Set-TenantSettings -RequestBody @{ “disablePortalsCreationByNonAdminUsers” = $true }
+    ```
+
+## 6. Power Apps Sharing Controls
+
+Power Apps supports discovery of apps by allowing makers to share canvas apps with individuals and security groups. Sharing with **Everyone**, or all users present in the directory, is disabled by default. When the **Share with Everyone** feature is disabled, only Dynamics 365 administrators, Power Platform administrators, and global administrators have the ability to share an application with everyone in the environment.
+
+### Policies
+
+#### MS.POWERPLATFORM.6.1v1
+The Share with Everyone feature SHOULD be disabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.POWERPLATFORM.6.1v1; Criticality: SHOULD -->
+- _Rationale:_ Prevents tenant-wide exposure of applications with unintended users. If enabled, this setting grants application access to the **Everyone** group for your organization. Its membership contains all users present in the directory, including B2B guest accounts and internal members. The **Everyone** group is not a standard Microsoft Entra ID security group and can't be edited or viewed, complicating auditing and access governance. The configuration setting is disabled by default; however, this is a defense-in-depth policy to protect against misconfigurations or malicious actors.
+- _Last Modified:_ October 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(5), AC-6(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.004: Cloud Accounts](https://attack.mitre.org/techniques/T1078/004/)
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098.007: Additional Local or Domain Groups](https://attack.mitre.org/techniques/T1098/007/)
+
+### Resources
+- [Limit Sharing with Everyone \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/power-platform/guidance/adoption/secure-default-environment#limit-sharing-with-everyone)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.POWERPLATFORM.6.1v1 Instructions
+1.  This setting currently can only be enabled through the [Power Apps PowerShell modules](https://learn.microsoft.com/en-us/power-platform/admin/powerapps-powershell#installation).
+
+2. After installing the Power Apps PowerShell modules, run `Add-PowerAppsAccount -Endpoint $YourTenantsEndpoint`. To authenticate to your tenant's Power Platform.
+Discover the valid endpoint parameter [here](https://learn.microsoft.com/en-us/powershell/module/microsoft.powerapps.administration.powershell/add-powerappsaccount?view=pa-ps-latest#-endpoint). Commercial tenants use `-Endpoint prod`, GCC tenants use `-Endpoint usgov` and so on.
+
+3. Then run the following PowerShell commands to get the settings object and set the variable `disableShareWithEveryone` to `$true`.
+
+    ```
+    $tenantSettings = Get-TenantSettings
+    $tenantSettings.powerPlatform.powerApps.disableShareWithEveryone = $true
+    Set-TenantSettings $tenantSettings
+    ```
+
+**`TLP:CLEAR`**

--- a/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md
+++ b/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/securitysuite.md
@@ -1,0 +1,1361 @@
+**`TLP:CLEAR`**
+
+# CISA M365 Secure Configuration Security Suite Baseline
+
+Several essential security functions for M365 services require a dedicated security suite, e.g., for
+data loss prevention. M365 provides these security functions natively via Defender for Office 365
+and Microsoft Purview. Notably, some of these capabilities require licenses not included by default
+with E3 or G3, such Defender for Office 365 Plan 1 and 2. These licenses are included with E5 and G5
+and are available as add-ons for E3 and G3. However, third-party solutions that offer comparable
+security functions can be used in lieu of Defender and Purview. The Security Suite Baseline
+enumerates a set of required security functions agencies should configure, be it through Defender
+and Purview or third-party tools of their choice. Should an agency elect to use Defender and
+Purview, agencies should follow the implementation guidance included with this baseline. However,
+regardless of whether Defender and Purview are used, the policies in this baseline are applicable
+to all M365 users.
+
+The Secure Cloud Business Applications (SCuBA) project, run by the Cybersecurity and Infrastructure Security Agency (CISA), provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies’ cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for M365 help secure federal information assets stored within M365 cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government’s threats and risk tolerance with the knowledge that every organization has different threat models and risk tolerance. While use of these baselines will be mandatory for civilian Federal Government agencies, organizations outside of the Federal Government may also find these baselines to be useful references to help reduce risks.
+
+For non-Federal users, the information in this document is being provided "as is" for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products; CISA has no control over vendor changes to products offerings or features.  Accordingly, these SCuBA SCBs for M365 may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+
+
+> This document is marked TLP:CLEAR. Recipients may share this information without restriction. Information is subject to standard copyright rules. For more information on the Traffic Light Protocol, see https://www.cisa.gov/tlp.
+
+## License Compliance and Copyright
+Portions of this document are adapted from documents in Microsoft's [M365](https://github.com/MicrosoftDocs/microsoft-365-docs/blob/public/LICENSE) and [Azure](https://github.com/MicrosoftDocs/azure-docs/blob/main/LICENSE) GitHub repositories. The respective documents are subject to copyright and are adapted under the terms of the Creative Commons Attribution 4.0 International license. Sources are linked throughout this document. The United States government has adapted selections of these documents to develop innovative and scalable configuration standards to strengthen the security of widely used cloud-based software services.
+
+## Assumptions
+The agency has identified a set of user accounts that are considered sensitive accounts. See [Key Terminology](#key-terminology) for a detailed description of sensitive accounts.
+
+The **License Requirements** sections of this document assume the organization is using an [M365 E3](https://www.microsoft.com/en-us/microsoft-365/compare-microsoft-365-enterprise-plans) or [G3](https://www.microsoft.com/en-us/microsoft-365/government) license level at a minimum. Therefore, only licenses not included in E3/G3 are listed.
+
+## Key Terminology
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+The following are key terms and descriptions used in this document.
+
+**Sensitive Accounts**: This term denotes a set of user accounts that have either
+access to sensitive and high-value information or are likely to be seen as trusted
+authority figures by other users. Certain accounts—like those belonging to CEOs,
+CFOs, CISOs, and IT administrators—have access to highly sensitive data and critical
+systems, making them prime targets for cyberattacks. These accounts, referred to
+as priority accounts, require enhanced security measures to minimize the risk of
+compromise.
+
+**Threat Policies**: Much of Microsoft Defender for Office 365's configuration
+is managed through threat policies. Users, groups, and domains can be added to
+or excluded from threat security polices. Users added to a policy receive the
+protections configured for that policy.
+While users can create custom threat polices, Microsoft Defender defines three
+[preset security policies](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/preset-security-policies?view=o365-worldwide):
+built-in protection, standard, and strict. These preset policies are informed by
+Microsoft's observations, and are designed to strike the balance between usability
+and security. They allow administrators to enable the full feature set of Defender
+by adding users to the policies rather than manually configuring each setting.
+One simple method of meeting many requirements of this baseline is to add users
+to the standard or strict preset policies, though some organizations may require
+the flexibility afforded by custom policies.
+
+**BOD 25-01 Requirement**: This indicator means that the policy is required under CISA BOD 25-01.
+
+**Automated Check**: This indicator means that the policy can be automatically checked via ScubaGear. See the [Quick Start Guide](../../../README.md#quick-start-guide) for help getting started.
+
+**Requires Configuration**: This indicator means that ScubaGear requires configuration via config file in order to check the policy.
+
+**Manual**: This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. Malware Protection
+
+Emails and Teams messages may include attachments that contain malware. Therefore,
+messages should be scanned for malware to prevent infections. Once malware has
+been identified, the scanner should drop or quarantine the associated messages.
+Because malware detections may be updated, it is also important that messages
+that were already delivered to users are also scanned and removed.
+
+The Safe Attachments feature included with Defender will scan messages for
+attachments with malicious content. All messages with attachments not already
+flagged by anti-malware protections in EOP are downloaded to a Microsoft virtual
+environment for further analysis. Safe Attachments then uses machine learning and
+other analysis techniques to detect malicious intent. While Safe Attachments for
+Exchange Online is automatically configured in the preset policies, separate
+action is needed to enable it for other products.
+
+### Policies
+
+#### MS.SECURITYSUITE.1.1v1
+Emails with click-to-run file attachments SHALL be blocked, including at a minimum .exe, .cmd, and .vbe files.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.1.1v1; Criticality: SHALL -->
+- _Rationale:_ Malicious attachments often take the form of click-to-run files.
+Sharing high risk file types, when necessary, is better left to a means other
+than email; the dangers of allowing them to be sent over email outweigh
+any potential benefits. Filtering email attachments based on file types can
+prevent spread of malware distributed via click-to-run email attachments.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+
+#### MS.SECURITYSUITE.1.2v1
+Email scanning SHALL be capable of reviewing emails after delivery.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.1.2v1; Criticality: SHALL -->
+- _Rationale:_ As known malware signatures are updated, it is possible for an email to be retroactively identified as containing malware after delivery. By scanning emails, the number of malware-infected in users' mailboxes can be reduced.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+
+#### MS.SECURITYSUITE.1.3v1
+Emails identified as containing malware SHALL be quarantined or dropped.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.1.3v1; Criticality: SHALL -->
+- _Rationale:_ Email can be used as a mechanism for delivering malware.
+Preventing emails with known malware from reaching user mailboxes helps ensure
+users cannot interact with those emails.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+
+#### MS.SECURITYSUITE.1.4v1
+SharePoint, OneDrive, and Teams message attachments SHOULD be scanned for malware.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.1.4v1; Criticality: SHOULD -->
+- _Rationale:_ Files shared through Teams or hosted on SharePoint/OneDrive can be used as a mechanism for delivering malware. In many cases, malware can be detected through scanning, reducing the risk for end users.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+
+### Resources
+
+- [Anti-malware protection for cloud mailboxes \| Microsoft Learn](https://learn.microsoft.com/en-us/defender-office-365/anti-malware-protection-about)
+- [Set up Safe Attachments policies in Microsoft Defender for Office 365 \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/safe-attachments-policies-configure?view=o365-worldwide)
+
+### License Requirements
+
+Safe attachments require Defender for Office 365 Plan 1 or 2. These are included with
+  E5 and G5 and are available as add-ons for E3 and G3.
+
+### Implementation
+
+#### MS.SECURITYSUITE.1.1v1 Instructions
+
+Both the standard and strict preset policies meet this baseline policy requirement,
+so no further actions are needed for users added to those policies. See
+[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)
+for instructions on adding users to these policies.
+
+As the steps for MS.SECURITYSUITE.1.1v1 and MS.SECURITYSUITE.1.2v1 share many steps in common,
+steps for both policies are included in this section. Steps that do not strictly apply to
+MS.SECURITYSUITE.1.1v1 are followed by the applicable SCuBA policy in parenthesis.
+
+For users not added to the standard or strict preset policies:
+1.  Sign in to **Microsoft 365 Defender**.
+2.  Under **Email & collaboration**, select **Policies & rules**.
+3.  Select **Threat policies**.
+4.  Under **Policies**, select **Anti-malware**.
+5.  If modifying an existing policy:
+    1. Click the name of the policy from the policy list to open the policy summary.
+    2. Click **Edit user and domains**. _Note:_ the **Default (default)** policy applies to all users, so skip this step if modifying the default policy.
+        - Add users, groups, and domains as needed. To make the policy apply to all users, under
+          **Domains**, enter all the tenant domains.
+        - (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**
+          to be exempted from this policy.
+        - Click **Save**.
+    3. Click **Edit protection settings**
+    4. Check **Enable zero-hour auto purge for malware (Recommended)**. (_MS.SECURITYSUITE.1.2v1_)
+    5. Check **Enable the common attachments filter**.
+    6. Click **Customize file types** and ensure that at a minimum .exe, .cmd, and .vba are selected.
+    7. Click **Save**.
+6.  If creating a new policy:
+    1. Click **Create**.
+    2. After naming the policy, click **Next**.
+    3. Add users, groups, and domains as needed. To make the policy apply to all users, under
+       **Domains**, enter all the tenant domains.
+    4. (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**
+       to be exempted from this policy.
+    5. Click **Next**.
+    6. Check **Enable zero-hour auto purge for malware (Recommended)**. (_MS.SECURITYSUITE.1.2v1_)
+    7. Check **Enable the common attachments filter**.
+    8. Click **Select file types** and ensure that at a minimum .exe, .cmd, and .vba are selected, then click **Done**.
+    9. Click **Next** then **Submit**.
+
+#### MS.SECURITYSUITE.1.2v1 Instructions
+Both the standard and strict preset policies meet this baseline policy requirement,
+so no further actions are needed for users added to those policies. See
+[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)
+for instructions on adding users to these policies.
+
+For users not added to the standard or strict preset policies, see [MS.SECURITYSUITE.1.2v1 Instructions](#mssecuritysuite12v1-instructions).
+
+#### MS.SECURITYSUITE.1.3v1 Instructions
+
+Both the standard and strict preset policies meet this baseline policy requirement,
+so no further actions are needed for users added to those policies. See
+[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)
+for instructions on adding users to these policies.
+
+For users not added to the standard or strict preset policies:
+1.  Sign in to **Microsoft 365 Defender**.
+2.  Under **Email & collaboration**, select **Policies & rules**.
+3.  Select **Threat policies**.
+4.  Under **Policies**, select **Safe Attachments**.
+5.  If modifying an existing policy:
+    1. Click the name of the policy from the policy list to open the policy summary.
+    2. Click **Edit user and domains**. _Note:_ the **Default (default)** policy applies to all users, so skip this step if modifying the default policy.
+        - Add users, groups, and domains as needed. To make the policy apply to all users, under
+          **Domains**, enter all the tenant domains.
+        - (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**
+          to be exempted from this policy.
+        - Click **Save**.
+    3. Click **Edit settings**
+    4. Under **Safe Attachments unknown malware response**, select **Block** or **Dynamic Delivery**.
+    5. Click **Save**.
+6.  If creating a new policy:
+    1. Click **Create**.
+    2. After naming the policy, click **Next**.
+    3. Add users, groups, and domains as needed. To make the policy apply to all users, under
+       **Domains**, enter all the tenant domains.
+    4. (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**
+       to be exempted from this policy.
+    5. Click **Next**.
+    4. Under **Safe Attachments unknown malware response**, select **Block** or **Dynamic Delivery**.
+    5. Click **Next** then **Submit**.
+
+#### MS.SECURITYSUITE.1.4v1 Instructions
+
+This baseline policy is _not_ covered by the preset policies, so these steps
+need to be taken even if the standard or strict policies are used.
+
+1.  Sign in to **Microsoft 365 Defender**.
+
+2.  Under **Email & collaboration**, select **Policies & rules**.
+
+3.  Select **Threat policies**.
+
+4.  Under **Policies**, select **Safe Attachments**.
+
+5.  Select **Global settings**.
+
+6.  Toggle the **Turn on Defender for Office 365 for SharePoint, OneDrive, and Microsoft Teams**
+    slider to **On**.
+
+7. Click **Save**.
+
+## 2. Impersonation Protection
+Impersonation protection checks incoming emails to see if the sender
+address is similar to the users or domains on an agency-defined list. If
+the sender address is significantly similar, as to indicate an
+impersonation attempt, the email is quarantined.
+
+### Policies
+#### MS.SECURITYSUITE.2.1v1
+User impersonation protection SHOULD be enabled for sensitive accounts.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Requires Configuration](https://img.shields.io/badge/Requires_Configuration-981D20)](../../../docs/configuration/configuration.md#security-suite-configuration)
+
+<!--Policy: MS.SECURITYSUITE.2.1v1; Criticality: SHOULD -->
+<!--ExclusionType: SensitiveUsers-->
+- _Rationale:_ User impersonation, especially of users seen as authority figures,
+has the potential to result in serious harm. Impersonation protection mitigates
+this risk.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+  - [T1656: Impersonation](https://attack.mitre.org/techniques/T1656/)
+
+#### MS.SECURITYSUITE.2.2v1
+Domain impersonation protection SHOULD be enabled for domains owned by the agency.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.2.2v1; Criticality: SHOULD -->
+- _Rationale:_ Configuring domain impersonation protection for agency-owned domains
+reduces the risk of a user being deceived by a look-alike domain.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+  - [T1656: Impersonation](https://attack.mitre.org/techniques/T1656/)
+
+#### MS.SECURITYSUITE.2.3v1
+Domain impersonation protection SHOULD be added for key suppliers and partners.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Requires Configuration](https://img.shields.io/badge/Requires_Configuration-981D20)](../../../docs/configuration/configuration.md#security-suite-configuration)
+
+<!--Policy: MS.SECURITYSUITE.2.3v1; Criticality: SHOULD -->
+<!--ExclusionType: PartnerDomains-->
+- _Rationale:_ Configuring domain impersonation protection for domains owned by important partners reduces the risk of a user being deceived by a look-alike domain.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+  - [T1656: Impersonation](https://attack.mitre.org/techniques/T1656/)
+
+#### MS.SECURITYSUITE.2.4v1
+User warnings, comparable to the user safety tips included with EOP, SHOULD be displayed.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.2.4v1; Criticality: SHOULD -->
+- _Rationale:_ Many tasks are better suited for automated processes, such as identifying
+unusual characters in the `FROM` address or identifying a first-time sender.
+User warnings can handle these tasks, reducing the burden on end users and the risk of
+successful phishing attempts.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AT-2b, SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+  - [T1656: Impersonation](https://attack.mitre.org/techniques/T1656/)
+
+### Resources
+
+- [Impersonation settings in anti-phishing policies in Microsoft Defender for Office 365 \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/anti-phishing-policies-about?view=o365-worldwide#impersonation-settings-in-anti-phishing-policies-in-microsoft-defender-for-office-365)
+- [Use the Microsoft 365 Defender portal to assign Standard and Strict preset security policies to users \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/preset-security-policies?view=o365-worldwide#use-the-microsoft-365-defender-portal-to-assign-standard-and-strict-preset-security-policies-to-users)
+- [User impersonation protection \| Microsoft Learn](https://learn.microsoft.com/en-us/defender-office-365/anti-phishing-policies-about#user-impersonation-protection)
+
+### License Requirements
+
+- Impersonation protection and advanced phishing thresholds require
+  Defender for Office 365 Plan 1 or 2. These are included with E5 and G5
+  and are available as add-ons for E3 and G3. As of January 2026,
+  anti-phishing for user and domain impersonation and spoof intelligence
+  are not yet available in M365 Government Community Cloud (GCC High) and Department of Defense (DoD) environments. See [Platform features \|
+  Microsoft
+  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/office-365-platform-service-description/office-365-us-government/office-365-us-government#platform-features)
+  for current offerings.
+
+### Implementation
+
+When evaluating an email for impersonation, both the email *sender* and the
+*recipient* are factors. Impersonation protection is only applied if the *sender*
+has been added to a threat policy's **Users to protect** list and the *recipient*
+has been added to the threat policy where that list is defined.
+As such, one simple way of ensuring the **Users to protect** list applies to all
+recipients is to define the list in the default anti-phish policy, as that applies
+to all recipients. For simplicity, the implementation steps that follow just
+instruct users to configure impersonation protection in the default anti-phish
+policy. However, agencies are welcome to instead configure it in the other
+policies if desired, as long as ultimately all recipients recieve the
+impersonation protection checks.
+
+**Note**: If the preset security policies are used, both the standard and strict preset policies meet the requirements for MS.SECURITYSUITE.2.2v1 and MS.SECURITYSUITE.2.4v1. However, additional configuration is required for MS.SECURITYSUITE.2.1v1 and MS.SECURITYSUITE.2.3v1, as the sensitive users need to be added on the **Add email addresses to flag when impersonated by attackers** page and the parner domains need to be added on the **Add domains to flag when impersonated by attackers** page. See [Preset security policies in cloud organizations](https://learn.microsoft.com/en-us/defender-office-365/preset-security-policies) for detailed instructions.
+
+#### MS.SECURITYSUITE.2.1v1 Instructions
+
+1.  Sign in to **Microsoft 365 Defender**.
+2.  Under **Email & collaboration**, select **Policies & rules**.
+3.  Select **Threat policies**.
+4.  Under **Policies**, select **Anti-phishing**.
+5.  Select the **Office365 AntiPhish Default (Default)** policy.
+6.  Click **Edit protection settings**.
+7.  Under **Impersonation**, select **Enable users to protect**.
+8.  Click **Manage [x] sender(s)**.
+9.  On the **Manage senders for impersonation protection** page, click **Add user**
+then add a name and valid email address for each sensitive account and click **Add** after each.
+10. Click **Done** then **Save**.
+11. Click **Edit actions**.
+12. Under **If a message is detected as user impersonation**, select one of the following:
+    - **Redirect the message to other email addresses**
+    - **Move the message to the recipients' Junk Email folders**
+    - **Quarantine the message**
+    - **Delete the message before it's delivered**
+13. Click **Save**.
+
+**Note**: In order for ScubaGear to evaluate MS.SECURITYSUITE.2.1v1, it needs to know which users are considered sensitive. To configure this, use the `SensitiveUsers` config file option. If this config file option is not used or is empty, ScubaGear will report this policy as non-compliant. See [Security Suite Configuration](/docs/configuration/configuration.md#security-suite-configuration) for more details.
+
+#### MS.SECURITYSUITE.2.2v1 Instructions
+
+1.  Sign in to **Microsoft 365 Defender**.
+2.  Under **Email & collaboration**, select **Policies & rules**.
+3.  Select **Threat policies**.
+4.  Under **Policies**, select **Anti-phishing**.
+5.  Select the **Office365 AntiPhish Default (Default)** policy.
+6.  Click **Edit protection settings**.
+7.  Under **Impersonation**, check **Enable domains to protect** and **Include domains I own**.
+8.  Click **Save**.
+9. Click **Edit actions**.
+10. Under **If a message is detected as domain impersonation**, select one of the following:
+    - **Redirect the message to other email addresses**
+    - **Move the message to the recipients' Junk Email folders**
+    - **Quarantine the message**
+    - **Delete the message before it's delivered**
+11.  Click **Done** then **Save**.
+
+#### MS.SECURITYSUITE.2.3v1 Instructions
+
+1.  Sign in to **Microsoft 365 Defender**.
+2.  Under **Email & collaboration**, select **Policies & rules**.
+3.  Select **Threat policies**.
+4.  Under **Policies**, select **Anti-phishing**.
+5.  Select the **Office365 AntiPhish Default (Default)** policy.
+6.  Click **Edit protection settings**.
+7.  Under **Impersonation**, check **Enable domains to protect** and **Include custom domains**.
+8.  Click **Manage [x] custom domain(s)**.
+9.  On the **Manage custom domains for impersonation protection** page, click **Add domain**.
+10. Under **Domain**, enter each partner domain, then click **Add domains**.
+11. Click **Done** then **Save**.
+12. Click **Edit actions**.
+13. Under **If a message is detected as domain impersonation**, select one of the following:
+    - **Redirect the message to other email addresses**
+    - **Move the message to the recipients' Junk Email folders**
+    - **Quarantine the message**
+    - **Delete the message before it's delivered**
+14. Click **Save**.
+
+**Note**: In order for ScubaGear to evaluate MS.SECURITYSUITE.2.3v1, it needs to know which domains should be protected. To configure this, use the `PartnerDomains` config file option. If this config file option is not used or is empty, ScubaGear will report this policy as non-compliant. See [Security Suite Configuration](/docs/configuration/configuration.md#security-suite-configuration) for more details.
+
+#### MS.SECURITYSUITE.2.4v1 Instructions
+
+1.  Sign in to **Microsoft 365 Defender**.
+2.  Under **Email & collaboration**, select **Policies & rules**.
+3.  Select **Threat policies**.
+4.  Under **Policies**, select **Anti-phishing**.
+5.  Select the **Office365 AntiPhish Default (Default)** policy.
+6.  Click **Edit actions**.
+7.  Under **Safety tips & indicators**, ensure each safety tip and indicator is enabled.
+8.  Click **Save**.
+
+## 3. Data Loss Prevention
+
+There are several approaches to securing sensitive information, such
+as warning users, encryption, or blocking attempts to share. Agency
+policies for sensitive information, such as personally identifiable
+information (PII), should dictate how that information is handled and
+inform associated data loss prevention (DLP) policies. Defender can detect
+sensitive information and associates a default confidence level with
+this detection based on the sensitive information type matched.
+Confidence levels are used to reduce false positives in detecting access
+to sensitive information. Agencies may choose to use the default
+confidence levels or adjust the levels in custom DLP policies to fit
+their environment and needs.
+
+### Policies
+#### MS.SECURITYSUITE.3.1v1
+A DLP policy SHALL be configured to protect PII and sensitive information, as defined by the agency, blocking at a minimum: credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN).
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.3.1v1; Criticality: SHALL -->
+- _Rationale:_ Users may inadvertently share sensitive information with
+               others who should not have access to it. DLP policies
+               provide a way for agencies to detect and prevent
+               unauthorized disclosures.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+
+#### MS.SECURITYSUITE.3.2v1
+The DLP policy SHOULD be applied to Exchange, OneDrive, SharePoint, Teams chat, and Devices.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.3.2v1; Criticality: SHOULD -->
+- _Rationale:_ Unauthorized disclosures may happen through M365 services
+               or endpoint devices. DLP policies should cover all
+               affected locations to be effective.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+    - [T1213.002: Sharepoint](https://attack.mitre.org/techniques/T1213/002/)
+
+#### MS.SECURITYSUITE.3.3v1
+The action for the DLP policy SHOULD be set to block sharing sensitive information with everyone.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.3.3v1; Criticality: SHOULD -->
+- _Rationale:_ Access to sensitive information should be prohibited unless
+               explicitly allowed. Specific exemptions can be made based
+               on agency policies and valid business justifications.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, SC-7(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+
+#### MS.SECURITYSUITE.3.4v1
+Notifications to inform users and help educate them on the proper use of sensitive information SHOULD be enabled in the DLP policy.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.3.4v1; Criticality: SHOULD -->
+- _Rationale:_ Some users may not be aware of agency policies on
+               proper use of sensitive information. Enabling
+               notifications provides positive feedback to users when
+               accessing sensitive information.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AT-2b
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+#### MS.SECURITYSUITE.3.5v1
+The DLP policy SHOULD include an action to block access to sensitive information by restricted apps
+and unwanted Bluetooth applications.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#mssecuritysuite35v1-instructions)
+
+<!--Policy: MS.SECURITYSUITE.3.5v1; Criticality: SHOULD -->
+- _Rationale:_ Some apps may inappropriately share accessed files or not conform to agency policies
+               for access to sensitive information. Defining a DLP policy with an action to block
+               access from restricted apps and unwanted Bluetooth applications prevents unauthorized
+               disclosure by those programs.
+- _Last modified:_ March 2026
+- _Note:_
+  - This action can only be included if at least one device is onboarded
+    to the agency tenant. Otherwise, the option to block restricted apps will
+    not be available.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-19a
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+  - [T1485: Data Destruction](https://attack.mitre.org/techniques/T1485/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1486: Data Encrypted for Impact](https://attack.mitre.org/techniques/T1486/)
+
+### Resources
+
+- [Plan for data loss prevention (DLP) \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/purview/dlp-overview-plan-for-dlp?view=o365-worldwide)
+
+- [Data loss prevention in Exchange Online \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/exchange/security-and-compliance/data-loss-prevention/data-loss-prevention)
+
+- [Personally identifiable information (PII) \|
+  NIST](https://csrc.nist.gov/glossary/term/personally_identifiable_information#:~:text=NISTIR%208259,2%20under%20PII%20from%20EGovAct)
+
+- [Sensitive information \|
+  NIST](https://csrc.nist.gov/glossary/term/sensitive_information)
+
+- [Get started with Endpoint data loss prevention - Microsoft Purview
+  (compliance) \| Microsoft Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)
+
+### License Requirements
+
+- DLP for Teams requires an E5 or G5 license. See [Microsoft Purview Data Loss Prevention: Data Loss Prevention for Teams \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#microsoft-purview-data-loss-prevention-data-loss-prevention-dlp-for-teams)
+  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.
+
+- DLP for Endpoint, needed for MS.SECURITYSUITE.3.5v1, requires an E5 or G5 license. See [Get started with
+  Endpoint data loss prevention - Microsoft Purview (compliance) \|
+  Microsoft
+  Learn](https://learn.microsoft.com/en-us/purview/endpoint-dlp-getting-started?view=o365-worldwide)
+  for more information. However, this requirement can also be met through a third-party solution. If a third-party solution is used, then a E5 or G5 license is not required for the respective policies.
+
+### Implementation
+
+#### MS.SECURITYSUITE.3.1v1 Instructions
+
+DLP is _not_ covered by the preset policies, so these steps need to be taken even if the standard
+or strict policies are used.
+
+As the steps for MS.SECURITYSUITE.3.1v1, MS.SECURITYSUITE.3.2v1, MS.SECURITYSUITE.3.3v1, and
+MS.SECURITYSUITE.3.4v1 share many steps in common, steps for all these policies are included in
+this section. Steps that do not strictly apply to MS.SECURITYSUITE.3.1v1 are followed by the
+applicable SCuBA policy in parenthesis.
+
+1. Sign in to the **Microsoft Purview portal**.
+
+2. Under the **Solutions** section on the left-hand menu, select **Data loss
+   prevention**.
+
+3. Select **Policies** from the top of the page.
+
+4. Select **Create policy**.
+
+5. From the **Categories** list, select **Custom**.
+
+6. From the **Regulations** list, select **Custom policy** and then click
+   **Next**.
+
+7. Edit the name and description of the policy if desired, then click
+   **Next**.
+
+8. Under **Assign admin units**,  ensure **Admin units** is set to **Full directory** by default, then click **Next**.
+
+9. Under **Choose where to apply the policy**, set **Status** to **On**
+   for at least the Exchange email, OneDrive accounts, SharePoint
+   sites, Teams chat and channel messages, and Devices locations, then
+   click **Next**. (_MS.SECURITYSUITE.3.2v1_)
+
+10. Under **Define policy settings**, select **Create or customize advanced
+   DLP rules**, and then click **Next**.
+
+11. Click **Create rule**. Assign the rule an appropriate name and
+   description.
+
+12. Click **Add condition**, then **Content contains**.
+
+13. Click **Add**, then **Sensitive info types**.
+
+14. Add information types that protect information sensitive to the agency.
+    At a minimum, the agency should protect:
+
+    - Credit card numbers
+    - U.S. Individual Taxpayer Identification Numbers (ITIN)
+    - U.S. Social Security Numbers (SSN)
+    - All agency-defined PII and sensitive information
+
+15. Click **Add**.
+
+16. Under **Actions**, click **Add an action**.
+
+17. Check **Restrict Access or encrypt the content in Microsoft 365
+    locations**.
+
+18. Under this action, select **Block Everyone**. (_MS.SECURITYSUITE.3.3v1_)
+
+19. Under **User notifications**, turn on **Use notifications to inform your users and help educate them on the proper use of sensitive info**. (_MS.SECURITYSUITE.3.4v1_)
+
+20. Under **Microsoft 365 services** if using a GCC environment or under **Microsoft 365 files and Microsoft Fabric items** if using a Commercial environment, a section that appears after user notifications are turned on, check the box next to **Notify users in Office 365 service with a policy tip or email notifications**. (_MS.SECURITYSUITE.3.4v1_)
+
+21. Click **Save**, then **Next**.
+
+22. Select **Turn the policy on immediately**, then click **Next**.
+
+23. Click **Submit**.
+
+#### MS.SECURITYSUITE.3.2v1 Instructions
+
+See [MS.SECURITYSUITE.3.1v1 Instructions](#mssecuritysuite31v1-instructions) step 9
+   for details on enforcing DLP policy in specific M365 service locations.
+
+#### MS.SECURITYSUITE.3.3v1 Instructions
+
+See [MS.SECURITYSUITE.3.1v1 Instructions](#mssecuritysuite31v1-instructions) steps
+   16-18 for details on configuring DLP policy to block sharing sensitive
+   information with everyone.
+
+#### MS.SECURITYSUITE.3.4v1 Instructions
+
+See [MS.SECURITYSUITE.3.1v1 Instructions](#mssecuritysuite31v1-instructions) steps
+   19-20 for details on configuring DLP policy to notify users when accessing
+   sensitive information.
+
+#### MS.SECURITYSUITE.3.5v1 Instructions
+
+These implementation steps are only applicable if at least one device has been onboarded with
+Defender for Endpoint.
+
+1. Sign in to the **Microsoft Purview portal**.
+2. Under **Settings**, select **Data Loss Prevention**.
+3. (Optional) Select **Restricted apps and app groups**. Add or edit restricted apps per agency
+  discretion.
+4. Select **Unallowed Bluetooth apps** then **Add or edit unallowed Bluetooth apps**.
+5. Ensure **Include Bluetooth apps recommended by Microsoft** is **On**.
+6. (Optional) Add other apps to restrict, per agency discretion.
+7. Click **Save**.
+8. Return to the main menu. Under **Solutions**, select **Data Loss Prevention**.
+9. Select **Policies** from the top of the page.
+10. Find the custom DLP policy configured under
+   [MS.SECURITYSUITE.3.1v1 Instructions](#mssecuritysuite31v1-instructions) in the list
+   and click the Policy name to select.
+11. Select **Edit Policy**.
+12. Click **Next** on each page in the policy wizard until you reach the
+   **Advanced DLP rules page**.
+13. Select the relevant rule and click the pencil icon to edit it.
+14. Under **Actions**, click **Add an action**.
+15. Choose **Audit or restrict activities on device**
+16. Under **File activities for all apps**, select
+    **Apply restrictions to specific activity**.
+17. Check the box next to **Copy or move using unallowed Bluetooth app**
+    and set its action to **Block**.
+18. Under **App access restrictions**, check the **Access by restricted apps** box
+   and set the action drop-down to **Block**.
+19. Click **Save** to save the changes.
+20. Click **Next** on each page until reaching the
+    **Review your policy and create it** page.
+21. Review the policy and click **Submit** to complete the policy changes.
+
+## 4. Alerts
+
+Managing and monitoring Exchange mailboxes and user activity requires a means
+to define activity of concern and notify administrators.  Alerts can be
+generated to help identify suspicious or malicious activity in Exchange Online.
+These alerts give administrators better real-time insight into possible
+security incidents.
+
+There are several pre-built alert policies available pertaining to
+various apps in the M365 suite. These alerts give administrators better
+real-time insight into possible security incidents.
+
+### Policies
+#### MS.SECURITYSUITE.4.1v1
+At a minimum, the following alerts SHALL be enabled:
+
+  a. **Suspicious email sending patterns detected.**
+
+  b. **Suspicious Connector Activity.**
+
+  c. **Suspicious Email Forwarding Activity.**
+
+  d. **Messages have been delayed.**
+
+  e. **Tenant restricted from sending unprovisioned email.**
+
+  f. **Tenant restricted from sending email.**
+
+  g. **A potentially malicious URL click was detected.**
+
+<!--Policy: MS.SECURITYSUITE.4.1v1; Criticality: SHALL -->
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Potentially malicious or service-impacting events may go undetected without a means of detecting these events. Setting up a mechanism to alert administrators to the list of events linked above draws attention to them to minimize any impact to users and the agency.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-4(5)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562.006: Indicator Blocking](https://attack.mitre.org/techniques/T1562/006/)
+
+#### MS.SECURITYSUITE.4.2v1
+The alerts SHOULD be sent to a monitored address or incorporated into a Security Information and Event Management (SIEM).
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#mssecuritysuite42v1-instructions)
+
+<!--Policy: MS.SECURITYSUITE.4.2v1; Criticality: SHOULD -->
+- _Rationale:_ Suspicious or malicious events, if not resolved promptly, may have a greater impact to users and the agency. Sending alerts to a monitored email address or SIEM system helps ensure events are acted upon in a timely manner to limit overall impact.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-4(5)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562.006: Indicator Blocking](https://attack.mitre.org/techniques/T1562/006/)
+
+### Resources
+
+- [Alert policies in Microsoft 365 \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/purview/alert-policies?view=o365-worldwide)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.SECURITYSUITE.4.1v1 Instructions
+
+1. Sign in to **Microsoft 365 Defender**.
+
+2. Under **Email & collaboration**, select **Policies & rules**.
+
+3. Select **Alert Policy**.
+
+4. Select the checkbox next to each alert to enable as determined by the
+   agency and at a minimum the following:
+
+   a. **Suspicious email sending patterns detected.**
+
+   b. **Suspicious connector activity.**
+
+   c. **Suspicious Email Forwarding Activity.**
+
+   d. **Messages have been delayed.**
+
+   e. **Tenant restricted from sending unprovisioned email.**
+
+   f. **Tenant restricted from sending email.**
+
+   g. **A potentially malicious URL click was detected.**
+
+5. Click the pencil icon from the top menu.
+
+6. Select the **Enable selected policies** action from the **Bulk actions**
+   menu.
+
+#### MS.SECURITYSUITE.4.2v1 Instructions
+
+For each enabled alert, to add one or more email recipients:
+
+1. Sign in to **Microsoft 365 Defender**.
+
+2. Under **Email & collaboration**, select **Policies & rules**.
+
+3. Select **Alert Policy**.
+
+4. Click the alert policy to modify.
+
+5. Click the pencil icon next to **Set your recipients**.
+
+6. Check the **Opt-In for email notifications** box.
+
+7. Add one or more email addresses to the **Email recipients** text box.
+
+8. Click **Next**.
+
+9. On the **Review** page, click **Submit** to save the notification settings.
+
+## 5. Audit Logging
+
+User activity from M365 services is captured in the organization's unified
+audit log. These logs are essential for conducting incident response and
+threat detection activity.
+
+By default, Microsoft retains the audit logs for 180 days. Activity
+by users with E5 licenses is logged for one year.
+
+
+
+### Policies
+#### MS.SECURITYSUITE.5.1v1
+Unified Audit logging SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.5.1v1; Criticality: SHALL -->
+- _Rationale:_ Responding to incidents without detailed information about activities that took place slows response actions. Enabling Unified Audit logging helps ensure agencies have visibility into user actions.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AU-12
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562.008: Disable or Modify Cloud Logs](https://attack.mitre.org/techniques/T1562/008/)
+
+#### MS.SECURITYSUITE.5.2v1
+Audit logs SHALL be retained and searchable for a minimum of 3 months and retrievable for a minimum of 12 months.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.5.2v1; Criticality: SHALL -->
+- _Rationale:_ Audit logs may no longer be available when needed if they are not retained for a sufficient time. Increased log retention time gives an agency the necessary visibility to investigate incidents that occurred some time ago.
+- _Last modified:_ June 2026
+- _Note:_ To maintain logs in M365 for longer than 180 days, the user generating the logs must meet the license requirement described below. If the user does not meet these requirements, their data is retained according to the highest priority retention policy. This retention might be either the default retention policy for the user's license or the highest priority policy that matches the user and its record type.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AU-11
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1070: Indicator Removal](https://attack.mitre.org/techniques/T1070/)
+
+### Resources
+
+- [OMB M-26-14, Ensuring Effective and Efficient Agency Logging and Network Visibility to
+Defend Against Evolving Cyber Threats \| Office of Management and
+  Budget](https://www.whitehouse.gov/wp-content/uploads/2026/05/M-26-14-Ensuring-Effective-and-Efficient-Agency-Logging-and-Network-Visibility-to-Defend-Against-Evolving-Cyber-Threats.pdf)
+
+- [Turn auditing on or off \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/purview/audit-log-enable-disable?view=o365-worldwide)
+
+- [Create an audit log retention policy \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies?view=o365-worldwide#create-an-audit-log-retention-policy)
+
+- [Search the audit log in the compliance center \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/purview/audit-log-search?view=o365-worldwide)
+
+- [Audit log activities \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/purview/audit-log-activities)
+
+- [Expanding cloud logging to give customers deeper security visibility \|
+  Microsoft Security Blog](https://www.microsoft.com/en-us/security/blog/2023/07/19/expanding-cloud-logging-to-give-customers-deeper-security-visibility/)
+
+- [Export, configure, and view audit log records | Microsoft Learn](https://learn.microsoft.com/en-us/purview/audit-log-export-records)
+
+- [Untitled Goose Tool Fact Sheet | CISA.](https://www.cisa.gov/resources-tools/resources/untitled-goose-tool-fact-sheet)
+
+- [Manage audit log retention policies | Microsoft Learn](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies?tabs=microsoft-purview-portal#before-you-create-an-audit-log-retention-policy)
+
+### License Requirements
+
+- The creation of a custom audit log retention policy requires E5/G5 licenses or E3/G3 licenses with add-on compliance licenses.
+- To maintain logs in M365 for longer than 180 days, the user generating the logs must have an Office 365 E5 or Microsoft 365 E5 license or a Microsoft Purview Suite (formerly known as Microsoft 365 E5 Compliance) or E5 eDiscovery and Audit add-on license.
+
+### Implementation
+
+#### MS.SECURITYSUITE.5.1v1 Instructions
+
+To enable auditing via the **Microsoft Purview portal**:
+
+1. Sign in to the **Microsoft Purview portal**.
+
+2. Under **Solutions**, select **Audit**.
+
+3. If auditing is not enabled, a banner is displayed to notify the
+administrator to start recording user and admin activity.
+
+4. Click the **Start recording user and admin activity**.
+
+#### MS.SECURITYSUITE.5.2v1 Instructions
+One option for controlling how long logs are retained in M365 is to create one or more custom audit
+retention policies. For more details, see [Create an audit log retention policy](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies?view=o365-worldwide#create-an-audit-log-retention-policy)
+instructions.
+
+As noted in the [License Requirements](https://github.com/cisagov/ScubaGear/baselines/securitysuite.md#license-requirements-1)
+section above, the creation of a custom audit log retention policy and its retention in the M365
+environment requires E5/G5 licenses or E3/G3 licenses with add-on compliance licenses. However, no
+additional license is required to export logs. To export audit logs, follow
+[Export, configure, and view audit log records | Microsoft Learn](https://learn.microsoft.com/en-us/purview/audit-log-export-records)
+and/or [Untitled Goose Tool Fact Sheet | CISA.](https://www.cisa.gov/resources-tools/resources/untitled-goose-tool-fact-sheet).
+
+
+## 6. Inbound Anti-Spam Protections
+
+Junk email, or spam, can clutter user mailboxes and hamper communications
+across an agency. Implementing a spam filter helps to identify inbound spam and
+quarantine or move those messages. Microsoft Defender includes several
+capabilities for protecting against inbound spam emails. Using Microsoft
+Defender is not strictly required for this purpose; any product that
+fulfills the requirements outlined in this baseline policy group may be
+used.
+
+### Policies
+
+#### MS.SECURITYSUITE.6.1v1
+Emails detected as spam and phishing SHALL NOT be delivered to the user's inbox.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.6.1v1; Criticality: SHALL -->
+- _Rationale:_ Spam is a constant threat as junk mail can reduce user productivity, fill up mailboxes unnecessarily, and in some cases include malicious links or attachments.
+Moving spam messages to a separate junk or quarantine folder helps users filter out spam while still giving them the ability to review messages, as needed, in case a message is filtered incorrectly.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+
+#### MS.SECURITYSUITE.6.2v1
+Allowed domains SHALL NOT be added to inbound anti-spam protection policies.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.6.2v1; Criticality: SHALL -->
+- _Rationale:_ Legitimate emails may be incorrectly filtered
+by spam protections. Adding allowed senders is an acceptable method of
+combating these false positives. Allowing an entire domain, especially
+a common domain like office.com, however, provides for a large number of
+potentially unknown users to bypass spam protections.
+- _Last modified:_ March 2026
+- _Note:_ Allowed senders MAY be added.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+
+### Resources
+
+- [Configure anti-spam policies in EOP \| Microsoft Learn](https://learn.microsoft.com/en-us/defender-office-365/anti-spam-policies-configure?view=o365-worldwide)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.SECURITYSUITE.6.1v1 Instructions
+
+Both the standard and strict preset policies meet this baseline policy requirement,
+so no further actions are needed for users added to those policies. See
+[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)
+for instructions on adding users to these policies.
+
+As the steps for MS.SECURITYSUITE.6.1v1 and MS.SECURITYSUITE.6.2v1 share many steps in common,
+steps for both policies are included in this section. Steps that do not strictly apply to
+MS.SECURITYSUITE.6.1v1 are followed by the applicable SCuBA policy in parenthesis.
+
+For users not added to the standard or strict preset policies:
+1.  Sign in to **Microsoft 365 Defender**.
+2.  Under **Email & collaboration**, select **Policies & rules**.
+3.  Select **Threat policies**.
+4.  Under **Policies**, select **Anti-spam**.
+5.  If modifying an existing policy:
+    1. Click the name of the policy from the policy list to open the policy summary. Note: be sure to
+    select an *inbound* policy. If it's a custom policy, it will say "Custom anti-spam policy"
+    under **Type** instead of of **Custom output spam policy**.
+    2. Click **Edit users, groups, and domains**. _Note:_ the **Anti-spam inbound policy (Default)** policy applies to all users, so skip this step if modifying the default policy.
+      - Add users, groups, and domains as needed. To make the policy apply to all users, under
+        **Domains**, enter all the tenant domains.
+      - (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**
+        to be exempted from this policy.
+      - Click **Save**.
+    3. Click **Edit spam threshold and properties** See [Recommended email and collaboration threat policy settings for cloud organizations](https://learn.microsoft.com/en-us/defender-office-365/recommended-settings-for-eop-and-office365)
+    for configuration guidance. We recommend mirroring the values used for either the standard or
+    strict preset policies. Click **Save**.
+    4. Click **Edit actions**.
+    5. For each email classification (**Spam**, **High confidence spam**, **Phishing**, and **High confidence phishing**), select one of the following options:
+      - **Move message to Junk Email folder**
+      - **Redirect message to email address**
+      - **Delete message**
+      - **Quarantine message**
+
+     Note: **Delete message** is not available for **High confidence phishing**; choose one of the other three options for that classification.
+    
+    6. If you selected **Redirect message to email address**, also fill in an appropriate email for
+      the **Redirect to this email address** field, such as a mailbox set up for monitoring incoming
+      spam and phishing messages.
+    7. Click **Edit allowed and blocked senders and domains**.
+    8. Under **Allowed**, click **Allow domains**. Select any domains that have been allowed, then
+        **Delete** (the trash icon). (_MS.SECURITYSUITE.6.2v1_)
+    9. Click **Save**.
+7.  If creating a new policy:
+    1. Click **Create**, then **Inbound**.
+    2. After naming the policy, click **Next**.
+    3. Add users, groups, and domains as needed. To make the policy apply to all users, under
+       **Domains**, enter all the tenant domains.
+    4. (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**
+       to be exempted from this policy.
+    5. Click **Next**.
+    6. On the **Bulk email threshold & spam properties** page, see [Recommended email and collaboration threat policy settings for cloud organizations](https://learn.microsoft.com/en-us/defender-office-365/recommended-settings-for-eop-and-office365)
+    for configuration guidance. We recommend mirroring the values used for either the standard or
+    strict preset policies.
+    7. For each email classification (**Spam**, **High confidence spam**, **Phishing**, and **High confidence phishing**), select one of the following options:
+      - **Move message to Junk Email folder**
+      - **Redirect message to email address**
+      - **Delete message**
+      - **Quarantine message**
+    8. If you selected **Redirect message to email address**, also fill in an appropriate email for
+      the **Redirect to this email address** field, such as a mailbox set up for monitoring incoming
+      spam and phishing messages.
+    9. Click **Next**
+    10. On the **Allow & block list** page, do not click **Allow domains** under **Allowed**. It
+    should read **Domains (0)** under **Allowed**. (_MS.SECURITYSUITE.6.2v1_)
+    11. **Next**, then **Submit**.
+
+#### MS.SECURITYSUITE.6.2v1 Instructions
+
+Both the standard and strict preset policies meet this baseline policy requirement,
+so no further actions are needed for users added to those policies. See
+[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)
+for instructions on adding users to these policies.
+
+For users not added to the standard or strict preset policies, see [MS.SECURITYSUITE.6.1v1 Instructions](#mssecuritysuite61v1-instructions).
+
+
+## 7. Link Protection
+
+Several technologies exist for protecting users from malicious links. For example,
+Microsoft Defender accomplishes this by prepending:
+
+`https://*.safelinks.protection.outlook.com/?url=`
+
+to any URLs included in emails. By prepending the safe links URL,
+Microsoft can proxy the initial URL through their scanning service.
+Their proxy can perform the following actions:
+
+- Compare the URL with a block list.
+
+- Compare the URL with a list of known malicious sites.
+
+- If the URL points to a downloadable file, apply real-time file
+  scanning.
+
+If all checks pass, the user is redirected to the original URL.
+
+Microsoft Defender for Office 365 includes link scanning capabilities.
+Using Microsoft Defender is not strictly required for this purpose;
+any product fulfilling the requirements outlined in this baseline policy group may be used.
+If the agency uses Microsoft Defender for Office 365 to meet this baseline policy group,
+implementations steps are provided below.
+
+### Policies
+
+#### MS.SECURITYSUITE.7.1v1
+URL comparison with a block-list SHOULD be enabled for URLs in emails, Teams messages, and Office documents.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.7.1v1; Criticality: SHOULD -->
+- _Rationale:_ Users may be directed to malicious websites via links in email. Blocking access to known, malicious URLs can prevent users from accessing known malicious websites.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+#### MS.SECURITYSUITE.7.2v1
+Direct download links SHOULD be scanned for malware.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.15.2v1; Criticality: SHOULD -->
+- _Rationale:_ URLs in emails may direct users to download and run malware.
+Scanning direct download links in real-time for known malware and blocking access can prevent
+users from infecting their devices.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+#### MS.SECURITYSUITE.7.3v1
+User click tracking SHOULD be enabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.7.3v1; Criticality: SHOULD -->
+- _Rationale:_ Users may click on malicious links in emails, leading to compromise or unauthorized data disclosure. Enabling user click tracking lets agencies know if a malicious link may have been visited after the fact to help tailor a response to a potential incident.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3, AU-12c
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566.002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+### Resources
+
+- [Set up Safe Links policies in Microsoft Defender for Office 365 \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/defender-office-365/safe-links-policies-configure)
+
+### License Requirements
+Safe links require Defender for Office 365 Plan 1 or 2. These are included with
+E5 and G5 and are available as add-ons for E3 and G3.
+
+### Implementation
+
+#### MS.SECURITYSUITE.7.1v1 Instructions
+
+Both the standard and strict preset policies meet this baseline policy requirement,
+so no further actions are needed for users added to those policies. See
+[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)
+for instructions on adding users to these policies.
+
+As the steps for MS.SECURITYSUITE.7.1v1, MS.SECURITYSUITE.7.2v1, and MS.SECURITYSUITE.7.3v1 share
+many steps in common, steps for all three policies are included in this section. Steps that do not
+strictly apply to MS.SECURITYSUITE.7.1v1 are followed by the applicable SCuBA policy in parenthesis.
+
+For users not added to the standard or strict preset policies:
+1.  Sign in to **Microsoft 365 Defender**.
+2.  Under **Email & collaboration**, select **Policies & rules**.
+3.  Select **Threat policies**.
+4.  Under **Policies**, select **Safe-links**.
+5.  If modifying an existing policy:
+    1. Click the name of the policy from the policy list to open the policy summary.
+    2. Click **Edit users and domains**.
+        - Add users, groups, and domains as needed. To make the policy apply to all users, under
+          **Domains**, enter all the tenant domains.
+        - (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**
+          to be exempted from this policy.
+        - Click **Save**.
+    3. Click **Edit protection settings**.
+    4. Under **Email**, ensure the following options are selected:
+        - **On: Safe Links checks a list of known, malicious links when users click links in email. URLs are rewritten by default.**
+        - **Apply Safe Links to email messages sent within the organization**
+        - **Apply real-time URL scanning for suspicious links and links that point to files** (_MS.SECURITYSUITE.7.2v1_)
+        - **Wait for URL scanning to complete before delivering the message** (_MS.SECURITYSUITE.7.2v1_)
+    5. Under **Teams**, select **On: Safe Links checks a list of known, malicious links when users click links in Microsoft Teams. URLs are not rewritten.**
+    6. Under **Office 365 Apps**, select **On: Safe Links checks a list of known, malicious links when users click links in Microsoft Office Apps. URLs are not rewritten.**
+    7. Under **Click protection settings**, select **Track user clicks**. (_MS.SECURITYSUITE.7.3v1_)
+    8. Click **Save**.
+6. If creating a new policy:
+    1. Click **Create**.
+    2. After naming the policy, click **Next**.
+    3. Add users, groups, and domains as needed. To make the policy apply to all users, under
+       **Domains**, enter all the tenant domains.
+    4. (Optional) Under **Exclude these users, groups, and domains**, add **Users** and **Groups**
+       to be exempted from this policy.
+    5. Click **Next**.
+    6. Under **Email**, ensure the following options are selected:
+        - **On: Safe Links checks a list of known, malicious links when users click links in email. URLs are rewritten by default.**
+        - **Apply Safe Links to email messages sent within the organization**
+        - **Apply real-time URL scanning for suspicious links and links that point to files** (_MS.SECURITYSUITE.7.2v1_)
+        - **Wait for URL scanning to complete before delivering the message** (_MS.SECURITYSUITE.7.2v1_)
+    7. Under **Teams**, select **On: Safe Links checks a list of known, malicious links when users click links in Microsoft Teams. URLs are not rewritten.**
+    8. Under **Office 365 Apps**, select **On: Safe Links checks a list of known, malicious links when users click links in Microsoft Office Apps. URLs are not rewritten.**
+    9. Under **Click protection settings**, select **Track user clicks**. (_MS.SECURITYSUITE.7.3v1_)
+    10. Click **Next**, **Next**, and **Submit**.
+
+
+#### MS.SECURITYSUITE.7.2v1 Instructions
+
+Both the standard and strict preset policies meet this baseline policy requirement,
+so no further actions are needed for users added to those policies. See
+[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)
+for instructions on adding users to these policies.
+
+For users not added to the standard or strict preset policies, see [MS.SECURITYSUITE.7.1v1 Instructions](#mssecuritysuite71v1-instructions).
+
+#### MS.SECURITYSUITE.7.3v1 Instructions
+
+Both the standard and strict preset policies meet this baseline policy requirement,
+so no further actions are needed for users added to those policies. See
+[Adding Users to the Preset Security Policies](#appendix-a-adding-users-to-the-preset-security-policies)
+for instructions on adding users to these policies.
+
+For users not added to the standard or strict preset policies, see [MS.SECURITYSUITE.7.1v1 Instructions](#mssecuritysuite71v1-instructions).
+
+## 8. IP Allow Lists
+
+Microsoft Defender supports creating IP allow lists intended
+to prevent blocking emails from *specific* senders. However,
+as a result, emails from these senders bypass important security
+mechanisms, such as spam filtering, SPF, DKIM, DMARC, and [FROM address
+enforcement](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/anti-phishing-from-email-address-validation?view=o365-worldwide#override-from-address-enforcement).
+
+IP block lists block email from listed IP addresses. Although we have no specific guidance on which IP addresses to add, block lists can be used to block mail from known spammers.
+
+IP safe lists are dynamic lists of "known, good senders," which Microsoft sources from various third-party subscriptions. As with senders in the allow list, emails from these senders bypass important security mechanisms.
+
+### Policies
+
+#### MS.SECURITYSUITE.8.1v1
+IP allow lists SHOULD NOT be created.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.8.1v1; Criticality: SHOULD -->
+- _Rationale:_ Messages sent from IP addresses on an allow list bypass important
+security mechanisms, including spam filtering and sender authentication checks.  Avoiding use of IP allow lists prevents potential threats from circumventing security mechanisms.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-4
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+#### MS.SECURITYSUITE.8.2v1
+Safe lists SHOULD NOT be enabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SECURITYSUITE.8.2v1; Criticality: SHOULD -->
+- _Rationale:_ Messages sent from allowed safe list addresses bypass important
+security mechanisms, including spam filtering and sender authentication checks.
+Avoiding use of safe lists prevents potential threats from circumventing
+security mechanisms. While blocking all malicious senders is not feasible,
+blocking specific known, malicious IP addresses may reduce the threat from
+specific senders.
+- _Last modified:_ March 2026
+- _Note:_ A connection filter MAY be implemented to create an IP block list.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-4
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+### Resources
+
+- [Use the IP Allow List \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/create-safe-sender-lists-in-office-365?view=o365-worldwide#use-the-ip-allow-list)
+
+- [Configure connection filtering \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/connection-filter-policies-configure?view=o365-worldwide)
+
+- [Use the Microsoft 365 Defender portal to modify the default
+  connection filter policy \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/connection-filter-policies-configure?view=o365-worldwide#use-the-microsoft-365-defender-portal-to-modify-the-default-connection-filter-policy)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.SECURITYSUITE.8.1v1 Instructions
+To modify the connection filters, follow the instructions found in [Use
+the Microsoft 365 Defender portal to modify the default connection
+filter
+policy](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/connection-filter-policies-configure?view=o365-worldwide#use-the-microsoft-365-defender-portal-to-modify-the-default-connection-filter-policy).
+
+1. Sign in to **Microsoft 365 Defender portal**.
+
+2. From the left-hand menu, find **Email & collaboration** and select **Policies and Rules**.
+
+3. Select **Threat Policies** from the list of policy names.
+
+4. Under **Policies**, select **Anti-spam**.
+
+5. Select **Connection filter policy (Default)**.
+
+6. Click **Edit connection filter policy**.
+
+7. Ensure no addresses are specified under **Always allow messages from
+   the following IP addresses or address range**.
+
+8. Ensure **Turn on safe list** is not selected.
+
+#### MS.SECURITYSUITE.8.2v1 Instructions
+
+1. Sign in to **Microsoft 365 Defender portal**.
+
+2. From the left-hand menu, find **Email & collaboration** and select **Policies and Rules**.
+
+3. Select **Threat Policies** from the list of policy names.
+
+4. Under **Policies**, select **Anti-spam**.
+
+5. Select **Connection filter policy (Default)**.
+
+6. Click **Edit connection filter policy**.
+
+7. (Optional) Enter addresses under **Always block messages from the following
+   IP addresses or address range** as needed.
+
+8. Ensure **Turn on safe list** is not selected.
+
+# Appendix A: Adding Users to the Preset Security Policies
+As many controls in this baseline can be satisfied by adding users to the standard
+or strict security policies, we describe this process once here, rather than
+duplicating it in each applicable control.
+
+To add users to the standard policy:
+1. Sign in to **Microsoft 365 Defender**.
+2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.
+3. Select **Threat Policies**.
+4. From the **Templated policies** section, select **Preset Security Policies**.
+5. Under **Standard protection**, ensure the toggle is enabled such that it reads "Standard protection is on."
+6. Under **Standard protection is on**, select **Manage protection settings**.
+7. On the **Apply Exchange Online Protection** page, select **All recipients**.
+8. (Optional) Under **Exclude these recipients**, add **Users** and **Groups**
+   to be exempted from the preset policies.
+9. Select **Next**, then on the **Apply Defender for Office 365 protection** page, select **All recipients**.
+10. (Optional) Under **Exclude these recipients**, add **Users** and **Groups**
+   to be exempted from the preset policies.
+11. Select **Next** on each page until the **Review and confirm your changes** page.
+12. On the **Review and confirm your changes** page, select **Confirm**.
+
+To add users to the strict policy:
+1. Sign in to **Microsoft 365 Defender**.
+2. In the left-hand menu, go to **Email & Collaboration** > **Policies & Rules**.
+3. Select **Threat Policies**.
+4. From the **Templated policies** section, select **Preset Security Policies**.
+5. Under **Strict protection**, ensure the toggle is enabled such that it reads "Strict protection is on."
+6. Under **Strict protection is on**, select **Manage protection settings**.
+7. On the **Apply Exchange Online Protection** page, select **All recipients**.
+8. (Optional) Under **Exclude these recipients**, add **Users** and **Groups**
+   to be exempted from the preset policies.
+9. Select **Next**, then on the **Apply Defender for Office 365 protection** page, select **All recipients**.
+10. (Optional) Under **Exclude these recipients**, add **Users** and **Groups**
+   to be exempted from the preset policies.
+11. Select **Next** on each page until the **Review and confirm your changes** page.
+12. On the **Review and confirm your changes** page, select **Confirm**.
+
+See [Recommended email and collaboration threat policy settings for cloud organizations](https://learn.microsoft.com/en-us/defender-office-365/recommended-settings-for-eop-and-office365) to understand the
+differences between the two preset policies.
+
+Note that a user can be added to multiple policies. In that case, the policies
+are applied in order of precedence, as desribed by
+[Order of precedence for preset security policies and other threat policies](https://learn.microsoft.com/en-us/defender-office-365/preset-security-policies#order-of-precedence-for-preset-security-policies-and-other-threat-policies).
+
+
+**`TLP:CLEAR`**

--- a/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/sharepoint.md
+++ b/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/sharepoint.md
@@ -1,0 +1,320 @@
+**`TLP:CLEAR`**
+# CISA M365 Secure Configuration Baseline for SharePoint Online and OneDrive
+
+Microsoft 365 (M365) SharePoint Online is a web-based collaboration and document management platform. It is primarily used to collaborate on documents and communicate information in projects. M365 OneDrive is a cloud-based file storage system primarily used to store a user's personal files, but it can also be used to share documents with others. This secure configuration baseline (SCB) provides specific policies to strengthen the security of both services.
+
+The Secure Cloud Business Applications (SCuBA) project, run by the Cybersecurity and Infrastructure Security Agency (CISA), provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies’ cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for M365 help secure federal information assets stored within M365 cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government’s threats and risk tolerance with the knowledge that every organization has different threat models and risk tolerance. While use of these baselines will be mandatory for civilian Federal Government agencies, organizations outside of the Federal Government may also find these baselines to be useful references to help reduce risks.
+
+For non-Federal users, the information in this document is being provided “as is” for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products; CISA has no control over vendor changes to products offerings or features.  Accordingly, these SCuBA SCBs for M365 may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+> This document is marked TLP:CLEAR. Recipients may share this information without restriction. Information is subject to standard copyright rules. For more information on the Traffic Light Protocol, see https://www.cisa.gov/tlp.
+
+## License Compliance and Copyright
+
+Portions of this document are adapted from documents in Microsoft’s [M365](https://github.com/MicrosoftDocs/microsoft-365-docs/blob/public/LICENSE) and [Azure](https://github.com/MicrosoftDocs/azure-docs/blob/main/LICENSE) GitHub repositories. The respective documents are subject to copyright and are adapted under the terms of the Creative Commons Attribution 4.0 International license. Source are linked throughout this document. The United States government has adapted selections of these documents to develop innovative and scalable configuration standards to strengthen the security of widely used cloud-based software services.
+
+## Assumptions
+The **License Requirements** sections of this document assume the organization is using an [M365 E3](https://www.microsoft.com/en-us/microsoft-365/compare-microsoft-365-enterprise-plans) or [G3](https://www.microsoft.com/en-us/microsoft-365/government) license level at a minimum. Therefore, only licenses not included in E3/G3 are listed.
+
+## Key Terminology
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+**BOD 25-01 Requirement**: This indicator means that the policy is required under CISA BOD 25-01.
+
+**Automated Check**: This indicator means that the policy can be automatically checked via ScubaGear. See the [Quick Start Guide](../../../README.md#quick-start-guide) for help getting started.
+
+# Baseline Policies
+
+## 1. External Sharing
+
+This section helps reduce security risks related to sharing files with users external to the agency. This includes guest users, users who use a verification code, and users who access an Anyone link.
+
+
+### Policies
+#### MS.SHAREPOINT.1.1v1
+External sharing for SharePoint SHALL be limited to "Existing guests" or "Only people in your organization".
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SHAREPOINT.1.1v1; Criticality: SHALL -->
+- _Rationale:_ Sharing information outside the organization via SharePoint increases the risk of unauthorized access. By limiting external sharing, administrators decrease the risk of access to information.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-2, AC-3, IA-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+    - [T1213.002: Sharepoint](https://attack.mitre.org/techniques/T1213/002/)
+
+#### MS.SHAREPOINT.1.2v1
+External sharing for OneDrive SHALL be limited to "Existing guests" or "Only people in your organization".
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SHAREPOINT.1.2v1; Criticality: SHALL -->
+- _Rationale:_ Sharing files outside the organization via OneDrive increases the risk of unauthorized access. By limiting external sharing, administrators decrease the risk of unauthorized access to information.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-2, AC-3, IA-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+    - [T1213.002: Sharepoint](https://attack.mitre.org/techniques/T1213/002/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+#### MS.SHAREPOINT.1.3v1
+External sharing SHALL be restricted to approved external domains and/or users in approved security groups per interagency collaboration needs.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SHAREPOINT.1.3v1; Criticality: SHALL -->
+- _Rationale:_ By limiting sharing to domains or approved security groups used for interagency collaboration purposes, administrators can help prevent sharing with unknown organizations and individuals.
+- _Last modified:_ March 2025
+- _Note:_ This policy is only applicable if the external sharing slider in the SharePoint admin center is not set to **Only people in your organization**.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, AC-6(10)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+    - [T1213.002: Sharepoint](https://attack.mitre.org/techniques/T1213/002/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+
+### Resources
+
+- [Overview of external sharing in SharePoint and OneDrive in Microsoft 365 \| Microsoft Documents](https://learn.microsoft.com/en-us/sharepoint/external-sharing-overview)
+
+- [Manage sharing settings for SharePoint and OneDrive in Microsoft 365 \| Microsoft Documents](https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.SHAREPOINT.1.1v1 Instructions
+
+1. Sign in to the **SharePoint admin center**.
+
+2.  Select **Policies** \> **Sharing**.
+
+3.  Adjust external sharing slider for SharePoint to **Existing guests** or **Only people in your organization**.
+
+4. Select **Save**.
+
+#### MS.SHAREPOINT.1.2v1 Instructions
+
+
+1.  Sign in to the **SharePoint admin center**.
+
+2.  Select **Policies** \> **Sharing**.
+
+3.  Adjust external sharing slider for OneDrive to **Existing Guests** or **Only people in your organization**.
+
+4. Select **Save**.
+
+#### MS.SHAREPOINT.1.3v1 Instructions
+
+Note: If SharePoint external sharing is set to its most restrictive setting of "Only people in your organization", then no external sharing is allowed and no implementation changes are required for this policy item.
+
+1.  Sign in to the **SharePoint admin center**.
+
+2.  Select **Policies** \> **Sharing**.
+
+3.  Expand **More external sharing settings**.
+
+4.  Select **Limit external sharing by domain**.
+
+5.  Select **Add domains**.
+
+6.  Add each approved external domain users are allowed to share files with.
+
+7.  Select **Manage security groups**
+
+8. Add each approved security group. Members of these groups will be allowed to share files externally.
+
+9.  Select **Save**.
+
+## 2. File and Folder Default Sharing Settings
+
+This section provides policies to set the scope and permissions for sharing links to secure default values.
+
+### Policies
+
+#### MS.SHAREPOINT.2.1v1
+File and folder default sharing scope SHALL be set to "Specific people (only the people the user specifies)".
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SHAREPOINT.2.1v1; Criticality: SHALL -->
+- _Rationale:_ By making the default sharing the most restrictive, administrators prevent accidentally sharing information too broadly.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+    - [T1213.002: Sharepoint](https://attack.mitre.org/techniques/T1213/002/)
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+    - [T1565.001: Stored Data Manipulation](https://attack.mitre.org/techniques/T1565/001/)
+
+#### MS.SHAREPOINT.2.2v1
+File and folder default sharing permissions SHALL be set to view only.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SHAREPOINT.2.2v1; Criticality: SHALL -->
+- _Rationale:_ Edit access to files and folders could allow a user to make unauthorized changes.  By restricting default permissions to **View** only, administrators prevent unintended or malicious modification.
+- _Last modified:_ June 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1080: Taint Shared Content](https://attack.mitre.org/techniques/T1080/)
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+    - [T1565.001: Stored Data Manipulation](https://attack.mitre.org/techniques/T1565/001/)
+
+### Resources
+
+- [File and folder links \| Microsoft
+  Documents](https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off#file-and-folder-links)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.SHAREPOINT.2.1v1 Instructions
+
+1.  Sign in to the **SharePoint admin center**.
+
+2.  Select **Policies** \> **Sharing**
+
+3.  Under **File and folder links**, set the default link type to **Specific people (only the people the user specifies)**
+
+4.  Select **Save**
+
+#### MS.SHAREPOINT.2.2v1 Instructions
+
+1.  Sign in to the **SharePoint admin center**.
+
+2. Select **Policies** \> **Sharing**.
+
+3. Under **File and folder links**, set the permission that is selected by default for sharing links to **View**.
+
+4. Select **Save**.
+
+## 3. Securing Anyone Links and Verification Code Users
+
+Sharing files with external users via the usage of **Anyone links** or **Verification codes** is strongly discouraged because it provides access to data within a tenant with weak or no authentication. If these features are used, this section details some access restrictions that could provide limited security risk mitigations.
+
+**Note**: The settings in this section are only applicable if an agency is using **Anyone links** or **Verification code** sharing. See each policy below for details.
+
+### Policies
+#### MS.SHAREPOINT.3.1v1
+Expiration days for Anyone links SHALL be set to 30 days or less.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SHAREPOINT.3.1v1; Criticality: SHALL -->
+- _Rationale:_ Links may be used to provide access to information for a short period of time. Without expiration, however, access is indefinite. By setting expiration timers for links, administrators can prevent unintended sustained access to the link.
+- _Last modified:_ March 2025
+- _Note:_ This policy is only applicable if the external sharing slider in the SharePoint admin center is set to **Anyone**.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, AC-21b
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+    - [T1213.002: Sharepoint](https://attack.mitre.org/techniques/T1213/002/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+#### MS.SHAREPOINT.3.2v1
+The allowable file and folder permissions for links SHALL be set to view only.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SHAREPOINT.3.2v1; Criticality: SHALL -->
+- _Rationale:_ Unauthorized changes to files can be made if permissions allow editing by anyone.  By restricting permissions on links to **View** only, administrators prevent anonymous file changes.
+- _Last modified:_ March 2025
+- _Note:_ This policy is only applicable if the external sharing slider in the SharePoint admin center is set to **Anyone**.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1080: Taint Shared Content](https://attack.mitre.org/techniques/T1080/)
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+    - [T1565.001: Stored Data Manipulation](https://attack.mitre.org/techniques/T1565/001/)
+
+#### MS.SHAREPOINT.3.3v2
+Reauthentication days for people who use a verification code SHALL be set to 30 days or less.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.SHAREPOINT.3.3v2; Criticality: SHALL -->
+- _Rationale:_ By setting expiration timers for verification code access, administrators can prevent unintended sustained access to documents.
+- _Last modified:_ April 2026
+- _Note:_ This policy is only applicable if the external sharing slider in the SharePoint admin center is set to **Anyone**, **New and existing guests**, or **Existing guests.**
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-11
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1080: Taint Shared Content](https://attack.mitre.org/techniques/T1080/)
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+    - [T1565.001: Stored Data Manipulation](https://attack.mitre.org/techniques/T1565/001/)
+
+### License Requirements
+
+- N/A
+
+### Resources
+
+- [Secure external sharing recipient experience \| Microsoft
+  Documents](https://learn.microsoft.com/en-us/sharepoint/what-s-new-in-sharing-in-targeted-release)
+
+### Implementation
+
+#### MS.SHAREPOINT.3.1v1 Instructions
+
+1.  Sign in to the **SharePoint admin center**.
+
+2.  Select **Policies** \> **Sharing**.
+
+3.  Scroll to the section **Choose expiration and permissions options for Anyone links**.
+
+4.  Select the checkbox **These links must expire within this many days**.
+
+5.  Enter **30** days or less.
+
+6.  Select **Save**.
+
+#### MS.SHAREPOINT.3.2v1 Instructions
+
+1.  Sign in to the **SharePoint admin center**.
+
+2.  Select **Policies** \> **Sharing**.
+
+3.  Scroll to the section **Choose expiration and permissions options for Anyone links**.
+
+4.  Set the configuration items in the section **These links can give these permissions**.
+
+5.  Set the **Files** option to **View**.
+
+6.  Set the **Folders** option to **View**.
+
+7.  Select **Save**.
+
+#### MS.SHAREPOINT.3.3v2 Instructions
+
+1.  Sign in to the **SharePoint admin center**.
+
+2.  Select **Policies** \> **Sharing**.
+
+3.  Expand **More external sharing settings**.
+
+4. Select **People who use a verification code must reauthenticate after this many days**.
+
+5.  Enter **30** days or less.
+
+6. Select **Save**.
+
+**`TLP:CLEAR`**

--- a/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md
+++ b/vendor/scuba/scubagear/d7cf55f53fcc7faddde61086581b06da86a8da1d/baselines/teams.md
@@ -1,0 +1,714 @@
+**`TLP:CLEAR`**
+# CISA M365 Secure Configuration Baseline for Teams
+
+Microsoft 365 (M365) Teams is a cloud-based text and live chat workspace that supports video calls, chat messaging, screen sharing, and file sharing. This secure configuration baseline (SCB) provides specific policies to strengthen Microsoft Teams' security.
+
+Many admin controls for Teams are found in the **Teams admin center**.
+However, several essential security functions for Teams require a dedicated security
+tool, e.g., for data loss prevention. M365 provides these security functions
+natively via Defender for Office 365. Notably, Defender for Office 365 capabilities
+require Defender for Office 365 Plan 1 or 2. These are included with E5 and G5
+and are available as add-ons for E3 and G3. However, third-party solutions that
+offer comparable security functions can be used in lieu of Defender.
+Refer to the [CISA M365 Secure Configuration Security Suite Baseline](securitysuite.md)
+for additional guidance.
+
+The Secure Cloud Business Applications (SCuBA) project, run by the Cybersecurity and Infrastructure Security Agency (CISA), provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies’ cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for M365 help secure federal information assets stored within M365 cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government’s threats and risk tolerance with the knowledge that every organization has different threat models and risk tolerance. While use of these baselines will be mandatory for civilian Federal Government agencies, organizations outside of the Federal Government may also find these baselines to be useful references to help reduce risks.
+
+For non-Federal users, the information in this document is being provided "as is" for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products; CISA has no control over vendor changes to products offerings or features.  Accordingly, these SCuBA SCBs for M365 may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+> This document is marked TLP:CLEAR. Recipients may share this information without restriction. Information is subject to standard copyright rules. For more information on the Traffic Light Protocol, see https://www.cisa.gov/tlp.
+
+## License Compliance and Copyright
+Portions of this document are adapted from documents in Microsoft's [M365](https://github.com/MicrosoftDocs/microsoft-365-docs/blob/public/LICENSE) and [Azure](https://github.com/MicrosoftDocs/azure-docs/blob/main/LICENSE) GitHub repositories. The respective documents are subject to copyright and are adapted under the terms of the Creative Commons Attribution 4.0 International license. Source documents are linked throughout this document. The United States government has adapted selections of these documents to develop innovative and scalable configuration standards to strengthen the security of widely used cloud-based software services.
+
+## Assumptions
+The **License Requirements** sections of this document assume the organization is using an [M365 E3](https://www.microsoft.com/en-us/microsoft-365/compare-microsoft-365-enterprise-plans) or [G3](https://www.microsoft.com/en-us/microsoft-365/government) license level at a minimum. Therefore, only licenses not included in E3/G3 are listed.
+
+## Key Terminology
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+Access to Teams can be controlled by the user type. In this baseline,
+the types of users are defined as follows:
+
+1.  **Internal users**: Members of the agency's M365 tenant.
+
+2.  **External users**: Members of a different M365 tenant.
+
+3.  **Business to Business (B2B) guest users**: External users who are
+    formally invited to collaborate with the team and added to the
+    agency's Microsoft Entra as guest users. These users
+    authenticate with their home organization/tenant and are granted
+    access to the team by virtue of being listed as guest users on the
+    tenant's Microsoft Entra.
+
+4.  **Unmanaged users**: Users who are not members of any M365 tenant or
+    organization (e.g., personal Microsoft accounts).
+
+5.  **Anonymous users**: Teams users joining calls who are not
+    authenticated through the agency's tenant; these users include unmanaged
+    users, external users (except for B2B guests), and true anonymous
+    users (i.e., users who are not logged in to any Microsoft or
+    organization account, such as dial-in users[^1]).
+
+**BOD 25-01 Requirement**: This indicator means that the policy is required under CISA BOD 25-01.
+
+**Automated Check**: This indicator means that the policy can be automatically checked via ScubaGear. See the [Quick Start Guide](../../../README.md#quick-start-guide) for help getting started.
+
+**Manual**: This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. Meeting Policies
+
+This section helps reduce security risks posed by the external participants during meetings. In this instance, the term "external participants" includes external users, B2B guest users, unmanaged users, and anonymous users.
+
+This section helps reduce security risks related to the user permissions for recording Teams meetings and events. These policies and user permissions apply to meetings hosted by a user, as well as during one-on-one calls and group calls started by a user. Agencies should comply with any other applicable policies or legislation in addition to this guidance.
+
+### Policies
+
+#### MS.TEAMS.1.1v1
+External meeting participants SHOULD NOT be enabled to request control of shared desktops or windows.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.TEAMS.1.1v1; Criticality: SHOULD -->
+- _Rationale:_ An external participant with control of a shared screen could potentially perform unauthorized actions on the shared screen. This policy reduces that risk by removing an external participant's ability to request control. However, if an agency has a legitimate use case to grant this control, it may be done on a case-by-case basis.
+- _Last modified:_ July 2023
+- _Note:_ This policy applies to the Global (Org-wide default) meeting policy, as well as custom meeting policies.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-17a
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+#### MS.TEAMS.1.2v2
+Anonymous users SHALL NOT be enabled to start meetings.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.TEAMS.1.2v2; Criticality: SHALL -->
+- _Rationale:_ This policy protects against anonymous users starting Microsoft Teams meetings to scrape internal contacts. The policy is beneficial for agencies that have implemented custom policies, providing flexibility for some users to automatically admit "everyone" to a Microsoft Teams meeting.
+- _Last modified:_ August 2025
+- _Note:_ This policy applies to the Global (Org-wide default) meeting policy, and custom meeting policies if they exist.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-15a
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.001: Default Accounts](https://attack.mitre.org/techniques/T1078/001/)
+
+#### MS.TEAMS.1.3v1
+Anonymous users and dial-in callers SHOULD NOT be admitted automatically.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.TEAMS.1.3v1; Criticality: SHOULD -->
+- _Rationale:_ Automatically allowing admittance to anonymous and dial-in users diminishes control of meeting participation and invites potential data breach. This policy reduces that risk by requiring all anonymous and dial-in users to wait in a lobby until admitted by an authorized meeting participant. If the agency has a use case to admit members of specific trusted organizations and/or B2B guests automatically, custom policies may be created and assigned to authorized meeting organizers.
+- _Last modified:_ July 2023
+- _Note:_ This policy applies to the Global (Org-wide default) meeting policy. Custom meeting policies MAY be created to allow specific users more flexibility. For example, B2B guest users and trusted partner members may be admitted automatically into meetings organized by authorized users.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-15a
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+#### MS.TEAMS.1.4v1
+Internal users SHOULD be admitted automatically.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.TEAMS.1.4v1; Criticality: SHOULD -->
+- _Rationale:_ Requiring internal users to wait in the lobby for explicit admission can lead to admission fatigue. This policy enables internal users to be automatically admitted to the meeting through global policy.
+- _Last modified:_ July 2023
+- _Note:_ This policy applies to the Global (Org-wide default) meeting policy. Custom meeting policies MAY be created to allow specific users more flexibility.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+#### MS.TEAMS.1.5v1
+Dial-in users SHOULD NOT be enabled to bypass the lobby.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.TEAMS.1.5v1; Criticality: SHOULD -->
+- _Rationale:_ Automatically admitting dial-in users reduces control over who can participate in a meeting and increases potential for data breaches. This policy reduces the risk by requiring all dial-in users to wait in a lobby until they are admitted by an authorized meeting participant.
+- _Last modified:_ July 2023
+- _Note:_ This policy applies to the Global (Org-wide default) meeting policy, as well as custom meeting policies.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-15a
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+#### MS.TEAMS.1.6v1
+Meeting recording SHOULD be disabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.TEAMS.1.6v1; Criticality: SHOULD -->
+- _Rationale:_ Allowing any user to record a Teams meeting or group call may lead to unauthorized disclosure of shared information, including audio, video, and shared screens. By disabling the meeting recording setting in the Global (Org-wide default) meeting policy, an agency limits information exposure.
+- _Last modified:_ March 2025
+- _Note:_ This policy applies to the Global (Org-wide default) meeting policy. Custom policies MAY be created to allow more flexibility for specific users.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+#### MS.TEAMS.1.7v2
+Record an event SHOULD NOT be set to Always record.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.TEAMS.1.7v2; Criticality: SHOULD -->
+- _Rationale:_ Limiting recording permissions to only the organizer minimizes the security risk to the organizer's discretion for these Live Events, reducing data leakage and other security risks. Administrators can also disable recording for all live events.
+- _Last modified:_ March 2025
+- _Note:_ This policy applies to the Global (Org-wide default) meeting policy. Custom policies MAY be created to allow more flexibility for specific users.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-21a
+- _MITRE ATT&CK TTP Mapping:_
+  - None
+
+
+
+### Resources
+
+- [Manage who can present and request control in Microsoft Teams \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoftteams/meeting-who-present-request-control)
+- [Meeting policy settings \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoftteams/settings-policies-reference#meetings)
+
+- [Teams cloud meeting recording \| Microsoft
+Learn ](https://learn.microsoft.com/en-us/microsoftteams/cloud-recording)
+
+- [Assign policies in Teams – getting started \| Microsoft
+Learn](https://learn.microsoft.com/en-us/microsoftteams/policy-assignment-overview)
+- [Live Event Recording Policies \| Microsoft
+Learn](https://learn.microsoft.com/en-us/microsoftteams/teams-live-events/live-events-recording-policies)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.TEAMS.1.1v1 Instructions
+
+To help ensure external participants do not have the ability to request
+control of the shared desktop or window in the meeting:
+
+1.  Sign in to the **Microsoft Teams admin center**.
+
+2.  Select **Meetings** > **Meeting policies**.
+
+3.  Select the **Global (Org-wide default)** policy.
+
+4.  Under the **Content sharing** section, set **External
+    participants can give or request control** to **Off**.
+
+5.  If custom policies were created, repeat these steps for each
+    policy, selecting the appropriate policy in step 3.
+
+#### MS.TEAMS.1.2v2 Instructions
+
+To configure settings for anonymous users:
+
+1.	Sign in to the **Microsoft Teams admin center**.
+
+2.	Select **Meetings** > **Meeting policies**.
+
+3.	Select the **Global (Org-wide default)** policy.
+
+4.	Under the **Meeting join & lobby** section, ensure the **Anonymous users and dial-in callers can start a meeting** setting remains at the default position of **Off**.
+
+5.	If custom policies were created, repeat these steps for each policy, selecting the appropriate policy in step 3.
+
+#### MS.TEAMS.1.3v1 Instructions
+
+1.	Sign in to the **Microsoft Teams admin center**.
+
+2.	Select **Meetings** > **Meeting policies**.
+
+3.	Select the **Global (Org-wide default)** policy.
+
+4.	Under the **Meeting join & lobby** section, ensure **Who can bypass the lobby** is **not** set to **Everyone**. Bypassing the lobby should be set to **People in my org**, though other options may be used if needed.
+
+5.	In the same section, set **People dialing in can bypass the lobby** to **Off**.
+
+#### MS.TEAMS.1.4v1 Instructions
+
+1.	Sign in to the **Microsoft Teams admin center**.
+
+2.	Select **Meetings** > **Meeting policies**.
+
+3.	Select the **Global (Org-wide default)** policy.
+
+4.	Under the **Meeting join & lobby** section, ensure **Who can bypass the lobby** is set to **People in my org**.
+
+5.	In the same section, set **People dialing in can bypass the lobby** to **Off**.
+
+#### MS.TEAMS.1.5v1 Instructions
+
+1.	Sign in to the **Microsoft Teams admin center**.
+
+2.	Select **Meetings** > **Meeting policies**.
+
+3.	Select the **Global (Org-wide default)** policy.
+
+4.	Under the **Meeting join & lobby** section, set **People dialing in can bypass the lobby** to **Off**.
+
+#### MS.TEAMS.1.6v1 Instructions
+
+1.  Sign in to the **Microsoft Teams admin center**.
+
+2.  Select **Meetings** > **Meeting policies**.
+
+3.  Select the **Global (Org-wide default)** policy.
+
+4.  Under the **Recording & transcription** section, set **Meeting
+    recording** to **Off**.
+
+5.  Select **Save**.
+
+#### MS.TEAMS.1.7v2 Instructions
+
+1.  Sign in to the **Microsoft Teams admin
+    center**.
+
+2.  Select **Meetings** > **Live events policies**.
+
+3.  Select **Global (Org-wide default)** policy.
+
+4.  Set **Record an event** to either  **Organizer can record** or **Never record**
+
+5.  Click **Save**.
+
+6.  If custom policies were created, repeat these steps for each
+    policy, selecting the appropriate policy in step 3.
+
+
+
+## 2. External User Access
+This section helps reduce security risks related to external and unmanaged user access. In this instance, external users refer to members of a different M365 tenant, and unmanaged users refer to users who are not members of any M365 tenant or organization.
+
+External access allows external users to look up internal users by their
+email address to initiate chats and calls entirely within Teams.
+Blocking external access prevents external users from using Teams as an
+avenue for reconnaissance or phishing. Even with external access
+disabled, external users will still be able to join Teams calls,
+assuming anonymous join is enabled. Depending on agency need, if both
+external access and anonymous join are blocked—neither required
+nor recommended by this baseline—external collaborators would only be
+able to attend meetings if added as B2B guest users.
+
+External access may be granted on a per-domain basis. This may be
+desirable in some cases (e.g., for agency-to-agency collaboration). See
+the Chief Information Officer Council's [Interagency Collaboration
+Program](https://community.max.gov/display/Egov/Interagency+Collaboration+Program) Office of Management and Budget MA site for a list of .gov domains for sharing.
+
+Similar to external users, blocking contact with unmanaged Teams users prevents these users from looking up internal users by their email address and initiating chats and calls within Teams. These users would still be able to join calls, assuming anonymous join is enabled. Additionally, unmanaged users may be added to Teams chats if the internal user initiates the contact.
+
+### Policies
+
+#### MS.TEAMS.2.1v2
+External access for users SHALL only be enabled on a per-domain basis.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.TEAMS.2.1v2; Criticality: SHALL -->
+- _Rationale:_ The default configuration allows members to communicate with all external users with similar access permissions. Unrestricted access can lead to data breaches and other security threats. This policy provides protection against threats posed by unrestricted access by allowing communication with only trusted domains.
+- _Last modified:_ August 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1199: Trusted Relationship](https://attack.mitre.org/techniques/T1199/)
+  - [T1204: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204.001: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+
+#### MS.TEAMS.2.2v2
+Unmanaged users SHALL NOT be enabled to initiate contact with internal users.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.TEAMS.2.2v2; Criticality: SHALL -->
+- _Rationale:_ Allowing contact from unmanaged users can expose users to email and contact address harvesting. This policy provides protection against this type of harvesting.
+- _Last modified:_ August 2025
+- _Note:_ This policy is not applicable to Government Community Cloud (GCC), GCC High, and Department of Defense (DoD) tenants.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7, SI-8
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1204: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204.001: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+
+#### MS.TEAMS.2.3v2
+Internal users SHOULD NOT be enabled to initiate contact with unmanaged users.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.TEAMS.2.3v2; Criticality: SHOULD -->
+- _Rationale:_ Contact with unmanaged users can pose the risk of data leakage and other security threats. This policy provides protection by disabling internal user access to unmanaged users.
+- _Last modified:_ August 2025
+- _Note:_ This policy is not applicable to Government Community Cloud (GCC), GCC High, and Department of Defense (DoD) tenants.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7, SC-7(10)(a)
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1204: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204.001: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+
+### Resources
+
+- [IT Admins - Manage external meetings and chat with people and organizations using Microsoft identities \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoftteams/manage-external-access)
+
+- [Teams settings and policies reference \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoftteams/meeting-settings-in-teams#allow-anonymous-users-to-join-meetings)
+
+- [Use guest access and external access to collaborate with people
+  outside your organization \| Microsoft
+  Learn](https://learn.microsoft.com/en-us/microsoftteams/communicate-with-users-from-other-organizations)
+
+- [Manage chat with external Teams users not managed by an organization
+\| Microsoft
+Learn](https://learn.microsoft.com/en-us/microsoftteams/manage-external-access#manage-chat-with-external-teams-users-not-managed-by-an-organization)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+Steps for the unmanaged users are outlined in [Manage chat with external Teams users not
+managed by an
+organization](https://learn.microsoft.com/en-us/microsoftteams/manage-external-access#manage-chat-with-external-teams-users-not-managed-by-an-organization).
+
+#### MS.TEAMS.2.1v2 Instructions
+
+To enable external access for only specific domains:
+
+1.  Sign in to the **Microsoft Teams admin center**.
+
+2.  Select **Users** > **External access** > **Organization settings**.
+
+3.  Next to **Teams and Skype for Business users in external organizations**,
+    select **Allow only specific external domains**
+
+4.  Select **Add external domains**. Enter domains allowed, and then select **Done**
+
+    **NOTE:** Domains will need to be added in this step in order for users to communicate with them.
+
+5.  Click **Save**.
+
+#### MS.TEAMS.2.2v2 Instructions
+
+1.  Sign in to the **Microsoft Teams admin center**.
+
+2.  Select **Users > External access**.
+
+3.  Select **Policies**.
+
+4.  Select **Global (Org-wide Default)**.
+
+5. Under **Edit policy details**, toggle **People in my organization can communicate with unmanaged Teams accounts** to one of the following:
+    1. To completely block contact with unmanaged users, toggle the setting to **Off**.
+    2. To allow contact with unmanaged users only if the internal user initiates the contact:
+        - Toggle the setting to **On**.
+        - Clear the check next to **External users with Teams accounts not managed by an organization can contact users in my organization**.
+
+#### MS.TEAMS.2.3v2 Instructions
+
+1.  Sign in to the **Microsoft Teams admin center**.
+
+2.  Select **Users > External access**.
+
+3.  Select **Policies**.
+
+4.  Select **Global (Org-wide Default)**.
+
+4.  To completely block contact with unmanaged users, under **Edit policy details**, set **People in my organization can communicate with unmanaged Teams accounts** to **Off**.
+
+## 4. Teams Email Integration
+This section helps reduce security risks related to Teams email integration. Teams provides an optional feature allowing channels to have an email address and receive email.
+
+### Policies
+#### MS.TEAMS.4.1v1
+Teams email integration SHALL be disabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.TEAMS.4.1v1; Criticality: SHALL -->
+- _Rationale:_ Microsoft Teams email integration associates a Microsoft, not tenant domain, email address with a Teams channel. Channel emails are addressed using the Microsoft-owned domain <code>&lt;teams.ms&gt;</code>. By disabling Teams email integration, an agency prevents potentially sensitive Teams messages from being sent through external email gateways.
+- _Last modified:_ July 2023
+- _Note:_ Teams email integration is not applicable to Government Community Cloud (GCC), GCC High, and Department of Defense (DoD) tenants.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8, SC-7(10)(a), AC-4
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1204: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204.001: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+    - [T1204.002: Malicious File](https://attack.mitre.org/techniques/T1204/002/)
+
+### Resources
+
+- [Email Integration \| Microsoft
+Learn](https://learn.microsoft.com/en-us/microsoftteams/settings-policies-reference#email-integration)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+#### MS.TEAMS.4.1v1 Instructions
+
+1.  Sign in to the **Microsoft Teams admin
+    center**.
+
+2.  Select **Teams** > **Teams Settings**.
+
+3.  Under the **Email integration** section, set **Users can send
+    emails to a channel email address** to **Off**.
+
+## 5. App Management
+
+This section helps reduce security risks related to app integration with Microsoft Teams. Teams can integrate with the following classes of apps:
+
+- *Microsoft apps*: apps published by Microsoft.
+
+- *Third-party apps*: apps not authored by Microsoft, published to the
+Teams store.
+
+- *Custom apps*: apps not published to the Teams store, such as apps under
+development, that users sideload into Teams.
+
+### Policies
+
+#### MS.TEAMS.5.1v2
+Agencies SHOULD only allow installation of Microsoft apps approved by the agency.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.TEAMS.5.1v2; Criticality: SHOULD -->
+- _Rationale:_ Allowing Teams integration with all Microsoft apps can expose the agency to potential vulnerabilities present in those apps. By only allowing specific apps and blocking all others, the agency can better manage app integration and potential exposure points.
+- _Last modified:_ August 2025
+- _Note:_ This policy applies to the Global (Org-wide default) policy, all custom policies, and the org-wide app settings. Custom policies MAY be created to allow more flexibility for specific users.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-11
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1195: Supply Chain Compromise](https://attack.mitre.org/techniques/T1195/)
+
+#### MS.TEAMS.5.2v2
+Agencies SHOULD only allow installation of third-party apps approved by the agency.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.TEAMS.5.2v2; Criticality: SHOULD -->
+- _Rationale:_ Allowing Teams integration with third-party apps can expose the agency to potential vulnerabilities present in an app not managed by the agency. By allowing only specific apps approved by the agency and blocking all others, the agency can limit its exposure to third-party app vulnerabilities.
+- _Last modified:_ August 2025
+- _Note:_ This policy applies to the Global (Org-wide default) policy, all custom policies if they exist, and the org-wide settings. Custom policies MAY be created to allow more flexibility for specific users. Third-party apps are not available in GCC, GCC High, or DoD regions.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-11
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1195: Supply Chain Compromise](https://attack.mitre.org/techniques/T1195/)
+  - [T1528: Steal Application Access Token](https://attack.mitre.org/techniques/T1528/)
+
+#### MS.TEAMS.5.3v2
+Agencies SHOULD only allow installation of custom apps approved by the agency.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+<!--Policy: MS.TEAMS.5.3v2; Criticality: SHOULD -->
+- _Rationale:_ Allowing custom apps integration can expose the agency to potential vulnerabilities present in an app not managed by the agency. By allowing only specific apps approved by the agency and blocking all others, the agency can limit its exposure to custom app vulnerabilities.
+- _Last modified:_ August 2025
+- _Note:_ This policy applies to the Global (Org-wide default) policy, all custom policies if they exist, and the org-wide settings. Custom policies MAY be created to allow more flexibility for specific users. Custom apps are not available in GCC, GCC High, or DoD regions.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-11
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1195: Supply Chain Compromise](https://attack.mitre.org/techniques/T1195/)
+  - [T1528: Steal Application Access Token](https://attack.mitre.org/techniques/T1528/)
+
+### Resources
+
+- [Use app permission policies to control user access to apps \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoftteams/teams-app-permission-policies)
+
+- [Upload your app in Microsoft Teams \| Microsoft Learn](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload)
+
+### License Requirements
+
+- N/A
+
+### Implementation
+
+**NOTE:** The Teams admin portal has been updated and the manner in which applications are controlled has changed. The MS.TEAMS.5.#v2 policies follow the new manner of implementing the policies. Newer Tenants, created within 2024 and newer will follow the newer version 2 policy implementation steps while older tenants will follow the legacy implementation steps.
+
+**ScubaGear will continue to look for and gather the legacy policies when running in any mode.  However, there a limitation in the API when gathering the data for the report. Users must utilize interactive mode to allow ScubaGear to gather the data for the newer portal based settings.**
+
+**NOTE:** Legacy implementation instructions are below the Version 2 intructions. If your tenant has the Version 2 settings available, there is no need to perform the legacy implementation instructions.
+
+#### MS.TEAMS.5.1v2 Instructions
+
+1.  Sign in to the **Microsoft Teams admin center**.
+
+2.  Select **Teams apps** > **Manage apps**.
+
+3.  In the upper right-hand corner select **Actions**
+
+4.  Select **Org-wide app settings**.
+
+5.  Under **Microsoft apps** > Select **On**
+
+6.  Click **Save**.
+
+    **NOTE:** This will make Microsoft apps in the application list available to "Everyone." If adjustments are needed follow the remaining instructions
+
+7. Select **Teams apps** > **Manage apps**.
+
+8. Select each individual app.
+
+9. Select **Users and groups** > **Edit availability**
+
+10. Change **Available to** to the appropriate setting for your organization. (Everyone, Specific users or groups, or No one)
+
+11. Repeat steps 7 to 10 for each application
+
+#### MS.TEAMS.5.2v2 Instructions
+
+1.  Sign in to the **Microsoft Teams admin center**.
+
+2.  Select **Teams apps** > **Manage apps**.
+
+3.  In the upper right-hand corner select **Actions**
+
+4.  Select **Org-wide app settings**.
+
+5.  Under **Third-party apps** > Select **Off**
+
+6.  Click **Save**.
+
+    **NOTE:** This will make third party apps in the application list available to "No one." If adjustments are needed follow the remaining                     instructions
+
+7.  Select **Teams apps** > **Manage apps**.
+
+8.  Select each individual app.
+
+9.  Select **Users and groups** > **Edit availability**
+
+10.  Change **Available to** to the appropriate setting for your organization. (Everyone, Specific users or groups, or No one)
+
+11.  Repeat steps 7 to 10 for each application
+
+#### MS.TEAMS.5.3v2 Instructions
+
+1.  Sign in to the **Microsoft Teams admin center**.
+
+2.  Select **Teams apps** > **Manage apps**.
+
+3.  In the upper right-hand corner select **Actions**
+
+4.  Select **Org-wide app settings**.
+
+5.  Under **Custom apps** > Select **Off**
+
+6.  Click **Save**.
+
+    **NOTE:** This will make Custom apps in the application list available to "No one." If adjustments are needed follow the remaining                     instructions
+
+7.  Select **Teams apps** > **Manage apps**.
+
+8.  Select each individual app.
+
+9.  Select **Users and groups** > **Edit availability**
+
+10.  Change **Available to** to the appropriate setting for your organization. (Everyone, Specific users or groups, or No one)
+
+11.  Repeat steps 7 to 10 for each application
+
+
+### Legacy Policy Implementation
+
+**NOTE:** Only Implement these settings if the v2 settings above are not available in your tenant.
+
+#### Legacy MS.TEAMS.5.1v1 Instructions
+
+1.  Sign in to the **Microsoft Teams admin center**.
+
+2.  Select **Teams apps** > **Permission policies**.
+
+3.  Select **Global (Org-wide default)**.
+
+4.  Under **Microsoft apps**, select **Allow specific apps and block all others** or **Block all apps**.
+
+5.  Click **Allow apps**.
+
+6.  Search and Click **Add** to all appropriate Microsoft Apps.
+
+7.  Click **Allow**.
+
+8.  Click **Save**.
+
+9.  If custom policies have been created, repeat these steps for each
+    policy, selecting the appropriate policy in step 3.
+
+#### Legacy MS.TEAMS.5.2v1 Instructions
+
+1.  Sign in to the **Microsoft Teams admin center**.
+
+2.  Select **Teams apps** > **Manage apps**.
+
+3.  Select **Org-wide app settings** button to access pop-up options.
+    - Under **Third-party apps** turn off **Third-party apps**.
+    - Click **Save**.
+
+4.  Select **Teams apps** > **Permission policies**.
+
+5.  Select **Global (Org-wide default)**.
+
+6.  Set **Third-party apps** to **Block all apps**, unless specific apps
+    have been approved by the agency, in which case select **Allow
+    specific apps and block all others**.
+
+7.  Click **Save**.
+
+8.   If custom policies have been created, repeat steps 4 to 7 for each
+    policy, selecting the appropriate policy in step 5.
+
+#### Legacy MS.TEAMS.5.3v1 Instructions
+
+1.  Sign in to the **Microsoft Teams admin center**.
+
+2.  Select **Teams apps** > **Manage apps**.
+
+3.  Select **Org-wide app settings** button to access pop-up options.
+    - Under **Custom apps** turn off **Interaction with custom apps**.
+    - Click **Save**.
+
+4.  Select **Teams apps** > **Permission policies**.
+
+5.  Select **Global (Org-wide default)**.
+
+6.  Set **Custom apps** to **Block all apps**, unless specific apps have
+    been approved by the agency, in which case select **Allow specific apps and block all others**.
+
+7.  Click **Save**.
+
+8.  If custom policies have been created, repeat steps 4 to 7 for each
+    policy, selecting the appropriate policy in step 5.
+
+
+[^1]: Note that B2B guest users and all anonymous users except for
+    external users appear in Teams calls as _John Doe (Guest)_. To avoid
+    potential confusion, true guest users are always referred to as B2B guest users in this document.
+
+# Appendix A - Custom Meeting Policies
+
+If there is a legitimate business need, custom meeting policies can be defined with _specific_ users assigned to them. For example, custom meeting policies can be configured with _specific_ users having
+permission to record meetings. To allow specific users the ability to
+record meetings:
+
+1.  Sign in to the **Microsoft Teams admin center**.
+
+2.  Select **Meetings** > **Meeting policies**.
+
+3.  Create a new policy by selecting **Add**. Give this new policy a
+    name and appropriate description.
+
+4.  Under the **Recording & transcription** section, set **Cloud
+    recording** to **On**.
+
+5.  Select **Save**.
+
+6.  After selecting **Save**, a table displays the set of policies.
+    Select the row containing the new policy, then select **Manage
+    users**.
+
+7.  Assign the users who need the ability to record to this policy.
+
+8.  Select **Apply**.
+
+**`TLP:CLEAR`**

--- a/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/assuredcontrols.md
+++ b/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/assuredcontrols.md
@@ -1,0 +1,139 @@
+# CISA Google Workspace Secure Configuration Baseline for Assured Controls and Assured Controls Plus
+
+Assured Controls and Assured Controls Plus are paid add-ons within Google Workspace (GWS) relating to compliance and security.
+This Secure Configuration Baseline (SCB) for Assured Controls provides specific policies to strengthen an organization's data security.
+This baseline is intended as guidance for agencies that already have Assured Controls or Assured Controls Plus licenses.
+Users who choose to implement this baseline should carefully consider the tradeoffs involved, including the potential security benefits, usability impacts, and possible increased fees for additional licenses.
+
+The Cybersecurity and Infrastructure Security Agency's (CISA) Secure Cloud Business Applications (SCuBA) project, provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies' cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for GWS help secure federal information assets stored within GWS cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government's threats and risk tolerance. Organizations outside of the federal government may also find these baselines useful references to help reduce risks even if such organizations have different risk tolerances or face different threats.
+
+For non-federal users, the information in this document is being provided "as is" for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products. CISA has no control over vendor changes to products offerings or features. Accordingly, these SCuBA SCBs for GWS may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+This baseline is based on Google documentation and addresses the following:
+- [Google Support Staff Data Access](#1-google-support-staff-data-access)
+- [Data Regions Advanced Settings](#2-data-regions-advanced-settings)
+
+## Assumptions
+
+This document assumes the organization is using both GWS Enterprise Plus and the Assured Controls Plus add-on.
+
+
+## Key Terminology
+
+The key words "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services) (**BOD 25-01 Requirement**): This indicator means that the policy is required under CISA BOD 25-01.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology) (**Automated Check**): This indicator means that the policy can be automatically checked via ScubaGoggles. See [our documentation](../../README.md) for help getting started.
+
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#break-glass-accounts)(**Configurable**): This indicator means that the policy can be customized via a configuration file.
+
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)(**Log-Based Check**): This indicator means that ScubaGoggles will check the policy by reviewing admin audit logs. See [Limitations](../../docs/usage/Limitations.md#log-based-policy-checks).
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols83v06-instructions)(**Manual**): This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. Google Support Staff Data Access
+
+Google Workspace (GWS) includes several mechanisms to control how Google support staff access an organization's data.
+Access Approvals requires Google support staff to request approval before viewing an organization's data.
+Access can also be restricted to specific demographics, such as access by U.S.-based Google staff only.
+However, these features require additional licensing and are not available by default with GWS Enterprise Plus.
+
+### Policies
+
+#### GWS.ASSUREDCONTROLS.1.1v1
+Access Approvals SHOULD be enabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)
+
+- _Rationale:_ Unauthorized data access increases the risk of exposing sensitive data to untrusted entities. Unauthorized access and actions to an organization's data may be reduced by requiring approval of Google staff requests to access organizations' data.
+- _Last modified:_ November 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)(a)
+- MITRE ATT&CK TTP Mapping
+    - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+    - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+    - [T1589: Gather Victim Identity Information](https://attack.mitre.org/techniques/T1589/)
+
+#### GWS.ASSUREDCONTROLS.1.2v1
+Agencies SHOULD restrict support access to U.S.-based Google staff only.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ This policy prevents data processing by Google personnel located outside of the U.S., reducing potential exposure to unauthorized entities. Implementation of this policy accounts for organizational data sovereignty.
+- _Last modified:_ November 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)(a)
+- MITRE ATT&CK TTP Mapping
+    - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+    - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+    - [T1589: Gather Victim Identity Information](https://attack.mitre.org/techniques/T1589/)
+
+### Resources
+
+- [GWS Admin Help \| Access Approvals: Require Google staff to request approval before viewing support data](https://support.google.com/a/answer/12410469)
+- [GWS Admin Help \| What data is covered by Access Management and Access Approvals?](https://support.google.com/a/answer/10379605)
+- [GWS Admin Help \| Access Management: Limit Google support actions related to your data](https://support.google.com/a/topic/10404276)
+- [GWS Admin Help \| Access Management: Limit the Google staff who can take support actions related to your data](https://support.google.com/a/answer/10343878)
+
+
+### Prerequisites
+- Access Approvals requires either the Assured Controls or the Assured Controls Plus add-ons.
+- Access Management requires the Assured Controls Plus add-on. However, customers who purchased the Assured Controls and the Assured Support add-on prior to June 17, 2024, also have access to Access Management.
+
+### Implementation
+
+#### GWS.ASSUREDCONTROLS.1.1v1 Instructions
+1.  Sign in to the [Google Admin console](https://admin.google.com/) as a super admin.
+2.  Select **Data** -\> **Compliance** -\> **Access Approvals**.
+3.  Check the **Require Google staff to request approval before viewing data necessary for support services** box.
+4.  Click **SAVE**.
+
+#### GWS.ASSUREDCONTROLS.1.2v1 Instructions
+
+1.  Sign in to the [Google Admin console](https://admin.google.com/) as a super admin.
+2.  Select **Data** -\> **Compliance** -\> **Access Management**.
+3.  Select either **Access by U.S. Google Staff Only** or **Access by CJIS-authorized and IRS 1075-authorized Google staff only**.
+4.  Click **SAVE**.
+
+## 2. Data Regions Advanced Settings
+Data regions advanced settings can be used to restrict access to features that process data globally.
+However, these settings only apply to users with the Assured Controls Plus add-on.
+
+### Policies
+
+#### GWS.ASSUREDCONTROLS.2.1v1
+Data processing across multiple regions SHOULD be disabled for all Google Workspace products.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)
+
+-  _Rationale:_ This policy prevents data processing in a region other than the United States, reducing potential exposure to unauthorized entities. Implementation of this policy helps prevent agency data from being subject to the laws of other nations.
+- _Last modified:_ November 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)(a)
+- MITRE ATT&CK TTP Mapping
+    - [T1591: Gather Victim Organization Information](https://attack.mitre.org/techniques/T1591)
+        - [T1591:001 Gather Victim Organization Information: Determine Physical Location](https://attack.mitre.org/techniques/T1591/001/)
+    - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+    - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
+### Resources
+- [GWS Admin Help \| Set up advanced settings for data regions](https://support.google.com/a/answer/14310030)
+
+### Prerequisites
+- Organizations with the Enterprise Plus or the Data Regions add-on subscriptions are able to modify the advanced data regions settings. However, these settings only apply to users with both the Enterprise Plus and the Assured Controls Plus licenses.
+
+### Implementation
+
+#### GWS.ASSUREDCONTROLS.2.1v1 Instructions
+1. Sign in to the [Google Admin Console](https://admin.google.com/) as an administrator.
+2. Navigate to **Data** -\> **Compliance** -\> **Data Regions** -\> **Advanced Settings**.
+3. Select **Calendar** and choose **Disable features that may process data across multiple regions**, then click **SAVE**.
+4. Select **Drive Docs** and choose **Disable features that may process data across multiple regions**, then click **SAVE**.
+5. Select **Gmail** and choose **Disable features that may process data across multiple regions**, then click **SAVE**.
+6. Select **Google Chat and classic Hangouts**, choose **Disable features that may process data across multiple regions**, and click **SAVE**.
+7. Select **Google Meet** and choose **Disable features that may process data across multiple regions**, then click **SAVE**.
+8. Select **Gemini app and Gemini in Google Workspace apps**, choose **Disable features that may process data across multiple regions**, and click **SAVE**.

--- a/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/calendar.md
+++ b/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/calendar.md
@@ -1,0 +1,248 @@
+# CISA Google Workspace Secure Configuration Baseline for Google Calendar
+
+Google Calendar is a calendar service in Google Workspace (GWS) used for creating and editing events that enables collaboration. Calendar allows administrators to control and manage their sharing settings for both internal and external use. This Secure Configuration Baseline (SCB) provides specific policies to strengthen Calendar security.
+
+The Cybersecurity and Infrastructure Security Agency's (CISA) Secure Cloud Business Applications (SCuBA) project provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies' cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for GWS help secure federal information assets stored within GWS cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government's threats and risk tolerance. Organizations outside of the federal government may also find these baselines to be useful references to help reduce risks even if such organizations have different risk tolerances or face different threats.
+
+For non-federal users, the information in this document is being provided "as is" for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products. CISA has no control over vendor changes to products offerings or features. Accordingly, these SCuBA SCBs for GWS may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+This baseline is based on Google documentation available at [Google Workspace Admin Help: Set Calendar sharing options](https://support.google.com/a/answer/60765?hl=en#zippy=%2Cset-a-default-for-internal-sharing%2Callow-or-restrict-external-sharing) and addresses the following:
+
+-   [External Sharing Options for Primary Calendars](#1-external-sharing-options)
+-   [External Invitations Warnings](#2-external-invitations-warnings)
+-   [Calendar Interop Management](#3-calendar-interop-management)
+-   [Paid Appointments](#4-paid-appointments)
+
+Settings can be assigned to certain users within Google Workspace through organizational units, configuration groups, or individually. Before changing a setting, the user can select the organizational unit, configuration group, or individual users to which they want to apply changes.
+
+## Assumptions
+
+This document assumes the organization is using GWS Enterprise Plus.
+
+This document does not address, ensure compliance with, or supersede any law, regulation, or other authority.  Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology.  This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+## Key Terminology
+
+The key words "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services) (**BOD 25-01 Requirement**): This indicator means that the policy is required under CISA BOD 25-01.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology) (**Automated Check**): This indicator means that the policy can be automatically checked via ScubaGoggles. See [our documentation](../../README.md) for help getting started.
+
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#break-glass-accounts)(**Configurable**): This indicator means that the policy can be customized via a configuration file.
+
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)(**Log-Based Check**): This indicator means that ScubaGoggles will check the policy by reviewing admin audit logs. See [Limitations](../../docs/usage/Limitations.md#log-based-policy-checks).
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols83v06-instructions)(**Manual**): This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. External Sharing Options
+
+This section determines what calendar information is shared with external entities.
+
+### Policies
+
+#### GWS.CALENDAR.1.1v1
+External sharing options for primary calendars SHALL be configured to "Only free/busy information (hide event details)."
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Calendars can contain private or otherwise sensitive information. Restricting calendar details to "only free/busy information (hide event details)" helps prevent data leakage by restricting the amount of information that is viewable when a user shares their calendar with someone external to the organization.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, SC-7(10)(a)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+#### GWS.CALENDAR.1.2v1
+External sharing options for secondary calendars SHALL be configured to "Only free/busy information (hide event details)."
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Calendars can contain private or otherwise sensitive information. Restricting calendar details to "only free/busy information (hide event details)" helps prevent data leakage by restricting the amount of information that is viewable when a user shares their calendar with someone external to the organization.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, SC-7(10)(a)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Set Calendar sharing options](https://support.google.com/a/answer/60765?hl=en#zippy=%2Cset-a-default-for-internal-sharing%2Callow-or-restrict-external-sharing)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To configure the settings for external sharing in primary calendar:
+
+#### GWS.CALENDAR.1.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Calendar**.
+3.  Select **Sharing settings** -\> **External sharing options for primary calendars**.
+4.  Select **Only free/busy information (hide event details)**.
+5.  Select **Save**.
+
+#### GWS.CALENDAR.1.2v1 Instructions
+
+To configure the settings for External Sharing in secondary calendars:
+
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Calendar**.
+3.  Select **General settings -\> External sharing options for secondary calendars**.
+4.  Select **Only free/busy information (hide event details)**.
+5.  Select **Save**.
+
+## 2. External Invitations Warnings
+
+This section determines whether users are warned when inviting one or more guests from outside of their domain.
+
+### Policies
+
+#### GWS.CALENDAR.2.1v1
+External invitations warnings SHALL be enabled to prompt users before sending invitations.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Users may inadvertently include external guests in calendar event invitations, potentially resulting in data leakage. Warning users when external participants are included can help reduce this risk.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AT-2b
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+    - [T1566:003: Phishing: Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Allow external invitations in Google Calendar events](https://support.google.com/a/answer/6329284?product_name=UnuFlow&visit_id=637836623092961849-291754447&rd=1&src=supportwidget0)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.CALENDAR.2.1v1 Instructions
+
+To configure the settings for Confidential Mode:
+
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Calendar**.
+3.  Select **Sharing settings** -\> **External Invitations**.
+4.  Check the **Warn users when inviting guests outside of the domain** checkbox.
+5.  Select **Save**.
+
+## 3. Calendar Interop Management
+
+This section determines whether Microsoft Exchange and Google Calendar can be configured to work together, allowing users in both systems to share their availability status and view each other's calendars. The availability and event information shared between Exchange and Calendar will include user availability status, group or team calendars, and calendar resources (such as meeting rooms). Calendar Interop respects event-level privacy settings from either Exchange or Calendar.
+
+Due to the added complexity and attack surface associated with configuring Calendar Interop, it should be disabled in environments where this capability is not necessary for agency mission fulfillment.
+
+### Policies
+
+#### GWS.CALENDAR.3.1v1
+Calendar Interop SHOULD be disabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Enabling Calendar interop adds a layer of complexity to calendar management, possibly increasing the attack surface. Disabling this feature (unless required by the organization) conforms to the principle of least functionality.
+- _Last modified:_ July 2023
+- _Note:_ This policy applies unless agency mission fulfillment requires collaboration between internal and external users who both utilize Microsoft Exchange and Google Calendar
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1199: Trusted Relationship](https://attack.mitre.org/techniques/T1199/)
+
+#### GWS.CALENDAR.3.2v1
+Microsoft 365 (Graph API) SHALL be used instead of basic authentication to establish connectivity between tenants or organizations in cases where Calendar Interop is deemed necessary for agency mission fulfillment.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscalendar32v06-instructions)
+
+- _Rationale:_ Basic authentication is a deprecated and risk-prone authentication method. The Microsoft 365 (Graph API) helps reduce the risk of credential compromise.
+- _Last modified:_ August 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), IA-2(2)
+- MITRE ATT&CK TTP Mapping
+  - [T1555: Credentials from Password Stores](https://attack.mitre.org/techniques/T1555/)
+
+### Resources
+
+-   [Google Workspace Admin Help: About Calendar Interop](https://support.google.com/a/answer/7444958?hl=en)
+-   [Deprecation of Basic Authentication in Exchange Online](https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.CALENDAR.3.1v1 Instructions
+
+To configure the settings for Calendar Interop:
+
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Calendar**.
+3.  Select **Calendar Interop management**.
+4.  Select **Exchange availability in Calendar**.
+5.  Uncheck the **Allow Google Calendar to display Exchange users' availability** checkbox.
+6.  Select **Save**.
+
+#### GWS.CALENDAR.3.2v1 Instructions
+
+To configure the settings for Calendar Interop:
+
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Calendar**.
+3.  Select **Calendar Interop management**.
+4.  Select **Exchange availability in Calendar**.
+5.  Check the **Allow Google Calendar to display Exchange users' availability** checkbox.
+6.  Select **Add an Exchange endpoint**.
+7.  Select **Microsoft 365 (Graph API)** as the endpoint type.
+8.  Enter the applicable **Exchange domain names**, **Exchange role accounts**, **Tenant ID**, **Application (client) ID**, and **Client secret**.
+9.  Click **Add**.
+10. Select **Save**.
+
+## 4. Paid Appointments
+
+This section details when the "paid appointment booking" feature is or is not enabled.
+
+### Policies
+
+#### GWS.CALENDAR.4.1v1
+"Appointment Schedule with Payments" SHOULD be disabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Enabling paid appointments adds a layer of complexity to calendar management, possibly increasing the attack surface. Disabling this feature conforms to the principle of least functionality.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1199: Trusted Relationship](https://attack.mitre.org/techniques/T1199/)
+
+### Resources
+
+-   [Google Workspace Help: Allow paid appointment schedules in Calendar](https://support.google.com/a/answer/13765946?hl=en)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.CALENDAR.4.1v1 Instructions
+
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Calendar**.
+3.  Select **Advanced settings -\> Appointment schedules with payments**.
+4.  Ensure the **Allow appointment schedule users to require payments for booked appointments through their own payment provider accounts** checkbox is unchecked.
+5.  Select **Save**.

--- a/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/chat.md
+++ b/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/chat.md
@@ -1,0 +1,278 @@
+# CISA Google Workspace Secure Configuration Baseline for Google Chat
+
+Google Chat is a communication and collaboration tool in Google Workspace (GWS) that supports direct messaging, group conversations, content creation, and sharing. Chat allows administrators to control and manage their messages and files. This Secure Configuration Baseline (SCB) provides specific policies to strengthen Chat security.
+
+The Cybersecurity and Infrastructure Security Agency's (CISA) Secure Cloud Business Applications (SCuBA) project provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies' cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for GWS help secure federal information assets stored within GWS cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government's threats and risk tolerance. Organizations outside of the federal government may also find these baselines to be useful references to help reduce risks even if such organizations have different risk tolerances or face different threats.
+
+For non-federal users, the information in this document is being provided "as is" for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products. CISA has no control over vendor changes to products offerings or features. Accordingly, these SCuBA SCBs for GWS may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+This baseline is based on Google documentation available at [Google Workspace Admin Help: Google Chat settings](https://support.google.com/a/answer/9540647?hl=en) and addresses the following:
+
+-   [Chat History](#1-chat-history)
+-   [External File Sharing](#2-external-file-sharing)
+-   [History for Spaces](#3-history-for-spaces)
+-   [External Chat Messaging](#4-external-chat-messaging)
+-   [Content Reporting](#5-content-reporting)
+
+Settings can be assigned to certain GWS users individually, through organizational units, or through configuration groups. Before changing a setting, the user can select the organizational unit, configuration group, or individual users to which they want to apply changes.
+
+## Assumptions
+
+This document assumes the organization is using GWS Enterprise Plus.
+
+This document does not address, ensure compliance with, or supersede any law, regulation, or other authority.  Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology.  This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+## Key Terminology
+
+The key words "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services) (**BOD 25-01 Requirement**): This indicator means that the policy is required under CISA BOD 25-01.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology) (**Automated Check**): This indicator means that the policy can be automatically checked via ScubaGoggles. See [our documentation](../../README.md) for help getting started.
+
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#break-glass-accounts)(**Configurable**): This indicator means that the policy can be customized via a configuration file.
+
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)(**Log-Based Check**): This indicator means that ScubaGoggles will check the policy by reviewing admin audit logs. See [Limitations](../../docs/usage/Limitations.md#log-based-policy-checks).
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols83v06-instructions)(**Manual**): This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. Chat History
+
+This section covers chat history retention for users within the organization and prevents users from changing their history setting. This control applies to both direct messages and group messages.
+
+### Policies
+
+#### GWS.CHAT.1.1v1
+Chat history SHALL be enabled for information traceability.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Google Chat users may inadvertently share sensitive or private information during conversations. Preservation of chat history may be crucial if details discussed in chats are needed for future reference or dispute resolution. Enabling chat history for Google Chat may mitigate these risks by providing a traceable record of all conversations, enhancing information traceability and security.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AU-2, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562:001: Impair Defenses: Disable or Modify Tools](https://attack.mitre.org/techniques/T1562/001/)
+
+#### GWS.CHAT.1.2v1
+Users SHALL NOT be allowed to change their history setting.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Altering the Google Chat history settings can potentially allow users to obfuscate the sharing of sensitive information via Chat. This policy helps preserve all Google Chat histories, enhancing data security and promoting accountability among users.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AU-9
+- MITRE ATT&CK TTP Mapping
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562:001: Impair Defenses: Disable or Modify Tools](https://attack.mitre.org/techniques/T1562/001/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Turn chat history on or off for users](https://support.google.com/a/answer/7664184)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To configure the settings for Google Chat history:
+
+#### GWS.CHAT.1.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Google Chat**.
+3.  Select **History for chats**.
+4.  Select **History is ON**.
+5.  Select **Save**
+
+#### GWS.CHAT.1.2v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Google Chat**.
+3.  Select **History for chats**.
+4.  Uncheck the **Allow users to change their history setting** checkbox.
+5.  Select **Save**.
+
+## 2. External File Sharing
+
+This section covers sharing files externally through Google Chat.
+
+### Policies
+
+#### GWS.CHAT.2.1v1
+External file sharing SHALL be disabled to protect sensitive information from unauthorized or accidental sharing.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Enabling external file sharing in Google Chat opens an avenue for data loss that may not be as rigorously monitored or protected as traditional collaboration channels, such as email. This policy limits the potential for unauthorized or accidental sharing.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+    - [T1048:002: Exfiltration Over Alternative Protocol: Exfiltration Over Asymmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/002/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Control file sharing in Chat](https://support.google.com/a/answer/10277783?hl=en)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To configure the settings for external file sharing:
+
+#### GWS.CHAT.2.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Google Chat**.
+3.  Select **Chat file sharing**.
+4.  In the **External file sharing** dropdown menu, select **No files.**
+5.  Select **Save**.
+
+## 3. History for Spaces
+
+This section covers whether chat history is retained by default for users within the organization. This control does not apply for threaded chat spaces because those require that "history" be turned on, a setting that cannot be changed. Chat spaces allow multiple users to share files, assign tasks, and stay connected.
+
+### Policies
+
+#### GWS.CHAT.3.1v1
+Space history SHOULD be enabled for information traceability.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Google Chat users may inadvertently share sensitive or private information during conversations. Preservation of chat history may be crucial if details discussed in chats are needed for future reference or dispute resolution. Enabling chat history for Google Chat may mitigate these risks by providing a traceable record of all conversations, enhancing information traceability and security.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AU-2, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562:001: Impair Defenses: Disable or Modify Tools](https://attack.mitre.org/techniques/T1562/001/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Set a space history option for users](https://support.google.com/a/answer/9948515?hl=en)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To configure the settings for history for spaces:
+
+#### GWS.CHAT.3.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Google Chat**.
+3.  Select **History for spaces**.
+4.  Select **History is ALWAYS ON**.
+5.  Select **Save**.
+
+## 4. External Chat Messaging
+
+This section permits users to send Google Chat messages outside of their organization but requires that external Google Chat messages must be restricted to allowlisted domains only.
+
+### Policies
+
+#### GWS.CHAT.4.1v1
+External chat messaging SHALL be restricted to allowlisted domains only.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Allowing Google Chat external chat messaging to unrestricted domains opens additional avenues for data exfiltration, increasing the risk of data leakage. Restricting external chat messaging to only allowlisted domains helps minimize the risk of sensitive information being shared outside the organization without explicit consent and approval.
+- _Last modified:_ November 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1213.005: Data from Information Repositories: Messaging Applications](https://attack.mitre.org/techniques/T1213/005/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Set external chat options](https://support.google.com/a/answer/9269229?product_name=UnuFlow&visit_id=637841711304802210-4105703050&rd=1&src=supportwidget0)
+-   [Google Workspace Admin Help: Allow external sharing with only trusted domains](https://support.google.com/a/answer/6160020)
+-   [CIS Google Workspace Benchmark v1.1.0 - 3.1.4.2.2 Ensure Google Chat Externally is Restricted to Allowlisted Domains](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To configure the settings for external chats:
+
+#### GWS.CHAT.4.1v1 Instructions
+To enable external chat for allowlisted domains only:
+1. Sign in to the [Google Admin Console](https://admin.google.com).
+2. Select **Apps** -\> **Google Workspace** -\> **Google Chat**.
+3. Select **External chat settings** -\> **Chat externally**.
+4. Select **ON**.
+5. Select **Only allow this for allowlisted domains**.
+6. To add allowlisted domains select **Manage allowlisted domains**.
+7. Select **Save**.
+
+Alternatively, to disable external chat entirely:
+1. Sign in to the [Google Admin Console](https://admin.google.com).
+2. Select **Apps** -\> **Google Workspace** -\> **Google Chat**.
+3. Select **External chat settings** -\> **Chat externally**.
+4. Select **OFF**.
+5. Select **Save**.
+
+
+## 5. Content Reporting
+
+This section covers the content reporting functionality, a feature that allows users to report messages in violation of organizational guidelines to workspace administrators.
+
+### Policies
+
+#### GWS.CHAT.5.1v1
+Chat content reporting SHALL be enabled for all conversation types.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)
+
+- _Rationale:_ Chat messages could be used as an avenue for phishing, malware distribution, or other security risks. Enabling this feature allows users to report any suspicious messages to Google Workspace (GWS) admins, increasing threat awareness and facilitating threat mitigation. By selecting all conversation types, agencies help enable their users to report risky messages regardless of the conversation type.
+- _Last modified:_ February 2024
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IR-6
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+#### GWS.CHAT.5.2v1
+All reporting message categories SHOULD be selected.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)
+
+- _Rationale:_ Users may be uncertain about what kind of messages should be reported. Enabling all message categories can help users determine which types of messages should be reported.
+- _Last modified:_ February 2024
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IR-6
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+### Resources
+- [Set-up content moderation for Chat](https://support.google.com/a/answer/13471510?hl=en)
+
+### Prerequisites
+-   Chat history must be enabled for users to be able to report messages.
+
+### Implementation
+
+#### GWS.CHAT.5.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Chat**.
+3.  Click **Manage content reporting** then **Content reporting**.
+4.  Ensure **Allow users to report content in Chat** is enabled.
+5.  Ensure all conversation type checkboxes are selected.
+6.  Click **Save**.
+
+#### GWS.CHAT.5.2v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Chat**.
+3.  Click **Manage content reporting** then **Content reporting**.
+4.  Ensure all checkboxes under **Reporting categories** are selected.
+5.  Click **Save**.

--- a/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/classroom.md
+++ b/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/classroom.md
@@ -1,0 +1,244 @@
+# CISA Google Workspace Secure Configuration Baseline for Google Classroom
+
+Google Classroom is a service in Google Workspace (GWS) to streamline assignments, boost collaboration, and foster communication. This service allows for the creation of classes, creating and grading assignments, student collaboration, communication with teachers and students, and integration with other Google products.
+
+Google Classroom is designed and intended for implementation in educational institutions. Google Classroom is available with the Google Workspace (GWS) for Education Edition and is included with all tiers of GWS for Education including Fundamentals, Standard, and Plus. CISA's Secure Configuration Baseline (SCB) Google Classroom policies and guidance are written to correspond with the Plus edition.
+
+The Cybersecurity and Infrastructure Security Agency's (CISA) Secure Cloud Business Applications (SCuBA) project provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies' cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for GWS help secure federal information assets stored within GWS cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government's threats and risk tolerance. Organizations outside of the federal government may also find these baselines to be useful references to help reduce risks even if such organizations have different risk tolerances or face different threats.
+
+For non-federal users, the information in this document is being provided "as is" for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products. CISA has no control over vendor changes to products offerings or features. Accordingly, these SCuBA SCBs for GWS may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+This baseline is based on Google documentation available at [Google Workspace Admin Help: Classroom](https://support.google.com/edu/classroom/?hl=en#topic=10298088) and addresses the following:
+
+-   [Class Membership](#1-class-membership)
+-   [Classroom API](#2-classroom-api)
+-   [Roster Import](#3-roster-import)
+-   [Student Unenrollment](#4-student-unenrollment)
+-   [Class Creation](#5-class-creation)
+
+Settings can be assigned to certain users within GWS through organizational units, configuration groups, or individually. Before changing a setting, the user can select the organizational unit, configuration group, or individual users to which they want to apply changes.
+
+## Assumptions
+
+This document assumes the organization is using GWS Education Plus.
+
+This document does not address, ensure compliance with, or supersede any law, regulation, or other authority.  Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology.  This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+## Key Terminology
+
+The key words "MUST," "MUST NOT," "REQUIRED," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services) (**BOD 25-01 Requirement**): This indicator means that the policy is required under CISA BOD 25-01.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology) (**Automated Check**): This indicator means that the policy can be automatically checked via ScubaGoggles. See [our documentation](../../README.md) for help getting started.
+
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#break-glass-accounts)(**Configurable**): This indicator means that the policy can be customized via a configuration file.
+
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)(**Log-Based Check**): This indicator means that ScubaGoggles will check the policy by reviewing admin audit logs. See [Limitations](../../docs/usage/Limitations.md#log-based-policy-checks).
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols83v06-instructions)(**Manual**): This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. Class Membership
+
+This section covers who has the ability to join classes and what classes the users in your domain can join.
+
+### Policies
+
+#### GWS.CLASSROOM.1.1v1
+"Who can join classes in your domain" SHOULD be set to "Users in your domain only."
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Classes can contain personally identifiable information (PII) or sensitive information. Restricting access to the organization's classes helps prevent data leakage resulting from unauthorized classroom access.
+- _Last modified:_ April 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
+#### GWS.CLASSROOM.1.2v1
+"Which classes users in your domain can join" SHOULD be set to "Classes in your domain only."
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Allowing users to join classes from outside the organization's domains could allow data to be exfiltrated to entities outside the organization's control, potentially creating a significant security risk.
+- _Last modified:_ April 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
+### Resources
+-   [Google Workspace Admin Help: Control User Access to Classroom](https://support.google.com/edu/classroom/answer/6023715)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+To configure the settings for Class Membership:
+
+#### Policy Group 1 Common Implementation:
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Additional Google Service** -\> **Classroom**.
+3.  Select **Class settings**.
+4.  Select **About class membership**.
+
+#### GWS.CLASSROOM.1.1v1 Instructions
+1.  For **Who can join classes in your domain**, select **Users in your domain only**.
+2.  Select **Save**.
+
+#### GWS.CLASSROOM.1.2v1 Instructions
+1.  For **Which classes can users in your domain join**, select **Classes in your domain only**.
+2.  Select **Save**.
+
+## 2. Classroom API
+
+This section covers policies related to the Google Classroom application programming interface (API).
+
+### Policies
+
+#### GWS.CLASSROOM.2.1v1
+Users SHOULD NOT be able to authorize apps to access their Google Classroom data.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Allowing non-administrator users to authorize apps granting access to classroom data opens a possibility for data loss. Allowing only administrators to authorize application access reduces this risk.
+- _Last modified:_ September 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1059: Command and Scripting Interpreter](https://attack.mitre.org/techniques/T1059/)
+    - [T1059:009: Command and Scripting Interpreter: Cloud API](https://attack.mitre.org/techniques/T1059/009/)
+  - [T1199: Trusted Relationship](https://attack.mitre.org/techniques/T1199/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Set Classroom data access](https://support.google.com/edu/classroom/answer/6250906?hl=en)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+To configure the settings for Classroom API:
+
+#### GWS.CLASSROOM.2.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Additional Google Service** -\> **Classroom**.
+3.  Select **Data access**.
+4.  Uncheck **Users can authorize apps to access their Google Classroom data**.
+5.  Select **Save**.
+
+## 3. Roster Import
+
+This section covers policies related to importing rosters from Clever.
+
+### Policies
+
+#### GWS.CLASSROOM.3.1v1
+"Roster Import" with Clever SHOULD be turned off.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ If an organization does not use Clever, allowing roster imports could create a way for unauthorized data to be incorporated into the organization's environment. If an organization does use Clever, then roster imports may be enabled.
+- _Last modified:_ April 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1199: Trusted Relationship](https://attack.mitre.org/techniques/T1199/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Get Started with SIS Roster Import](https://support.google.com/edu/classroom/answer/10495270?visit_id=638337540290677144-1371568967&p=sis_overview&rd=1)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+To configure the settings for Roster Import:
+
+#### GWS.CLASSROOM.3.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Additional Google Service** -\> **Classroom**.
+3.  Select **Roster import**.
+4.  Select **OFF**.
+5.  Select **Save**.
+
+## 4. Student Unenrollment
+
+This section covers policies related to unenrolling a student from a class.
+
+### Policies
+
+#### GWS.CLASSROOM.4.1v1
+Only teachers SHOULD be allowed to unenroll students from classes.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Allowing students to unenroll themselves from classes within Google Classroom creates the opportunity for data loss or other inconsistencies, especially for K-12 classrooms. Restricting this ability to teachers mitigates this risk.
+- _Last modified:_ April 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Control Student Unenrollment Settings](https://support.google.com/edu/classroom/answer/11189334?visit_id=638326465630147042-2696822563&p=student_unenrollment&rd=1)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+To configure the settings for Student Unenrollment:
+
+#### GWS.CLASSROOM.4.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Additional Google Service** -\> **Classroom**.
+3.  Select **Student unenrollment**.
+4.  Select **Teachers only**.
+5.  Select **Save**.
+
+## 5. Class Creation
+
+When first-time users sign in to Classroom, they self-identify as either a student or a teacher. Users who identify as teachers will be marked as a "pending teacher" until an administrator verifies their identity. Google Classroom allows administrators to restrict class creation to only verified teachers.
+
+### Policies
+
+#### GWS.CLASSROOM.5.1v1
+Class creation SHOULD be restricted to verified teachers only.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Allowing "pending teachers" to create classes could potentially allow students to impersonate teachers. This could result in exploiting the trusted relationship between teacher and student, such as if the role was used to phish sensitive information from other students. Restricting class creation to verified teachers reduces this risk.
+- _Last modified:_ April 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(5), AC-6(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1656: Impersonation](https://attack.mitre.org/techniques/T1656/)
+  - [T534: Internal Spearphishing](https://attack.mitre.org/techniques/T1534/)
+  - [T1598: Phishing for Information](https://attack.mitre.org/techniques/T1598/)
+    - [T1598:002: Phishing for Information: Spearphishing Attachment](https://attack.mitre.org/techniques/T1598/002/)
+    - [T1598:003: Phishing for Information: Spearphishing Link](https://attack.mitre.org/techniques/T1598/003/)
+    - [T1598:004: Phishing for Information: Spearphishing Voice](https://attack.mitre.org/techniques/T1598/004/)
+
+### Resources
+
+-   [Verify teachers and set permissions](https://support.google.com/edu/classroom/answer/6071551?hl=en)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+To configure the settings for Class Creation:
+
+#### GWS.CLASSROOM.5.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Additional Google Service** -\> **Classroom**.
+3.  Select **General settings**.
+4.  Select **Teacher permissions**.
+5.  Select **Verified teachers only** for **Who can create classes?**
+6.  Select **Save**.

--- a/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md
+++ b/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/commoncontrols.md
@@ -1,0 +1,1513 @@
+# CISA Google Workspace Secure Configuration Baseline for Common Controls
+
+The Google Workspace (GWS) Admin console is the primary hub for configuring and setting up the subscription. The scope of this document is to provide recommendations for setting up the subscription's security controls. This Secure Configuration Baseline (SCB) provides specific policies to strengthen GWS tenant security.
+
+The Cybersecurity and Infrastructure Security Agency's (CISA) Secure Cloud Business Applications (SCuBA) project provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies' cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for GWS help secure federal information assets stored within GWS cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government's threats and risk tolerance. Organizations outside of the federal government may also find these baselines to be useful references to help reduce risks even if such organizations have different risk tolerances or face different threats.
+
+For non-federal users, the information in this document is being provided "as is" for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products. CISA has no control over vendor changes to products offerings or features. Accordingly, these SCuBA SCBs for GWS may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+This baseline is based on Google documentation and addresses the following:
+- [Phishing-Resistant Multifactor Authentication](#1-phishing-resistant-multifactor-authentication)
+- [Context Aware Access](#2-context-aware-access)
+- [Login Challenges](#3-login-challenges)
+- [User Session Duration](#4-user-session-duration)
+- [Secure Passwords](#5-secure-passwords)
+- [Privileged Accounts](#6-privileged-accounts)
+- [Conflicting Account Management](#7-conflicting-account-management)
+- [Account Recovery Options](#8-account-recovery-options)
+- [GWS Advanced Protection Program](#9-gws-advanced-protection-program)
+- [App Access to Google APIs](#10-app-access-to-google-apis)
+- [Authorized Marketplace Apps](#11-authorized-google-marketplace-apps)
+- [Google Takeout Service](#12-google-takeout-services-for-users)
+- [System-Defined Rules](#13-system-defined-rules)
+- [Google Workspace Logs](#14-google-workspace-logs)
+- [Data Regions](#15-data-regions-and-storage)
+- [Additional Google Services](#16-additional-google-services)
+- [Multi-Party Approvals](#17-multi-party-approval)
+- [Data Loss Prevention](#18-data-loss-prevention)
+
+## Assumptions
+
+This document assumes the organization is using GWS Enterprise Plus. The GWS Common Controls SCB is somewhat unique among CISA's GWS configuration baselines it does not align to one specific GWS application. Implementers should be aware of this when cross-referencing the baseline statements to the live GWS administrator console. This document serves as an enterprise-level compendium of implementable and testable configuration settings across the entire GWS administrator console. The configurations specified herein correlate to the Security, Account, Directory, Rules, and Marketplace applications sections of the GWS administrator console.
+
+This document does not address, ensure compliance with, or supersede any law, regulation, or other authority.  Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology.  This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+This Common Controls baseline document:
+
+-   Assumes users are familiar with overarching federal cyber guidance and cloud security fundamentals, such as the shared responsibility model;
+-   Accounts for recent direction from Executive Order 14028, the Federal Zero Trust Strategy (published as Office of Management and Budget Memo M-22-09 *Moving the U.S. Government Toward Zero Trust Cybersecurity Principles*), CISA's Zero Trust Maturity Model, and the Federal Cloud Security Technical Reference Architecture;
+-   Observes industry guidance such as the Center for Internet Security's Google Workspace Foundations benchmark and Google official documentation; and
+-   Incorporates input from both the Office of Management and Budget (OMB) and Google product managers/security engineers.
+
+## Key Terminology
+
+The key words "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services) (**BOD 25-01 Requirement**): This indicator means that the policy is required under CISA BOD 25-01.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology) (**Automated Check**): This indicator means that the policy can be automatically checked via ScubaGoggles. See [our documentation](../../README.md) for help getting started.
+
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#break-glass-accounts)(**Configurable**): This indicator means that the policy can be customized via a configuration file.
+
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)(**Log-Based Check**): This indicator means that ScubaGoggles will check the policy by reviewing admin audit logs. See [Limitations](../../docs/usage/Limitations.md#log-based-policy-checks).
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols83v06-instructions)(**Manual**): This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. Phishing-Resistant Multifactor Authentication
+
+Multifactor authentication (MFA), particularly phishing-resistant MFA, is a critical security control against attacks such as password spraying, password theft, and phishing. Adopting phishing-resistant MFA may take time, especially on mobile devices. Organizations must upgrade to a phishing-resistant MFA method as soon as possible to be compliant with OMB M-22-09 and this policy, addressing the critical security threat posed by modern phishing attacks.
+
+This control recognizes federation as a viable option for phishing-resistant MFA. It includes architectural considerations around on-premises and cloud-native identity federation in established federal civilian executive branch (FCEB) environments. Federation for GWS can be implemented via a cloud-native identity provider (IdP). Google's documentation acknowledges that on-premises Microsoft Active Directory implementations may be predominant in environments that adopt GWS. The documentation provides guidance on the use of Google Cloud Directory Sync (GCDS) to synchronize Google Account data with an established Microsoft Active Directory or LDAP server.
+
+The following graphic illustrates the spectrum of MFA options and their relative strength, with phishing resistant MFA (per OMB Memo 22-09) being the mandated method.
+Please note there is a distinction between Google 2-Step Verification (2SV) and MFA as a general term. While FIDO Security Key and Phone as a Security Key are acceptable forms of phishing-resistant MFA which rely on Google 2SV as the underlying mechanism, the other forms listed in the "strongest" column are still acceptable forms of Phishing-Resistant MFA even though they do not use Google 2SV.
+
+<img src="images/MFA.PNG">
+
+### Policies
+
+#### GWS.COMMONCONTROLS.1.1v1
+Phishing-Resistant MFA SHALL be required for all users.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+        > Phishing-resistant methods:
+
+            - FIDO2 Security Key (directly in Google Workspace)
+
+            - Phone as Security Key
+
+            - FIDO2 Security Key (Federated from Identity Provider)
+
+            - Federal Personal Identity Verification (PIV) card (Federated from agency Active Directory or other identity provider).
+
+            - Google Passkeys
+
+- _Rationale:_ Weaker forms of MFA do not protect against sophisticated phishing attacks. Enforcing phishing-resistant MFA methods reduces those risks. Additionally, the Office of Management and Budget (OMB) Memorandum M-22-09, “Moving the U.S. Government Toward Zero Trust Cybersecurity Principles,” requires phishing-resistant MFA for FCEB agency staff, contractors, and partners.
+- _Last modified:_ January 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), IA-2(2), IA-5c, IA-5g, IA-2(8)
+- MITRE ATT&CK TTP Mapping
+  - [T1621: MFA Request Generation](https://attack.mitre.org/techniques/T1621/)
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+  - [T1556: Modifying Authentication Process](https://attack.mitre.org/techniques/T1556/)
+    - [T1556:006: Modifying Authentication Process: Multi-Factor Authentication](https://attack.mitre.org/techniques/T1556/006/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+
+#### GWS.COMMONCONTROLS.1.2v1
+If phishing-resistant MFA has not been enforced, an alternative MFA method SHALL be enforced for all users.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ This is a stopgap security policy to help protect the tenant if phishing-resistant MFA has not been enforced. This policy requires MFA enforcement, thus reducing single-form authentication risk.
+- _Last modified:_ April 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), IA-2(2)
+- MITRE ATT&CK TTP Mapping
+  - [T1621: MFA Request Generation](https://attack.mitre.org/techniques/T1621/)
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+  - [T1556: Modifying Authentication Process](https://attack.mitre.org/techniques/T1556/)
+    - [T1556:006: Modifying Authentication Process: Multi-Factor Authentication](https://attack.mitre.org/techniques/T1556/006/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+
+#### GWS.COMMONCONTROLS.1.3v1
+SMS or Voice SHALL NOT be used as the MFA method.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Weaker forms of MFA, such as SMS or Voice, do not protect against sophisticated phishing attacks. Enforcing methods phishing-resistant reduces those risks. Additionally, OMB M-22-09 requires phishing-resistant MFA for FCEB agency staff, contractors, and partners.
+- _Last modified:_ April 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7b, IA-5c
+- MITRE ATT&CK TTP Mapping
+  - [T1621: MFA Request Generation](https://attack.mitre.org/techniques/T1621/)
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+  - [T1556: Modifying Authentication Process](https://attack.mitre.org/techniques/T1556/)
+    - [T1556:006: Modifying Authentication Process: Multi-Factor Authentication](https://attack.mitre.org/techniques/T1556/006/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+
+#### GWS.COMMONCONTROLS.1.4v1
+The Google 2-Step Verification (2SV) new user enrollment period SHALL be set to at least one day and at most one week.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Enrollment must be enforced within a reasonable timeframe. One week balances the need for allowing new personnel time to set up their authentication methods while minimizing the risks inherent to not enforcing MFA immediately.
+- _Last modified:_ April 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), IA-2(2)
+- MITRE ATT&CK TTP Mapping
+  - [T1621: MFA Request Generation](https://attack.mitre.org/techniques/T1621/)
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+  - [T1556: Modifying Authentication Process](https://attack.mitre.org/techniques/T1556/)
+    - [T1556:006: Modifying Authentication Process: Multi-Factor Authentication](https://attack.mitre.org/techniques/T1556/006/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+
+#### GWS.COMMONCONTROLS.1.5v1
+Allow users to trust the device SHALL be disabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Trusting the device allows users to bypass 2-Step Verification (2SV) for future logins on that device. Disabling this option makes it possible for multifactor authentication (MFA) to protect future logins on the device.
+- _Last modified:_ February 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), IA-2(2)
+- MITRE ATT&CK TTP Mapping
+  - [T1621: MFA Request Generation](https://attack.mitre.org/techniques/T1621/)
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+  - [T1556: Modifying Authentication Process](https://attack.mitre.org/techniques/T1556/)
+    - [T1556:006: Modifying Authentication Process: Multi-Factor Authentication](https://attack.mitre.org/techniques/T1556/006/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+
+### Resources
+
+-  [GWS Admin Help \| Set up 2-Step Verification (Deploy)](https://support.google.com/a/answer/9176657?hl=en&ref_topic=2759193&fl=1#zippy=%2Cchoose-a--step-verification-method-to-enforce%2Cturn-on-enforcement)
+-   [GWS Admin Help \| Set up 2-Step Verification (Protect your business)](https://support.google.com/a/answer/175197#zippy=%2Csecurity-keys%2Cconsider-using-security-keys-in-your-business)
+-   [Google Workspace Updates \| Simplify and Strengthen Sign-In by Enabling Passkeys for Your Users](https://workspaceupdates.googleblog.com/2023/06/passkey-open-beta.html)
+-   [Google Security Blog \| So Long Passwords, Thanks for all the Phish](https://security.googleblog.com/2023/05/so-long-passwords-thanks-for-all-phish.html)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+-   [Office of Management and Budget (OMB) Memorandum M-22-09](https://bidenwhitehouse.archives.gov/wp-content/uploads/2022/01/M-22-09.pdf)
+
+### Prerequisites
+
+-   GWS.COMMONCONTROLS.1.1v1 may require FIDO2-compliant security keys
+
+### Implementation
+
+#### Policy 1 Common Instructions
+1.  Sign in to [Google Admin console](https://admin.google.com/) as an administrator.
+2.  Select **Security** -\> **Authentication**.
+3.  Select **2-Step Verification**.
+
+#### GWS.COMMONCONTROLS.1.1v1 Instructions
+1.  Under **Authentication**, ensure that **Allow users to turn on 2-Step Verification** is checked.
+2.  Set **Enforcement** to **On.**
+3.  Under **Methods** select **Only security key.**
+4.  Under **Security codes** select **Don't allow users to select security codes.**
+5.  Select **Save**.
+
+#### GWS.COMMONCONTROLS.1.2v1 Instructions
+1.  Under **Authentication**, ensure that **Allow users to turn on 2-Step Verification** is checked.
+2.  Set **Enforcement** to **On**.
+
+#### GWS.COMMONCONTROLS.1.3v1 Instructions
+1.  Under **Methods**, select **Any except verification codes via text, phone call**.
+2.  Select **Save**.
+
+#### GWS.COMMONCONTROLS.1.4v1 Instructions
+1.  Set **New user enrollment** period to at least **1 Day** or at most **1 Week**.
+2.  Select **Save**.
+
+#### GWS.COMMONCONTROLS.1.5v1 Instructions
+1.  Under Frequency, deselect the **Allow user to trust device** checkbox.
+2.  Select **Save**.
+
+## 2. Context-aware Access
+
+Device-based context-aware access provides access control policies based on device disposition attributes such as compliance with organizational secure configuration policies for devices (e.g., managed by Unified Endpoint Management). GWS also provides context-aware access policies based on authentication and network information. These can be used to implement more targeted access policies. For advanced use cases, custom context-aware access rules can be authored using the Common Expressions Language (CEL).
+
+Device-based context-aware access can be used in several ways depending on agency business requirements. The following options are all acceptable approaches:
+
+-   Properties of the device as reported by Google (encryption, screen lock, OS version, etc.)
+-   Device inventory status (corporate-issued versus bring your own device)
+-   Use of managed Chrome browser
+-   Data based on integration with certain third-party device management tools
+
+It is extremely important to understand how context-aware access policies affect one another. For example:
+
+-   At a given scope (e.g., Organizational Unit [OU] or Group), each context aware access rule is evaluated separately. If any rule grants access, then access is allowed to the given application.
+-   If rules are applied to OUs and Groups, which allow an action that may be denied after evaluating a policy at a higher level, then access will be allowed.
+
+To enforce a device policy that requires company-owned devices, Google requires a list of serial numbers for company-owned devices.
+
+### Policies
+
+#### GWS.COMMONCONTROLS.2.1v1
+Policies restricting access to Google Workspace (GWS) based on enterprise device signals SHOULD be implemented.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)
+
+- _Rationale:_ Granular device access control afforded by context-aware access aligns with federal zero trust strategy and principles. Context-aware access can help to increase the security of GWS data by allowing organizations to restrict access to certain applications or services based on user/device attributes.
+- _Last modified:_ July 2023
+- _Note:_ Agencies may use controls with greater granularity if needed.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-3
+- MITRE ATT&CK TTP Mapping
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098:005: Account Manipulation: Device Registration](https://attack.mitre.org/techniques/T1098/005/)
+
+### Resources
+
+-   [GWS Admin Help \| Context-Aware Access overview](https://support.google.com/a/answer/9275380)
+-   [GWS Admin Help \| Context-Aware Access examples for Basic mode](https://support.google.com/a/answer/9587667)
+-   [GWS Admin Help \| Context-Aware Access examples for Advanced mode](https://support.google.com/a/answer/11368990)
+-   [GWS Admin Help \| Device management security checklist](https://support.google.com/a/answer/7422256)
+-   [GWS Admin Help \| Set up guide: Deploy company-owned devices in Google endpoint management](https://support.google.com/a/answer/10287358)
+-   [GWS Admin Help \| Turn endpoint verification on or off](https://support.google.com/a/answer/9007320)
+-   [GWS Admin Help \| Set up guide: Deploy company-owned devices in Google endpoint management—Steps 1 and 2](https://support.google.com/a/answer/10287358#zippy=%2Cstep-sign-up-for-enterprise-management-services%2Cstep-source-devices)
+-   [GitHub \| Google \| Google Common Expressions Language (CEL)](https://github.com/google/cel-spec)
+-   [Google Cloud Access Context Manager \| Macros for CEL expressions](https://cloud.google.com/access-context-manager/docs/custom-access-level-spec#macros_for_cel_expressions)
+-   [Google Cloud Access Context Manager \| Custom access level specification](https://cloud.google.com/access-context-manager/docs/custom-access-level-spec)
+-   [GWS Blog \| Enable advanced context-aware access to Google Workspace in the Admin console](https://workspaceupdates.googleblog.com/2021/11/enable-advanced-context-aware-access-to.html)
+-  [GWS Admin Help \| Google Workspace Device management security checklist](https://support.google.com/a/answer/7422256)
+-   [GWS Admin Help \| Deploy Context-Aware Access](https://support.google.com/a/answer/12643733)
+
+### Prerequisites
+
+-   One or more of the following user roles should have been configured to set context-aware policies:
+
+        > Super admin
+
+        > Delegated administrator with each of these privileges:
+
+                - Data Security -\> Access level management
+
+                - Data Security -\> Rule management
+
+                - Administrator API Privileges -\> Groups\>Read
+
+                - Administrator API Privileges -\> Users\>Read
+
+-   Serial numbers may be required to enforce a policy for company-owned devices. Refer to [Google documentation](https://support.google.com/a/answer/10287358) on device management for additional guidance.
+
+### Implementation
+
+#### GWS.COMMONCONTROLS.2.1v1 Instructions
+To turn on Context-Aware Access:
+
+1.  Access the [Google Admin console](https://admin.google.com/).
+2.  From the menu, go to **Security** -\> **Access and data control** -\> **Context-Aware Access**.
+3.  Verify **Context-Aware Access** is **ON for everyone**. If not, click **Turn On**.
+4.  Select **Access Level** and then **Create Access Level**. Then determine the rule conditions per agency needs.
+5.  Select **Assign access levels to applications**, then select the applications to which the rule should apply.
+
+Note that the implementation details of context-aware access use cases will vary per agency. Refer to [Google's documentation](https://support.google.com/a/answer/12643733) on implementing context-aware access for your specific use cases. Common use cases include:
+-   Require company-owned access on desktop but not on mobile device
+-   Require basic device security
+-   Allow access to contractors only through the corporate network
+-   Block access from known hijacker IP addresses
+-   Allow or disallow access from specific locations
+-   Use nested access levels instead of selecting multiple access levels during assignment
+
+## 3. Login Challenges
+Login challenges are additional security measures used to verify a user's identity, including post-single sign-on (Post-SSO) verification.
+
+Post-SSO verification controls what additional checks are performed (e.g., Google 2SV) after a user successfully authenticates through a third-party identity provider.
+SSO is managed through profiles, which can be assigned organization-wide or to specific organization units/groups.
+Google Workspace handles post-SSO verification for profiles assigned organization-wide as a separate case, allowing users more control over when post-SSO verification requirements apply.
+
+### Policies
+
+#### GWS.COMMONCONTROLS.3.1v1
+Post-single sign-on (SSO) verification SHOULD be enabled for users signing in using the organization's SSO profile.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)
+
+- _Rationale:_ Without enabling post-SSO verification, Google 2-Step Verification (2SV) configurations are not enforced for third-party SSO users. Enabling post-SSO verification ensures the application of 2SV verification policies.
+- _Last modified:_ January 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), IA-2(2)
+- MITRE ATT&CK TTP Mapping
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+
+#### GWS.COMMONCONTROLS.3.2v1
+Post-SSO verification SHOULD be enabled for users signing in using other SSO profiles.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)
+
+- _Rationale:_ Without enabling post-SSO verification, any Google 2-Step Verification (2SV) configuration is ignored for third-party SSO users. Enabling post-SSO verification will apply 2SV verification policies.
+- _Last modified:_ November 2024
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), IA-2(2)
+- MITRE ATT&CK TTP Mapping
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+
+### Resources
+
+-   [GWS Admin Help \| Protect Google Workspace accounts with security challenges](https://support.google.com/a/answer/6002699)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### Policy Group 3 Common Instructions
+1.  Sign in to [Google Admin console](https://admin.google.com) as an administrator.
+2.  Select **Security**-\>**Authentication**-\>**Login challenges**.
+3.  Under **Organizational units**, ensure that the name for the entire organization is selected.
+4.  Click **Post-SSO verification**.
+
+#### GWS.COMMONCONTROLS.3.1v1 Instructions
+1. For **Settings for users signing in using the SSO profile for your organization**, select **Ask users for additional verifications from Google if a sign-in looks suspicious, and always apply 2-Step Verification policies (if configured)**.
+2. Click **SAVE**.
+
+#### GWS.COMMONCONTROLS.3.2v1 Instructions
+1. For **Settings for users signing in using other SSO profiles**, select **Ask users for additional verifications from Google if a sign-in looks suspicious, and always apply 2-Step Verification policies (if configured)**.
+2. Click **SAVE**.
+
+## 4. User Session Duration
+
+This control allows configuration for time limits on active GWS sessions before users are prompted for authentication credentials.
+
+Note: If using a third-party identity provider (IdP) and agency-set web session lengths for its users, the IdP session length parameter needs to be set to expire before the Google session expires in order to ensure users are forced to sign in again. See [GWS documentation](https://support.google.com/a/answer/7576830) for additional details.
+
+### Policies
+
+#### GWS.COMMONCONTROLS.4.1v1
+Users SHALL be forced to re-authenticate after an established 12-hour GWS login session has expired.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Allowing sessions to persist indefinitely enables users to bypass 2-Step Verification (2SV) for future activity on that device. Limiting sessions to 12 hours may reduce the possibility of session hijacking attacks and prevent users from inadvertently remaining logged in on unattended devices.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-11
+- MITRE ATT&CK TTP Mapping
+  - [T1550: Use Alternate Authentication Material](https://attack.mitre.org/techniques/T1550/)
+    - [T1550:004: Use Alternate Authentication Material: Web Session Cookie](https://attack.mitre.org/techniques/T1550/004/)
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078:004: Valid Accounts: Cloud Accounts](https://attack.mitre.org/techniques/T1078/004/)
+
+### Resources
+
+-   [GWS Admin Help \| Set session length for Google services](https://support.google.com/a/answer/7576830?hl=en)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.COMMONCONTROLS.4.1v1 Instructions
+To configure Google session control:
+
+1.  Sign in to the [Google Admin console](https://admin.google.com) as an administrator.
+2.  Select **Security.**
+3.  Select **Access and data control** -\> **Google session control.**
+4.  Look for the **Web session duration** heading.
+5.  Set the duration to **12 hours.**
+
+## 5. Secure Passwords
+
+Per NIST 800-63 and OMB M-22-09, ensure that user passwords do not expire and that long passwords are chosen. Research indicates that frequent password rotation breeds poor password choice and encourages password reuse. Ensure that passwords are strong to defend against brute-force attacks. Ensure that passwords are not reused to defend against credential theft.
+
+### Policies
+
+#### GWS.COMMONCONTROLS.5.1v1
+User password strength SHALL be enforced.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Weak passwords increase the risk of account compromise. Enforcing password strength adds an additional layer of defense, reducing the risk of account compromise. Strong password policies protect an organization by discouraging the use of weak passwords.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-5(1)
+- MITRE ATT&CK TTP Mapping
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+
+#### GWS.COMMONCONTROLS.5.2v1
+User password length SHALL be at least 12 characters.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ The National Institute of Standards and Technology (NIST) published guidance indicating that password length is a primary factor in characterizing password strength (NIST SP 800-63B). Longer passwords tend to be more resistant to brute force and dictionary-based attacks.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-5(1)
+- MITRE ATT&CK TTP Mapping
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+
+#### GWS.COMMONCONTROLS.5.3v1
+User password length SHOULD be at least 16 characters.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ The National Institute of Standards and Technology (NIST) published guidance indicating that password length is a primary factor in characterizing password strength (NIST SP 800-63B). Longer passwords tend to be more resistant to brute force and dictionary-based attacks.
+- _Last modified:_ January 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-5(1)
+- MITRE ATT&CK TTP Mapping
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+
+#### GWS.COMMONCONTROLS.5.4v1
+Password policy SHALL be enforced at next sign-in.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ If the password policy is not enforced at next login, a user could potentially operate indefinitely using a weak password. Enforcing the policy at next login helps ensure that all active user passwords meet current requirements.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-5(1)
+- MITRE ATT&CK TTP Mapping
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+
+#### GWS.COMMONCONTROLS.5.5v1
+User passwords SHALL NOT be reused.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Password reuse represents a significant security risk. When possible, preventing password reuse limits the scope of a compromised password.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-5(1)
+- MITRE ATT&CK TTP Mapping
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+
+#### GWS.COMMONCONTROLS.5.6v1
+User passwords SHALL NOT expire.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ The National Institute of Standards and Technology (NIST), OMB, and Microsoft have published guidance indicating mandated periodic password changes make user accounts less secure. For example, OMB M-22-09 states, "Password policies must not require use of special characters or regular rotation."
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-5(1)
+- MITRE ATT&CK TTP Mapping
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+
+### Resources
+
+-   [GWS Admin Help \| Enforce and monitor password requirements for users](https://support.google.com/a/answer/139399?hl=en#zippy=%2Cwhat-makes-a-password-strong)
+-   [Create a strong password & a more secure account](https://support.google.com/accounts/answer/9094506?fl=1&sjid=14948418137648107240-NA)
+-   [CISA Cross-Sector Cybersecurity Performance Goals](https://www.cisa.gov/cross-sector-cybersecurity-performance-goals#MinimumPasswordStrength2B)
+-   [Office of Management and Budget (OMB) Memorandum M-22-09](https://bidenwhitehouse.archives.gov/wp-content/uploads/2022/01/M-22-09.pdf)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To configure a strong password policy, use the Google Workspace admin console:
+
+#### Policy Group 5 common Instructions
+1.  Sign in to the [Google Admin console](https://admin.google.com) as an administrator.
+2.  Select **Security** -\> **Authentication.**
+3.  Locate **Password management.**
+4. Follow implementation for each individual policy.
+5. Select **Save**.
+
+#### GWS.COMMONCONTROLS.5.1v1 Instructions
+1.  Under **Strength**, select the **Enforce strong password** checkbox.
+
+#### GWS.COMMONCONTROLS.5.2v1 Instructions
+1.  Under **Length**, set **Minimum Length** to 12+.
+
+#### GWS.COMMONCONTROLS.5.3v1 Instructions
+1.  Under **Length**, set **Minimum Length** to 16+.
+
+#### GWS.COMMONCONTROLS.5.4v1 Instructions
+1.  Under **Strength and Length enforcement**, select the **Enforce password policy at next sign-in** checkbox.
+
+#### GWS.COMMONCONTROLS.5.5v1 Instructions
+1.  Under **Reuse**, uncheck the **Allow password reuse** checkbox.
+
+#### GWS.COMMONCONTROLS.5.6v1 Instructions
+1.  Under **Expiration**, select **Never Expires.**
+
+## 6. Privileged Accounts
+
+Administrative, or "admin," accounts are privileged accounts in GWS that can manage settings, access sensitive data, and perform critical functions. The compromise of an administrative account could have catastrophic impacts on the organization. This section defines privileged accounts as both pre-built and custom administrative accounts.
+
+Examples of these privileged accounts include the following pre-built GWS administrative roles:
+
+-   Super admin: This role possesses critical control over the entire GWS structure. It has access to all features in the Admin Console and Admin API. This role can manage every aspect of an organization's GWS accounts.
+-   User management admin: This account has rights to add, remove, and delete normal users, in addition to managing all user passwords, security settings, and other management tasks. A compromise of this role can be potentially critical.
+-   Services admin: This role has full rights to turn on/off GWS services and security settings for these services (Gmail, Drive, Voice, etc.). Given that most GWS features rely on these services being secure, compromise of this account type would be critical.
+-   Mobile admin: This role has full rights to manage all of an agency's mobile devices, including device use authorization and control of application downloads. This role can also set the security policies on all organization mobile devices connected to GWS.
+-   Groups admin: This role has full rights to view profiles in the organizational and Organizational Unit (OU) structures and can manage all rights for Groups members.
+
+### Policies
+
+#### GWS.COMMONCONTROLS.6.1v1
+All administrative accounts SHALL be provisioned as cloud-only accounts separate from an agency's authoritative on-premises or other federated identity providers.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Cloud-only accounts leveraging Google Account authentication with phishing resistant MFA for highly privileged accounts reduces the risks associated with a compromise of on-premises federation infrastructure. Enforcing this policy makes it more challenging for a threat actor to pivot from a compromised on-premises environment to the cloud with privileged access.
+- _Last modified:_ November 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(5)
+- MITRE ATT&CK TTP Mapping
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+  - [T1556: Modifying Authentication Process](https://attack.mitre.org/techniques/T1556/)
+    - [T1556:006: Modifying Authentication Process: Multi-Factor Authentication](https://attack.mitre.org/techniques/T1556/006/)
+
+#### GWS.COMMONCONTROLS.6.2v1
+A minimum of **two** and a maximum of **eight** separate and distinct super admin users SHALL be configured.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#break-glass-accounts)
+
+- _Rationale:_ The super admin role provides unfettered access to Google Workspace. Properly managing the number of users with this access level reduces the risk of a GWS compromise. Having too few super admin accounts can increase the risk of losing admin access entirely (e.g., if a super admin forgets their password). Maintaining between two to eight super admin accounts helps mitigate accessibility and security concerns.
+- _Last modified:_ July 2023
+- _Note:_ The total number of super admin accounts does not include "break-glass" super admin accounts.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(5)
+- MITRE ATT&CK TTP Mapping
+  - [T1136: Create Account](https://attack.mitre.org/techniques/T1136/)
+    - [T1136:003: Create Account: Cloud Account](https://attack.mitre.org/techniques/T1136/003/)
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098:003: Account Manipulation: Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003/)
+
+### Resources
+
+-   [Google Cloud Architecture Center \| Best practices for planning accounts and organizations](https://cloud.google.com/architecture/identity/best-practices-for-planning)
+-   [GWS Admin Help \| Create, edit, and delete custom admin roles](https://support.google.com/a/answer/2406043)
+-   [GWA Admin Help \| Assign Specific Admin Roles](https://support.google.com/a/answer/9807615?hl=en)
+-   [GWA Admin Help \| Pre-Built Admin Roles](https://support.google.com/a/answer/2405986?hl=en)
+
+### Prerequisites
+
+-   Super admin users cannot log in to admin.google.com with a third-party identity provider (IdP) when using super admin level accounts. These users must use Google Login as the authentication mechanism. This policy also extends this rule to other admin types.
+-   Delegated accounts, including those defined as highly privileged, can use a third-party IdP by default to access admin.google.com. However, this policy prohibits that practice. All highly privileged accounts must use phishing-resistant Google Authentication.
+
+### Implementation
+
+#### GWS.COMMONCONTROLS.6.1v1 Instructions
+1.  Determine how to track highly privileged accounts. For example, create an OU or a group containing all highly privileged accounts.
+2.  Follow the instructions in the [Set up SSO for your organization](https://support.google.com/a/answer/12032922?hl=en) guide, under "Decide which users should use SSO." For all OUs or groups with highly privileged users, set the **SSO profile assignment** to **None**.
+
+#### GWS.COMMONCONTROLS.6.2v1 Instructions
+To obtain a list of all GWS Super Admins:
+
+1.  Sign in to the [Google Admin console](https://admin.google.com) as an administrator.
+2.  Navigate to **Account** -\> **Admin Roles**.
+3.  Click the **Super Admin** role in the list of roles
+4.  The subsequent dialog provides a list of Super Admins.
+
+## 7. Conflicting Account Management
+
+It is possible for employees of an organization to create conflicting accounts that are unmanaged by an enterprise's Google Workspace tenant. Unmanaged accounts are defined as users who independently create a Google account using the organization's domain. For example, a user with an enterprise/corporate email of user@company.com could create a personal, unmanaged Google account using that email address. This would create an account conflict in a GWS tenant licensed to company.com since email addresses are unique.
+
+A conflicting account can also be created unintentionally. After signing up for Google Cloud Identity or Google Workspace, administrators might decide to set up single sign-on with an external identity provider (IdP) such as Azure Active Directory (AAD) or Active Directory. When configured, the external IdP might automatically create accounts in Cloud Identity or Google Workspace for all users for which single sign-on was enabled, inadvertently creating conflicting accounts.
+
+Unmanaged accounts carry significant risk, as they cannot be managed by administrators. This gap renders the accounts outside the scope of protection administrators can apply to ensure data security. Significantly, two-step verification (2SV) cannot be enforced. Even if access is revoked, these accounts can carry a social engineering risk. Further, reconciling conflicting accounts creates additional workload for administrators and adds to the workload of onboarding users to Google Workspace & Google Cloud.
+
+The GWS administrator console provides several options for handling conflicting, unmanaged accounts:
+  - Automatically invite users to transfer unmanaged accounts.
+  - Replace unmanaged accounts with managed accounts.
+  - Don't create new accounts if unmanaged accounts exist.
+
+This policy requires replacing unmanaged accounts with managed accounts. When this option is configured, data owned by the account will not be imported. The user will receive a temporary account address, which they'll need to manually replace with a @gmail.com address of their choice. The user will receive an email notification with their temporary account address and notification that the original email can no longer be used.
+
+By changing the email address to a managed account, the user resolves the conflict by ensuring that the managed account and consumer account have different identities. The result remains that they have one consumer account with all of their original data, and one managed account without access to the original data.
+
+### Policies
+
+#### GWS.COMMONCONTROLS.7.1v1
+Account conflict management SHOULD be configured to replace conflicting unmanaged accounts with managed accounts.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols71v06-instructions)
+
+- _Rationale:_ Unmanaged user accounts cannot be controlled or monitored by GWS administrators. By resolving conflicting accounts, organizations can ensure all users have managed user accounts.
+- _Last modified:_ April 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2
+- MITRE ATT&CK TTP Mapping
+  - [T1136: Create Account](https://attack.mitre.org/techniques/T1136/)
+    - [T1136:003: Create Account: Cloud Account](https://attack.mitre.org/techniques/T1136/003/)
+  - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T1098:003: Account Manipulation: Additional Cloud Roles](https://attack.mitre.org/techniques/T1098/003/)
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+
+### Resources
+
+-   [GWS Admin Help | Use the transfer tool to migrate unmanaged users](https://support.google.com/a/answer/6178640)
+-   [GWS Admin Help | Find and add unmanaged users](https://support.google.com/a/answer/11112794)
+-   [Google Workspace Updates Blog | Resolve conflict accounts faster with the new Conflict Accounts Management tool](https://workspaceupdates.googleblog.com/2023/08/conflict-accounts-management-tool.html)
+-   [Google Cloud Architecture Center | Migrating consumer accounts](https://cloud.google.com/architecture/identity/migrating-consumer-accounts#using_a_conflicting_account)
+-   [Google Cloud Architecture Center | Best practices for planning accounts and organizations](https://cloud.google.com/architecture/identity/best-practices-for-planning)
+-   [How a conflicting account is created](https://support.google.com/accounts/answer/181526)
+
+### Prerequisites
+
+-   Super Admin privileges
+
+### Implementation
+#### GWS.COMMONCONTROLS.7.1v1 Instructions
+
+To configure account conflict management per the policy:
+1.	Sign in to the [Google Admin console](https://admin.google.com) as an administrator.
+2.	Navigate to **Account** -\> **Account settings.**
+3.	Click the **Conflicting accounts management** section.
+4.	Select the radio button option reading **"Replace conflicting unmanaged accounts with managed ones."**
+5.	Click **Save.**
+
+## 8. Account Recovery Options
+
+This section addresses the GWS account self-recovery feature. When enabled, this feature allows users to add a recovery email or phone number. This allows users to reset their own accounts if needed, without requiring GWS administrator support.
+
+### Policies
+
+#### GWS.COMMONCONTROLS.8.1v1
+Account self-recovery for super admins SHALL be disabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ If enabled, a threat actor could attempt to access a super admin account through the account recovery method. Disabling this feature forces super admins to contact another super admin in order to recover their account, making it more difficult for a potential threat actor to compromise the account.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-5d, IA-5g
+- MITRE ATT&CK TTP Mapping
+  - [T1556: Modifying Authentication Process](https://attack.mitre.org/techniques/T1556/)
+    - [T1556:006: Modifying Authentication Process: Multi-Factor Authentication](https://attack.mitre.org/techniques/T1556/006/)
+
+#### GWS.COMMONCONTROLS.8.2v1
+Account self-recovery for users and non-super admins SHALL be disabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ If enabled, a user could add a personal email or phone number for account recovery. Disabling this feature requires account recovery to go through official channels, making it more difficult for a potential threat actor to compromise an account.
+- _Last modified:_ February 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-5d, IA-5g
+- MITRE ATT&CK TTP Mapping
+  - [T1556: Modifying Authentication Process](https://attack.mitre.org/techniques/T1556/)
+    - [T1556:006: Modifying Authentication Process: Multi-Factor Authentication](https://attack.mitre.org/techniques/T1556/006/)
+
+#### GWS.COMMONCONTROLS.8.3v1
+Ability to add recovery information SHOULD be disabled.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols83v06-instructions)
+
+- _Rationale:_ If enabled, a user could add a personal email or phone number for account recovery. Disabling this feature prevents a user from adding personally identifiable information (PII) to their organizational account and makes it more difficult for a potential threat actor to steal PII in the event of a compromise.
+- _Last modified:_ August 2025
+- _Note:_ This setting is not applicable if using single sign-on (SSO) with a third-party identity provider or password sync. GWS.COMMONCONTROLS.8.3 acts as a defense in-depth policy when GWS.COMMONCONTROLS.8.1 and GWS.COMMONCONTROLS.8.2 are not enabled.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+### Resources
+
+-   [GWS Admin Help \| Allow super administrators to recover their password](https://support.google.com/a/answer/9436964?fl=1)
+-   [GWS Admin Help \| Recover an account protected by 2-Step Verification](https://support.google.com/a/answer/9176734?hl=en)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.COMMONCONTROLS.8.1v1 Instructions
+To disable Super Admin account self-recovery:
+
+1.  Sign in to https://admin.google.com as an administrator.
+2.  Select **Security** -\> **Authentication**.
+3.  Select **Account Recovery**.
+4.  Click **Super admin account recovery**.
+5.  Deselect the **Allow Super Admins to recover their account** checkbox.
+6.  Click **Save**.
+
+#### GWS.COMMONCONTROLS.8.2v1 Instructions
+1.  Sign in to https://admin.google.com as an administrator.
+2.  Select **Security** -\> **Authentication**.
+3.  Select **Account Recovery**.
+4.  Click **User account recovery**.
+5.  Deselect the **Allow users and all non-super admins to recover their account** checkbox.
+6.  Click **Save**.
+
+#### GWS.COMMONCONTROLS.8.3v1 Instructions
+1.  Sign in to https://admin.google.com as an administrator.
+2.  Select **Security** -\> **Authentication**.
+3.  Select **Account Recovery**.
+4.  Click **Recovery Information**.
+5.  Deselect the **Allow admins and users to add recovery email information to their account** checkbox.
+6.  Deselect the **Allow admins and users to add recovery phone information to their account** checkbox.
+7.  Click **Save**.
+
+## 9. GWS Advanced Protection Program
+
+This control enforces increased secure protections for highly privileged, senior executive and sensitive users accounts from targeted attacks. It enforces optional GWS user security features including:
+
+-   Strong authentication with security keys
+-   Use of security codes with security keys
+-   Restrictions on third-party access to account data
+-   Deep Gmail scans
+-   Google Safe Browsing protections in Chrome
+-   Account recovery through administrator
+
+### Policies
+
+#### GWS.COMMONCONTROLS.9.1v1
+Highly privileged accounts SHALL be enrolled in the Google Workspace (GWS) Advanced Protection Program.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#policy-group-9-instructions)
+
+- _Rationale:_ Sophisticated phishing tactics can trick even savvy users into giving their sign-in credentials to attackers. The Advanced Protection Program requires users to use a security key – a hardware device or special software on mobile devices used to verify identity – to sign in to a Google Account. Unauthorized users will not be able to sign in without the user's security key, even if they have the user's username and password. The Advanced Protection Program includes a curated group of high-security policies that are applied to enrolled accounts. Additional policies may be added to the Advanced Protection Program to ensure protections are current.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), IA-2(2), IA-5c, IA-5d, IA-5g, SI-3, SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+  - [T1556: Modifying Authentication Process](https://attack.mitre.org/techniques/T1556/)
+    - [T1556:006: Modifying Authentication Process: Multi-Factor Authentication](https://attack.mitre.org/techniques/T1556/006/)
+
+#### GWS.COMMONCONTROLS.9.2v1
+All sensitive user accounts SHOULD be enrolled into the GWS Advanced Protection Program.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#policy-group-9-instructions)
+
+- _Rationale:_ Sophisticated phishing tactics can trick even savvy users into giving their sign-in credentials to attackers. The Advanced Protection Program requires users to use a security key – a hardware device or special software on mobile devices used to verify identity – to sign in to a Google Account. Unauthorized users will not be able to sign in without the user's security key, even if they have the user's username and password. The Advanced Protection Program includes a curated group of high-security policies that are applied to enrolled accounts. Additional policies may be added to the Advanced Protection Program to ensure protections are current.
+- _Last modified:_ July 2023
+- _Note:_ This control enforces more secure protection of sensitive user accounts from targeted attacks. Sensitive user accounts include political appointees, Senior Executive Service (SES) officials, or other senior officials whose account compromise would pose a level of risk prohibitive to agency mission fulfillment
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), IA-2(2), IA-5c, IA-5d, IA-5g, SI-3, SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+  - [T1556: Modifying Authentication Process](https://attack.mitre.org/techniques/T1556/)
+    - [T1556:006: Modifying Authentication Process: Multi-Factor Authentication](https://attack.mitre.org/techniques/T1556/006/)
+
+### Resources
+
+-   [GWS Admin Help \| Protect users with the Advanced Protection Program](https://support.google.com/a/answer/9378686)
+-   [GWS Admin Help \| Advanced Protection Program FAQ](https://support.google.com/a/answer/9503534?hl=en)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   Two security keys are required for added assurance. If one key is lost or damaged, users can use the second key to regain account access.
+
+### Implementation
+
+#### Policy Group 9 Instructions
+To allow all users to enroll:
+
+1.  Sign in to the [Google Admin console](https://admin.google.com) as an administrator.
+2.  Select **Security -**\> **Authentication** -\> **Advanced Protection Program.**
+3.  On the right, locate the **Advanced Protection** header.
+4.  Locate the **Allow users to enroll in the Advanced Protection Program** header.
+5.  Select **Enable user enrollment.**
+6.  Click **SAVE.**
+
+## 10. App Access to Google APIs
+
+Agencies need a process in place to manage and control application access to GWS data. This control enables agencies to restrict applications' access to Google Workspace APIs. The control is intended to mitigate the significant cybersecurity risk posed by the potential compromise of OAuth tokens. The baseline policy statements are written to allow implementers to balance operational needs with risk posed by granting application access.
+
+### Policies
+
+#### GWS.COMMONCONTROLS.10.1v1
+Agencies SHALL use GWS application access control policies to restrict access to all GWS services by third-party applications.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Third-party applications may include malicious content. Restricting application access to only trusted applications reduces the risk of malicious applications connecting to GWS.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3
+- MITRE ATT&CK TTP Mapping
+  - [T1550: Use Alternate Authentication Materials](https://attack.mitre.org/techniques/T1550/)
+    - [T1550:001: Use Alternate Authentication Materials: Application Access Token](https://attack.mitre.org/techniques/T1550/001/)
+  - [T1195: Supply Chain Compromise](https://attack.mitre.org/techniques/T1195/)
+    - [T1195:002: Supply Chain Compromise: Compromise Software Supply Chain](https://attack.mitre.org/techniques/T1195/002/)
+  - [T1059: Command and Scripting Interpreter](https://attack.mitre.org/techniques/T1059/)
+    - [T1059:009: Command and Scripting Interpreter: Cloud API](https://attack.mitre.org/techniques/T1059/009/)
+
+#### GWS.COMMONCONTROLS.10.2v1
+Agencies SHALL NOT allow users to grant consent for access to low-risk scopes.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Allowing users to grant access to OAuth scopes not classified as high-risk could enable untrusted applications to gain access without non-administrative approval being allowlisted, violating policy 10.1.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6
+- MITRE ATT&CK TTP Mapping
+  - [T1550: Use Alternate Authentication Materials](https://attack.mitre.org/techniques/T1550/)
+    - [T1550:001: Use Alternate Authentication Materials: Application Access Token](https://attack.mitre.org/techniques/T1550/001/)
+  - [T1195: Supply Chain Compromise](https://attack.mitre.org/techniques/T1195/)
+    - [T1195:002: Supply Chain Compromise: Compromise Software Supply Chain](https://attack.mitre.org/techniques/T1195/002/)
+  - [T1059: Command and Scripting Interpreter](https://attack.mitre.org/techniques/T1059/)
+    - [T1059:009: Command and Scripting Interpreter: Cloud API](https://attack.mitre.org/techniques/T1059/009/)
+
+#### GWS.COMMONCONTROLS.10.3v1
+Agencies SHALL NOT trust unconfigured internal applications.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Internal applications may contain vulnerabilities or malicious content created by compromised user accounts. Restricting access to these applications reduces the risk of unsafe applications connecting to GWS.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3
+- MITRE ATT&CK TTP Mapping
+  - [T1550: Use Alternate Authentication Materials](https://attack.mitre.org/techniques/T1550/)
+    - [T1550:001: Use Alternate Authentication Materials: Application Access Token](https://attack.mitre.org/techniques/T1550/001/)
+  - [T1195: Supply Chain Compromise](https://attack.mitre.org/techniques/T1195/)
+    - [T1195:002: Supply Chain Compromise: Compromise Software Supply Chain](https://attack.mitre.org/techniques/T1195/002/)
+  - [T1059: Command and Scripting Interpreter](https://attack.mitre.org/techniques/T1059/)
+    - [T1059:009: Command and Scripting Interpreter: Cloud API](https://attack.mitre.org/techniques/T1059/009/)
+
+#### GWS.COMMONCONTROLS.10.4v1
+Agencies SHALL NOT allow users to access unconfigured third-party applications.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ External applications may contain vulnerabilities and malicious content. Restricting access to these applications reduces the risk of unsafe applications connecting to GWS.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3
+- MITRE ATT&CK TTP Mapping
+  - [T1550: Use Alternate Authentication Materials](https://attack.mitre.org/techniques/T1550/)
+    - [T1550:001: Use Alternate Authentication Materials: Application Access Token](https://attack.mitre.org/techniques/T1550/001/)
+  - [T1195: Supply Chain Compromise](https://attack.mitre.org/techniques/T1195/)
+    - [T1195:002: Supply Chain Compromise: Compromise Software Supply Chain](https://attack.mitre.org/techniques/T1195/002/)
+  - [T1059: Command and Scripting Interpreter](https://attack.mitre.org/techniques/T1059/)
+    - [T1059:009: Command and Scripting Interpreter: Cloud API](https://attack.mitre.org/techniques/T1059/009/)
+
+#### GWS.COMMONCONTROLS.10.5v1
+Access to GWS applications by less secure applications that do not meet security authentication standards SHALL be prevented.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Antiquated authentication methods introduce additional risk into the GWS environment. Allowing only applications using modern authentication standards helps reduce the risk of credential compromise.
+- _Last modified:_ January 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2(1), IA-2(2)
+- MITRE ATT&CK TTP Mapping
+  - [T1110: Brute Force](https://attack.mitre.org/techniques/T1110/)
+    - [T1110:001: Brute Force: Password Guessing](https://attack.mitre.org/techniques/T1110/001/)
+    - [T1110:002: Brute Force: Password Cracking](https://attack.mitre.org/techniques/T1110/002/)
+    - [T1110:003: Brute Force: Password Spraying](https://attack.mitre.org/techniques/T1110/003/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+### Resources
+
+-   [RFC 6819](https://datatracker.ietf.org/doc/html/rfc6819)
+-   [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749)
+-   [OMB M-22-09](https://bidenwhitehouse.archives.gov/wp-content/uploads/2022/01/M-22-09.pdf)
+-   [GWS Admin Help \| Control which third-party & internal apps access GWS data](https://support.google.com/a/answer/7281227#zippy=%2Cstep-control-api-access%2Cstep-restrict-or-unrestrict-google-services%2Cbefore-you-begin-review-authorized-third-party-apps%2Cstep-manage-third-party-app-access-to-google-services-add-apps)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+-   [GWS Admin Help \| Control access to less secure apps](https://support.google.com/a/answer/6260879?hl=en)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### Policy Group 10 Instructions
+1.  Sign in to [Google Admin console](https://admin.google.com).
+2.  Go to **Security** -\> **Access and Data Control** -\> **API controls.**
+
+#### GWS.COMMONCONTROLS.10.1v1 instructions:
+1.  Select **Manage Google Services.**
+2.  Select the **Services box** to check all services boxes.
+3.  Once this box is selected, then the **Change access** link at the top of console will be available; select it.
+4.  Select **Restricted: Only trusted apps can access a service.**
+5.  Select **Change** then **confirm** if prompted.
+
+#### GWS.COMMONCONTROLS.10.2v1 instructions:
+1.  Select **Manage Google Services.**
+2.  Select the **Services box** to check all services boxes.
+3.  Once this box is selected, then the **Change access** link at the top of console will be available; select it.
+4.  Ensure to uncheck the check box next to **For apps that are not trusted, allow users to give access to OAuth scopes that aren't classified as high-risk.**
+5.  Select **Change** then **confirm** if prompted.
+
+#### GWS.COMMONCONTROLS.10.3v1 Instructions
+1.  Select **Settings.**
+2.  Select **Internal apps** and uncheck the box next to **Trust internal apps.**
+3.  Select **SAVE.**
+
+#### GWS.COMMONCONTROLS.10.4v1 Instructions
+1.  Select **Settings.**
+2.  Select **Unconfigured third-party apps** and select **Don't allow users to access any third-party apps**
+3.  Select **SAVE.**
+
+#### GWS.COMMONCONTROLS.10.5v1 Instructions
+1.  Sign in to the [Google Admin console](https://admin.google.com) as an administrator.
+2.  Select **Security** -\> **Overview**.
+3.  Select **Less Secure Apps**.
+4.  Select **Disable access to less secure apps (Recommended)**.
+5.  Click **Save** to commit this configuration change.
+
+It should be noted that administrators will have to manually approve each trusted application. The implementation steps for this activity are outlined in Google's [documentation on controlling which third-party & internal apps access GWS data](https://support.google.com/a/answer/7281227) (also listed under Resources).
+
+
+## 11. Authorized Google Marketplace Apps
+
+This section enables the ability to restrict installation of Google Workspace Marketplace applications to a defined list, provided and configured in the application allowlist. This guidance includes and applies to internally developed applications. This control disables legacy authentication and requires the use of modern authentication protocols based on federation for access from applications.
+
+Some older versions of common software may break when this control is implemented. Examples of these applications include:
+-   Mail configured with POP3
+-   Older versions of Outlook
+
+### Policies
+
+#### GWS.COMMONCONTROLS.11.1v1
+Only approved Google Workspace (GWS) Marketplace applications SHALL be allowed for installation.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Marketplace applications may include malicious content. Restricting application access to only organization-trusted applications reduces the risk of malicious applications connecting to GWS.
+- _Last modified:_ October 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1195: Supply Chain Compromise](https://attack.mitre.org/techniques/T1195/)
+    - [T1195:002: Supply Chain Compromise: Compromise Software Supply Chain](https://attack.mitre.org/techniques/T1195/002/)
+
+### Resources
+
+-   [GWS Admin Help \| Manage Google Workspace Marketplace apps on your allowlist](https://support.google.com/a/answer/6089179?fl=1)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.COMMONCONTROLS.11.1v1 Instructions
+1.  Sign in to the [Google Admin console](https://admin.google.com) as an administrator.
+2.  Select **Apps** -\> **Google Workspace Marketplace apps** -\> **Settings.**
+3.  Select **Allow users to install and run allowlisted apps from the Marketplace.**
+4.  Ensure that the **Allow exception for internal apps. Users can install and run any internal app, even if it's not allowlisted** checkbox is unchecked.
+5.  Click **Save.**
+
+To add an application to the allowlist:
+1.  On the left-hand side above **Setting,** click **Apps lists.**
+2.  Click the **ALLOWLIST APP** to add an application to the allowlist.
+
+    or
+
+3.  Click **Allowlisted Apps** to manage the allowlist.
+
+## 12. Google Takeout Services for Users
+
+This section prevents users from downloading a copy of the Google Takeout services' data to their user accounts. Services include Google Blogger, Books, Maps, Pay, Photos, Play, Play Console, Location History and YouTube, among numerous others.
+
+### Policies
+
+#### GWS.COMMONCONTROLS.12.1v1
+Google Takeout services SHALL be disabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Google Takeout is a service that allows users to download a copy of their data stored within 40+ Google products and services, including data from Gmail, Drive, Photos, and Calendar. While there may be a valid use case for users to back up their data in non-enterprise settings, this feature represents considerable attack surface as a mass data exfiltration mechanism, particularly in enterprise settings where other backup mechanisms are likely in use.
+- _Last modified:_ January 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+### Resources
+
+-   [GWS Admin Help \| Security checklist for medium and large businesses](https://support.google.com/a/answer/7587183?hl=en#zippy=%2Caccounts%2Capps-google-workspace-only%2Csites-google-workspace-only%2Cdrive%2Cgoogle-groups)
+-   [GWS Admin Help \| Allow or block Google Takeout](https://support.google.com/a/answer/6396995#managing&zippy=)
+
+### Prerequisites
+
+-   Determine which OU or access group will be affected by this policy and confirm that the right user and system accounts are in that OU or access group.
+
+### Implementation
+
+#### GWS.COMMONCONTROLS.12.1v1 Instructions
+1.  Sign in to [Google Admin console](https://admin.google.com).
+2.  Select **Data** -\> **Data import and export** -\> **Google Takeout**.
+3.  Select **User access to Takeout for Google services**.
+4.  For services without an individual administrator control, select **Services without an individual administrator control** then **Edit**.
+5.  Select **Don't allow for everyone**.
+6.  Click **Save**.
+7.  For services with an individual administrator control, under **Applications** select the checkbox next to **Service name** and select **Don't allow**.
+
+## 13. System-defined Rules
+
+GWS includes system-defined alerting rules that provide situational awareness into risky events and actions. Enabling the following list of rules is a security best practice. Please note that some, but not all, of these rules may be set to "on" by default. Rules that are not listed may be useful but not security relevant. Review all system-defined rules to implement the appropriate configuration based on individual requirements.
+
+-   Government-backed attacks
+-   User-reported phishing
+-   User's Admin privilege revoked
+-   User suspended for spamming through relay
+-   User suspended for spamming
+-   User suspended due to suspicious activity
+-   User suspended (Google identity alert)
+-   User granted Admin privilege
+-   Suspicious programmatic login
+-   Suspicious message reported
+-   Suspicious login
+-   Suspicious device activity
+-   Spike in user-reported spam
+-   Rate limited recipient
+-   Phishing message detected post-delivery
+-   Phishing in inboxes due to bad whitelist
+-   Mobile settings changed
+-   Malware message detected post-delivery
+-   Leaked password
+-   Google Operations
+-   Gmail potential employee spoofing
+-   Email settings changed
+-   Drive settings changed
+-   Domain data export initiated
+-   Device compromised
+-   Calendar settings changed
+-   Account suspension warning
+-   Super admin password reset
+-   SSO profile added
+-   SSO profile updated
+
+### Policies
+
+#### GWS.COMMONCONTROLS.13.1v1
+Required system-defined alerting rules, as listed in the policy group description, SHALL be enabled with alerts.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Potentially malicious or service-impacting events may go undetected. Setting up a mechanism to alert administrators to the required system-defined events draws attention to these events while minimizing any user or organizational impact.
+- _Last modified:_ January 2025
+- _Note:_ Any system-defined rules not listed are considered optional but should be reviewed and considered for activation by an administrator.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-4(5)
+- MITRE ATT&CK TTP Mapping
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562:001: Impair Defenses: Disable or Modify Tools](https://attack.mitre.org/techniques/T1562/001/)
+
+### Resources
+
+-   [GWS Admin Help \| Data sources for the security investigation tool](https://support.google.com/a/answer/11482175)
+-   [GWS Admin Help \| View and edit system-defined rules](https://support.google.com/a/answer/3230421)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.COMMONCONTROLS.13.1v1 Instructions
+1.	Sign in to the [Google Admin console](https://admin.google.com) as an administrator.
+2.  Click **Rules**.
+3.  From the Rules page, click **Add a filter**.
+4.  From the drop-down menu, select **Type**.
+5.  Select the **System defined** check box.
+6.  Click **Apply**.
+7.  A list of system-defined rules will appear. For each of the rules listed above, edit the configuration:
+    1.  Select the rule by clicking the table row for the rule.
+    2.  Select **Actions**.
+    3.  From the Actions page, configure the **Severity** for the alert to High, Medium, or Low, and select **Send to alert center** if available. If alerts are not available or supported, select **Send email notifications** and specify recipients for those notifications.
+    4.  Click **Next: Review**.
+    5.  Review the updated rule details, and then click **Update Rule**.
+
+## 14. Google Workspace Logs
+
+Configure GWS to send critical logs to the agency's centralized Security Information and Event Management (SIEM) so that they can be audited and queried. Configure GWS to send logs to a storage account and retain them for when incident response is needed.
+
+### Policies
+
+#### GWS.COMMONCONTROLS.14.1v1
+The following critical logs SHALL be sent to the agency's centralized SIEM.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols141v06-instructions)
+
+        > Admin Audit logs
+
+        > Enterprise Groups Audit logs
+
+        > Login Audit logs
+
+        > OAuth Token Audit logs
+
+        > SAML Audit log
+
+        > Context Aware Access logs
+
+- _Rationale:_ This policy enhances security by centralizing critical logs in the agency's Security Information and Event Management (SIEM) system, enabling timely detection and response to potential security incidents. It also aids agency compliance with applicable laws and binding policy, and helps maintain the confidentiality, integrity, and availability of the agency's information systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-4(5)
+- MITRE ATT&CK TTP Mapping
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562:008: Impair Defenses: Disable Cloud Logs](https://attack.mitre.org/techniques/T1562/008/)
+
+#### GWS.COMMONCONTROLS.14.2v1
+Audit logs SHALL be retained and searchable for a minimum of 3 months and retrievable for a minimum of 12 months.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols142v06-instructions)
+
+- _Rationale:_ Audit logs should be retained for a sufficient duration to ensure availability when needed. Extending log retention provides an agency with the necessary visibility to investigate incidents that occurred in the past. Additionally, the Office of Management and Budget (OMB) Memorandum M-26-14, "Ensuring Effective and Efficient Agency Logging and Network Visibility to Defend Against Evolving Cyber Threats", establishes data retention times that are dependent on the "maturity level" and targets for when those maturity levels should be reached, contingent on CISA publishing a logging reference architecture (LRA).
+- _Last modified:_ June 2026
+- _Note:_ Google offers the ability to export certain logs to Google BiqQuery or Google Cloud log buckets for an additional cost. Though these tools could be used to satisfy this baseline requirement, agencies may use the tool that best fits their individual circumstances.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AU-11
+- MITRE ATT&CK TTP Mapping
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562:008: Impair Defenses: Disable Cloud Logs](https://attack.mitre.org/techniques/T1562/008/)
+
+### Resources
+
+-   [GWS Admin Help \| Share data with Google Cloud Platform services](https://support.google.com/a/answer/9320190)
+-   [Google Cloud Operations Suite \| Audit logs for Google Workspace](https://cloud.google.com/logging/docs/audit/gsuite-audit-logging)
+-   [Google Cloud Operations Suite \| View and manage audit logs for Google Workspace](https://cloud.google.com/logging/docs/audit/configure-gsuite-audit-logs)
+-   [Google Cloud Operations Suite \| Aggregate and store your organization's logs](https://cloud.google.com/logging/docs/central-log-storage)
+-   [Google Cloud Architecture Center \| Google Logging export scenarios](https://cloud.google.com/architecture/design-patterns-for-exporting-stackdriver-logging?hl=en#logging_export_scenarios)
+-   [GWS Admin Help \| Data sources for GWS Audit and investigation page](https://support.google.com/a/answer/9725452)
+-   [GWS Admin Help \| Set up service log exports to BigQuery](https://support.google.com/a/answer/9079365)
+-   [GWS Admin Help \| Export your organization’s Drive inventory](https://support.google.com/a/answer/15141054)
+-   [Google Cloud Operations Suite \| Configure and Manage sinks – Google Cloud](https://cloud.google.com/logging/docs/export/configure_export_v2)
+- [OMB M-26-14, Ensuring Effective and Efficient Agency Logging and Network Visibility to Defend Against Evolving Cyber Threats \| Office of Management and  Budget](https://www.whitehouse.gov/wp-content/uploads/2026/05/M-26-14-Ensuring-Effective-and-Efficient-Agency-Logging-and-Network-Visibility-to-Defend-Against-Evolving-Cyber-Threats.pdf)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.COMMONCONTROLS.14.1v1 Instructions
+Follow the configuration instructions unique to the products and integration patterns at your organization to send the security logs to the security operations center for monitoring.
+
+Note: Agencies can benefit from security detection capabilities offered by the CISA Cloud Log Aggregation Warehouse (CLAW) system. Agencies are urged to send the logs to CLAW. Contact CISA at [cyberliason@cisa.dhs.gov]
+
+#### GWS.COMMONCONTROLS.14.2v1 Instructions
+1.  There is no implementation for this policy.
+
+## 15. Data Regions and Storage
+
+Google Workspace administrators can choose to store data in a specific geographic region (currently the United States or Europe) by using a data region policy. The policy can be applied to a specific organizational unit (OU) in a tenant or the parent OU. For federal agencies, the best practice is to restrict stored data for all users to the United States. This means applying this setting at the parent OU. Data region storage covers the primary data-at-rest (including backups) for Google Workspace core services (see resources section for services in scope).
+
+Currently, data region policies cannot be applied to data types that are not specifically listed in documentation linked in the resources section. Notably, this includes logs and cached content.
+
+### Policies
+
+#### GWS.COMMONCONTROLS.15.1v1
+The data storage region SHALL be set to be the United States for all users in the agency's GWS environment.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale_: Without this policy, data could be stored in various regions, potentially exposing it to unauthorized entities. Implementing this policy keeps most data in the United States, making it harder for potential threat actors to compromise data.
+- _Last modified:_ January 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1591: Gather Victim Organization Information](https://attack.mitre.org/techniques/T1591/)
+    - [T1591:001 Gather Victim Organization Information: Determine Physical Location](https://attack.mitre.org/techniques/T1591/001/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
+#### GWS.COMMONCONTROLS.15.2v1
+Data SHALL be processed in the region selected for data at rest.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Implementing this policy accounts for sovereignty over organizational data. Without this policy, data could be processed in a region other than the United States, potentially exposing it to unauthorized entities.
+- _Last modified:_ January 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1591: Gather Victim Organization Information](https://attack.mitre.org/techniques/T1591/)
+    - [T1591:001: Gather Victim Organization Information: Determine Physical Location](https://attack.mitre.org/techniques/T1591/001/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+    - [T1567:002: Exfiltration Over Web Service: Exfiltration to Cloud Storage](https://attack.mitre.org/techniques/T1567/002/)
+
+### Resources
+-	[GWS Admin Help \| Data regions: Choose a geographic location for your data](https://support.google.com/a/answer/7630496)
+-	[GWS Admin Help \| What data is covered by a data region policy?](https://support.google.com/a/answer/9223653)
+
+### Prerequisites
+
+- Super Admin role
+
+### Implementation
+
+#### GWS.COMMONCONTROLS.15.1v1 Instructions
+To configure Data Regions per the policy:
+1.	Sign in to the [Google Admin console](https://admin.google.com) as an administrator.
+2.	Navigate to **Data** -\> **Compliance** -\> **Data Regions.**
+3.	Click the **Region** card.
+4.	Click the **Data at rest** card.
+5.	Select the radio button option: "**United States.**"
+6.	Click **Save**.
+
+#### GWS.COMMONCONTROLS.15.2v1 Instructions
+1. Sign in to the [Google Admin console](https://admin.google.com) as an administrator.
+2. Navigate to **Data** -\> **Compliance** -\> **Data Regions.**
+3. Click the **Region** card.
+4. Click the **Data processing** card.
+5. Select the radio button option: "**Process data in the region selected for data at rest.**"
+6. Click **Save**.
+
+
+## 16. Additional Google Services
+
+Google Workspace considers some of its services to be "core services," including Gmail, Calendar, and Drive. Services outside of these core offerings are controlled within the "additional Google services" portion of the administrator console. This section outlines requirements relating to those services.
+
+### Policies
+
+#### GWS.COMMONCONTROLS.16.1v1
+Service status for Google services that do not have an individual control SHOULD be set to OFF for everyone.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale_: Accessing additional Google services without necessity can introduce potential vulnerabilities within the GWS environment. Disabling these services mitigates the risk of restricting unnecessary access.
+- _Last modified:_ January 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1199: Trusted Relationship](https://attack.mitre.org/techniques/T1199/)
+  - [T1204: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204:001: Trusted Execution: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+    - [T1204:002: Trusted Execution: Malicious File](https://attack.mitre.org/techniques/T1204/002/)
+    - [T1204:003: Trusted Execution: Malicious Image](https://attack.mitre.org/techniques/T1204/003/)
+
+#### GWS.COMMONCONTROLS.16.2v1
+User access to Early Access applications SHOULD be disabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale_: Allowing early access to applications may expose users to applications that have not yet been fully vetted and may still need to undergo robust testing to ensure compliance with applicable security standards.
+- _Last modified:_ January 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1199: Trusted Relationship](https://attack.mitre.org/techniques/T1199/)
+  - [T1204: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204:001: User Execution: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+    - [T1204:002: User Execution: Malicious File](https://attack.mitre.org/techniques/T1204/002/)
+    - [T1204:003: User Execution: Malicious Image](https://attack.mitre.org/techniques/T1204/003/)
+
+#### GWS.COMMONCONTROLS.16.3v1
+Looker Studio Sharing outside org SHOULD be set to OFF.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale_: Disabling Looker Studio asset sharing outside of the organization helps keep sensitive data, reports, and dashboards within the organization's control. This policy helps mitigate the risk of unauthorized access, data leakage, or exposure of proprietary information to external entities. By restricting sharing, the organization can maintain compliance with data governance standards, protect intellectual property, and safeguard customer or business-critical data. Additionally, this approach reduces the likelihood of accidental sharing or misuse of information, enhancing overall security and operational integrity.
+- _Last modified:_ February 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+    - [T1567:002 Exfiltration Over Cloud Storage](https://attack.mitre.org/techniques/T1567/002)
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078:004 Cloud Accounts](https://attack.mitre.org/techniques/T1078/004)
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+    - [T1565:003 Stored Data Manipulation](https://attack.mitre.org/techniques/T1565/003)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+    - [T1213:002 Cloud-Based Information Repositories](https://attack.mitre.org/techniques/T1213/002)
+
+#### GWS.COMMONCONTROLS.16.4v1
+Pinpoint access to drive SHOULD be set to OFF.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale_: Disabling Pinpoint access to Google Drive helps protect sensitive files and data stored within the organization's Drive from inadvertent access, analysis, or sharing through Pinpoint. This policy helps protect organizational data confidentiality and integrity by preventing unauthorized or unintended interactions between Pinpoint and Drive. By restricting access, the organization can reduce the risk of data breaches, maintain compliance with data privacy regulations, and uphold strict data governance practices. This approach also reduces potential misuse or exposure of sensitive information, enhancing overall security and operational control.
+- _Last modified:_ February 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1567: Exfiltration Over Web Service](https://attack.mitre.org/techniques/T1567/)
+    - [T1567:002 Exfiltration Over Cloud Storage](https://attack.mitre.org/techniques/T1567/002)
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078:004 Cloud Accounts](https://attack.mitre.org/techniques/T1078/004)
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+    - [T1565:003 Stored Data Manipulation](https://attack.mitre.org/techniques/T1565/003)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+    - [T1213:002 Cloud-Based Information Repositories](https://attack.mitre.org/techniques/T1213/002)
+  - [T1189: Drive-by Compromise](https://attack.mitre.org/techniques/T1189/)
+
+### Resources
+-	[GWS Admin Help \| Turn on or off additional Google services](https://support.google.com/a/answer/181865)
+-	[GWS Admin Help \| Turn Early Access apps on or off for users](https://support.google.com/a/answer/13515709)
+
+### Prerequisites
+
+- Super Admin role
+
+### Implementation
+
+#### Policy Group 16 Common Instructions
+1.	Sign in to the [Google Admin console](https://admin.google.com) as an administrator.
+2.	Navigate to **Apps** -> **Additional Google services**.
+
+#### GWS.COMMONCONTROLS.16.1v1 Instructions
+1. Click **CHANGE** at the top where it says if **Access to additional services without individual control for all organizational units is On/Off**.
+2. Select the option: "**OFF for everyone**"
+3. Click **Save**.
+
+#### GWS.COMMONCONTROLS.16.2v1 Instructions
+1. In the list of all services, scroll to and click on the **Early Access Apps** service.
+2. Click on **Service status**.
+3. Ensure **OFF for everyone** is checked.
+4. Click **Save**.
+
+#### GWS.COMMONCONTROLS.16.3v1 Instructions
+1. In the list of all services, scroll to and click on the **Looker Studio** service.
+2. Select **Sharing setting**.
+3. Ensure **OFF** is checked.
+4. Click **Save**.
+
+#### GWS.COMMONCONTROLS.16.4v1 Instructions
+1. In the list of all services, scroll to and click on the **Pinpoint** service.
+2. Click on **Data Access Settings**.
+3. Ensure **OFF - Users cannot copy files from Drive to Pinpoint** is checked.
+4. Click **Save**.
+
+## 17. Multi-Party Approval
+This section covers whether multiple super admins need to approve changes to specific admin console settings.
+
+### Policies
+
+#### GWS.COMMONCONTROLS.17.1v1
+Require multi-party approval for sensitive admin actions SHOULD be enabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)
+
+- _Rationale_: Changes to sensitive admin settings, such as disabling 2-step verification (2SV), could introduce serious vulnerabilities to the GWS environment. Requiring multiple super admins to approve changes to those settings mitigates this risk.
+- _Last modified:_ August 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-5
+- MITRE ATT&CK TTP Mapping
+  - No TTP Mappings
+
+### Resources
+-	[GWS Admin Help \| Multi-party approval for sensitive actions](https://support.google.com/a/answer/13790448?hl=en-Link)
+
+### Prerequisites
+
+- Super Admin role
+
+### Implementation
+
+#### GWS.COMMONCONTROLS.17.1v1 Instructions
+To configure additional services per the policy:
+1.	Sign in to the [Google Admin console](https://admin.google.com) as an administrator.
+2.	Navigate to **Security** -> **Authentication** -> **Multi-party approval settings**.
+3.	Ensure **Require multi party approval for sensitive admin actions** is checked.
+4.	Click **Save**.
+
+## 18. Data Loss Prevention
+
+Using data loss prevention (DLP), organizations can create and apply rules to control the content that users can share in files outside the organization, which helps prevent unintended exposure of sensitive information.
+
+DLP rules can use predefined content detectors to match PII (e.g., SSN), credentials (e.g., API keys), or specific document types (e.g., source code). Custom rules can also be applied based upon regex match or document labels.
+
+There are several commercial DLP solutions available that document support for Google Workspace. Google itself offers DLP services. Agencies may select any service that fits their needs and meets the baseline requirements outlined in this policy group. The DLP solution selected by an agency should offer services comparable to those offered by Google.
+
+Though use of Google's DLP solution is not strictly required, guidance for configuring Google's DLP solution can be found in the instructions of this policy section.
+
+### Policies
+#### GWS.COMMONCONTROLS.18.1v1
+A custom policy SHALL be configured for Google Drive, Google Calendar, Google Chat, and Gmail to protect PII and sensitive information as defined by the agency, covering at a minimum: credit card numbers, U.S. Individual Taxpayer Identification Numbers (ITIN), and U.S. Social Security numbers (SSN).
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols181v06-instructions)
+
+- _Rationale:_ Users may inadvertently share sensitive information with others who should not have access to it. DLP policies provide a way for agencies to detect and prevent unauthorized disclosures.
+- _Last modified:_ April 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+    - [T1048:002: Exfiltration Over Alternative Protocol: Exfiltration Over Asymmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/002/)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+
+
+[//]: # (Keep the version suffix out of the anchor.)
+<a name="commoncontrols182"></a>
+#### GWS.COMMONCONTROLS.18.2v1
+The action for DLP policies SHOULD be set to block.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols184v06-instructions)
+
+- _Rationale:_ Users may inadvertently share sensitive information with others who should not have access to it. DLP policies provide a way for agencies to detect and prevent unauthorized disclosures.
+- _Last modified:_ January 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+    - [T1048:002: Exfiltration Over Alternative Protocol: Exfiltration Over Asymmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/002/)
+  - [T1213: Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+
+### Resources
+- [GWS Admin Help \| Protect sensitive information using DLP](https://support.google.com/a/topic/7556687?hl=en&ref_topic=7558840&fl=1&sjid=4459086914710819343-NA)
+- [GWS Admin Help \| Use Workspace DLP to prevent data loss](https://support.google.com/a/answer/9646351?hl=en&visit_id=638635679011849528-69139467&ref_topic=9646660&rd=1)
+- [GWS Admin Help \| Create DLP for Drive rules and custom content detectors](https://support.google.com/a/answer/9655387)
+- [GWS Admin Help \| Prevent data leaks from Chat messages & attachments](https://support.google.com/a/answer/10846568)
+- [GWS Admin Help \| Prevent data leaks in email & attachments](https://support.google.com/a/answer/14767988?fl=1&sjid=4620103790740920406-NA)
+
+### Prerequisites
+Google DLP is available to users of the following GWS editions: Frontline Standard; Enterprise Standard and Enterprise Plus; Education Fundamentals, Education Standard, Teaching and Learning Upgrade, and Education Plus; and Enterprise Essentials Plus.
+
+Drive DLP and Chat DLP are available to Cloud Identity Premium users with a Google Workspace license. For Drive DLP, the license must include the Drive log events.
+
+### Implementation
+
+#### GWS COMMONCONTROLS 18 Common Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Menu -\> Security -\> Access and data control -\> Data protection**.
+3.  Under **Data protection rules and detectors** click **Manage Rules**.
+4.  Click **Add rule** -\> **New rule**.
+
+#### GWS.COMMONCONTROLS.18.1v1 Instructions
+1. In the **Name and apps** section, add the name and description of the rule.
+2. In the **Name and apps** section, under **Google Calendar**, choose the trigger for **Event saved**.
+3. In the **Name and apps** section, under **Google Chat**, choose the trigger for **Message Sent** and **File uploaded**.
+4. In the **Name and apps** section, under **Google Drive**, choose the trigger for **Drive files**.
+5. In the **Name and apps** section, under **Gmail**, choose the trigger for **Message Sent** and **Message received**.
+6. In the **Actions** section, select the appropriate action for each application (per [GWS.COMMONCONTROLS.18.2](#commoncontrols182)).
+7. In the **Alerting** section, choose a severity level, and optionally, check **Send to alert center to trigger notifications**.
+8. Under **Scope** Click **All in your tennant**
+9. In the **Conditions** section:
+    1. Click **Add Condition**. For **Content type to scan**, select **All content**. For **What to scan for**, select **Matches predefined data type**. For **Select data type**, select **Global - Credit card number**. Select the remaining condition properties according to agency need.
+    2. Click **Add Condition**. For **Content type to scan**, select **All content**. For **What to scan for**, select **Matches predefined data type**. For **Select data type**, select **United States - Individual Taxpayer Identification Number**. Select the remaining condition properties according to agency need.
+    3. Click **Add Condition**. For **Content type to scan**, select **All content**. For **What to scan for**, select **Matches predefined data type**. For **Select data type**, select **United States - Social Security Number**. Select the remaining condition properties according to agency need.
+    4. Configure other appropriate content and condition definition(s) based upon the agency's individual requirements and click **Continue**.
+10. Review the rule details, mark the rule as **Active**, and click **Create.**
+
+
+#### GWS.COMMONCONTROLS.18.2v1 Instructions
+1.  For each rule in the **Actions** section follow these steps depending on application:
+    1. For Google Calendar policies select **Block event**.
+    2. For Chat policies rules select **Block message** and select **External Conversations** and **Spaces**, **Group chats**, and **1:1 chats**.
+    3. Optionally, for Chat policies rules select **Block message** and select **Internal Conversations** and **Spaces**, **Group chats**, and **1:1 chats**.
+    4. For Gmail policies select **Audit Only**, and then select **Messages sent to external recipients**, **Messages to internal recipients**, **Messages from external senders**, and **Messages from internal senders** .
+    5. For Google Drive policies select **Block external sharing**.
+2. Click **Continue**.

--- a/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md
+++ b/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/drive.md
@@ -1,0 +1,466 @@
+# CISA Google Workspace Secure Configuration Baseline for Google Drive and Docs
+
+Google Drive and Google Docs are collaboration tools in Google Workspace (GWS) that support document management and storage, access, and sharing of files. Drive and Docs allow administrators to control and manage their files and documents. This Secure Configuration Baseline (SCB) provides specific policies to strengthen Drive and Docs security.
+
+The Cybersecurity and Infrastructure Security Agency's (CISA) Secure Cloud Business Applications (SCuBA) project provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies' cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for GWS help secure federal information assets stored within GWS cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government's threats and risk tolerance. Organizations outside of the federal government may also find these baselines to be useful references to help reduce risks even if such organizations have different risk tolerances or face different threats.
+
+For non-federal users, the information in this document is being provided "as is" for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products. CISA has no control over vendor changes to products offerings or features. Accordingly, these SCuBA SCBs for GWS may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+This baseline is based on Google documentation available at [Google Workspace Admin Help: Overview: Manage Drive for an organization](https://support.google.com/a/answer/2490026?hl=en) and addresses the following:
+
+-   [Sharing Outside the Organization](#1-sharing-outside-the-organization)
+-   [Shared Drive Creation](#2-shared-drive-creation)
+-   [Security Updates for Files](#3-security-updates-for-files)
+-   [Drive SDK](#4-drive-sdk)
+-   [Drive for Desktop](#5-drive-for-desktop)
+
+Settings can be assigned to certain users within GWS individually, through organizational units, or through configuration groups. Before changing a setting, the user can select the organizational unit, configuration group, or individual users to which they want to apply changes.
+
+## Assumptions
+
+This document assumes the organization is using GWS Enterprise Plus.
+
+This document does not address, ensure compliance with, or supersede any law, regulation, or other authority.  Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology.  This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+## Key Terminology
+
+The key words "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services) (**BOD 25-01 Requirement**): This indicator means that the policy is required under CISA BOD 25-01.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology) (**Automated Check**): This indicator means that the policy can be automatically checked via ScubaGoggles. See [our documentation](../../README.md) for help getting started.
+
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#break-glass-accounts)(**Configurable**): This indicator means that the policy can be customized via a configuration file.
+
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)(**Log-Based Check**): This indicator means that ScubaGoggles will check the policy by reviewing admin audit logs. See [Limitations](../../docs/usage/Limitations.md#log-based-policy-checks).
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols83v06-instructions)(**Manual**): This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. Sharing Outside the Organization
+
+This section covers whether users can share files outside of the organization, whether Google checks a shared file to ensure that recipients have access, and which users have permission to distribute content outside of the organization to include uploading or moving content to shared drives owned by another organization. These files include Google Docs, Google Sheets, Google Slides, My Maps, folders, and anything else stored in Google Drive.
+
+### Policies
+
+#### GWS.DRIVEDOCS.1.1v1
+External sharing SHALL be restricted to allowlisted domains.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Documents may contain personally identifiable information or sensitive information. Disabling external sharing reduces the risk of inadvertent data leakage.
+- _Last modified:_ August 2025
+- _Note:_
+  - This policy restricts information sharing
+  - This policy prevents data leakage outside of the organization
+  - If specific users have a need for broader external sharing (e.g., for community outreach), external sharing MAY be enabled for specific Organization Units (OUs).
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
+#### GWS.DRIVEDOCS.1.2v1
+Receiving files from non-allowlisted domains SHOULD be disabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Users given access to external files may inadvertently input personally identifiable information or sensitive information. Additionally, files created externally may contain malicious content. Disallowing external files from being shared may reduce the risk of data loss or external threats.
+- _Last modified:_ August 2025
+- _Note:_ This policy is only applicable if external sharing is set to **ALLOWLISTED DOMAINS**.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3, SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
+#### GWS.DRIVEDOCS.1.3v1
+Warnings SHALL be enabled when a user is attempting to share with someone in a non-allowlisted domain.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Users may not always be aware that a given user is external to their organization. Warning them before sharing increases user awareness and accountability.
+- _Last modified:_ August 2025
+- _Note:_ This policy is only applicable if external sharing is set to **ALLOWLISTED DOMAINS**.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AT-2b
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
+#### GWS.DRIVEDOCS.1.4v1
+If sharing outside of the organization, agencies SHOULD disable sharing of files with individuals who are not using a Google account.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Allowing users to view shared files when they are not signed in to a Google account diminishes oversight and accountability, increasing the potential for a data breach. This policy reduces that risk by requiring all users to be signed in when viewing shared Google Docs/Google Drive materials.
+- _Last modified:_ August 2025
+- _Note:_ This policy is only applicable if external sharing is set to **ON**.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-8, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
+#### GWS.DRIVEDOCS.1.5v1
+Any Organizational Units that allow external sharing SHOULD disable content availability to "anyone with the link."
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Allowing users to view shared files when they are not signed in to a Google account diminishes oversight and accountability and increases the chance of a potential data breach. This policy reduces that risk by requiring all people to be signed in when viewing shared Google Docs/Google Drive materials.
+- _Last modified:_ August 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-8
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
+#### GWS.DRIVEDOCS.1.6v1
+Agencies SHALL set access checking to "recipients only."
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ The "Access Checker" feature can be configured to allow users to grant a recipient open access, creating the potential for data leakage. This control mitigates the risk by allowing access to be granted to recipients only.
+- _Last modified:_ June 2024
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, IA-8, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
+#### GWS.DRIVEDOCS.1.7v1
+Users SHOULD NOT be allowed to upload or move content to shared drives owned by another organization.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Once a document is moved outside of the organization's drives, the organization no longer has control over the dissemination of the document. By preventing users from distributing content to external shared drives, the organization maintains more control over the document.
+- _Last modified:_ August 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
+#### GWS.DRIVEDOCS.1.8v1
+"Private to owner" SHALL be the default access level for newly created items.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ By implementing least privilege and setting the default to "Private to owner," the organization is able to prevent broad accidental sharing of information.
+- _Last modified:_ August 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+  - [T1538: Cloud Service Dashboard](https://attack.mitre.org/techniques/T1538/)
+
+#### GWS.DRIVEDOCS.1.9v1
+Out-of-Domain file-level warnings SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Implementing out-of-domain file-level warnings can help users identify potentially risky files and avoid phishing scams when working with files shared from external entities.
+- _Last modified:_ August 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-8, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
+#### GWS.DRIVEDOCS.1.10v1
+If external sharing is not allowed, then forms owned by users within the organization SHOULD NOT be able to accept responses from anyone accessing the link from outside the organization.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwsdrivedocs110v06-instructions)
+
+- _Rationale:_ If external sharing is not allowed, enabling the ability to accept responses from anyone bypasses the external sharing restrictions in place. Users external to the organization could use forms to maliciously collect and share data without oversight. Implementing this policy reduces these risks.
+- _Last modified:_ August 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-8, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
+#### GWS.DRIVEDOCS.1.11v1
+If receiving external files is not allowed, then users in the organization SHOULD NOT be able to submit responses to forms from users or shared drives outside of the organization.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwsdrivedocs111v06-instructions)
+
+- _Rationale:_ If receiving external files is not allowed, enabling the ability to submit responses to forms from users or shared drives outside of the organization bypasses the external sharing restrictions in place. Users external to the organization could use forms to maliciously collect and share data without oversight. Implementing this policy reduces these risks.
+- _Last modified:_ August 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-8, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
+
+### Resources
+
+-   [Google Workspace Admin Help: Set Drive users' sharing permissions](https://support.google.com/a/answer/60781?hl=en)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+-   [Manage external sharing for your organization](https://support.google.com/a/answer/60781)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To configure the settings for Sharing options:
+
+#### Policy Group 1 Common Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Drive and Docs**.
+4.  Follow implementation for each individual policy
+5.  Select **Save**
+
+#### GWS.DRIVEDOCS.1.1v1 Instructions
+1.  Select **Sharing settings** -\> **Sharing options**.
+2.  Select **Sharing outside of your domain** -\> **OFF – Files owned by users in your domain cannot be shared outside of your domain**
+
+#### GWS.DRIVEDOCS.1.2v1 Instructions
+1.  Select **Sharing settings** -\> **Sharing options**.
+2.  Deselect **Allow users to receive files from users or shared drives outside of allowlisted domains**.
+
+#### GWS.DRIVEDOCS.1.3v1 Instructions
+1.  Select **Sharing settings** -\> **Sharing options**.
+2.  Select **Warn when files owned by users or shared drives in your organization are shared with users in allowlisted domains**.
+
+#### GWS.DRIVEDOCS.1.4v1 Instructions
+1.  Select **Sharing settings** -\> **Sharing options**.
+2.  Deselect **Allow users or shared drives in your organization to share items with people outside of your organization who aren't using a Google account.**
+
+#### GWS.DRIVEDOCS.1.5v1 Instructions
+1.  Select **Sharing settings** -\> **Sharing options**.
+2.  Deselect **When sharing outside of your organization is allowed, users in your organization can make files and published web content visible to anyone with the link.**
+
+#### GWS.DRIVEDOCS.1.6v1 Instructions
+1.  Select **Sharing settings** -\> **Sharing options**.
+2.  Select **Access Checker** -\> **Recipients only.**
+
+#### GWS.DRIVEDOCS.1.7v1 Instructions
+1.  Select **Sharing settings** -\> **Sharing options**.
+2.  Select **Distributing content outside of your domain** -\> **No one**
+
+#### GWS.DRIVEDOCS.1.8v1 Instructions
+1.  Select **Sharing settings -\> General access default.**
+2.  Select **When users in your organization create items, the default access will be -\> Private to the owner.**
+
+#### GWS.DRIVEDOCS.1.9v1 Instructions
+1.  Select **Sharing settings -\> Highlight External Files**.
+2.  Check the **Mark files shared or owned externally as "external" to indicate that content may be viewable outside your organization. Applies to Drive, Docs, Sheets, Slides, Drawings, and Vids.** box to turn on the indicator.
+3.  Select **Save**.
+
+#### GWS.DRIVEDOCS.1.10v1 Instructions
+1.  Select **Sharing settings -\> Sharing options**
+2.  Select **Form responses**
+3.  Check the **Allow forms owned by users in XXXX to accept responses from anyone with the link outside XXXX, even if external sharing isn't allowed. If this option isn’t selected, settings for sharing outside XXXX apply to forms** box
+4.  Select **Save**.
+
+#### GWS.DRIVEDOCS.1.11v1 Instructions
+1.  Select **Sharing settings -\> Sharing options**
+2.  Select **Form responses**
+3.  Check the **Allow users in XXXX to submit responses to forms from users or shared drives outside of XXXX, even if receiving external files isn’t allowed. If this option isn’t selected, settings for receiving files external to XXXX apply to forms** box
+4.  Select **Save**.
+
+## 2. Shared Drive Creation
+
+This section covers whether users can create new shared drives to share with other users, including those external to their organization. Even if users cannot create new shared drives, they can still be added to shared drives owned by other users. This control also determines which users, both internal and external to the organization, can access files in shared drives.
+
+### Policies
+
+#### GWS.DRIVEDOCS.2.1v1
+Agencies SHOULD NOT allow members with manager access to override shared Google Drive creation settings.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Allowing users who are not the Google Drive manager to override settings violates the principle of least privilege. This policy reduces the risk of Google Drive settings being modified by unauthorized individuals.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+#### GWS.DRIVEDOCS.2.2v1
+Agencies SHALL allow users who are not members of a shared Google Drive to be added to files.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Prohibiting non-members from being added to a file would require they be added as Google Drive members to access the file, potentially exposing all Google Drive files and increasing the risk of sensitive content exposure. Disallowing the sharing of these individual files reduces the risk of internal documents from being distributed outside the organization without explicit consent and approval.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+### Resources
+-   [Google Workspace Admin Help: Set Drive users' sharing permissions](https://support.google.com/a/answer/60781?hl=en)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To configure the settings for Shared drive creation:
+
+#### Policy Group 2 common Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Drive and Docs**.
+3.  Select **Sharing settings -\> Shared drive creation**.
+4.  Follow the implementation for each individual policy.
+5.  Select **Save**
+
+#### GWS.DRIVEDOCS.2.1v1 Instructions
+1.  Uncheck the **Allow members with manager access to override the settings below** checkbox.
+
+#### GWS.DRIVEDOCS.2.2v1 Instructions
+1.  Check the **Allow people who aren't shared drive members to be added to files** checkbox.
+
+
+## 3. Security Updates for Files
+
+This section covers whether a security update issued by Google will be applied to increase file link security. When sharing files using a link, users must not remove the resource key parameter, as doing so may result in unexpected file access requests.
+
+### Policies
+
+#### GWS.DRIVEDOCS.3.1v1
+Agencies SHALL enable the security update for Google Drive files.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Failure to enable the resource key security update may result in unauthorized access to files. Enabling this update reduces the risk of unauthorized access and potential data spillage by enhancing control for files in Google Drive.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Manage the link-sharing security update for files](https://support.google.com/a/answer/10685032?hl=en-EN&fl=1&sjid=14749870194899350730-NA)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To configure the settings for Security update for files:
+
+#### GWS.DRIVEDOCS.3.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Drive and Docs.**
+3.  Select **Sharing settings -\> Security update for files.**
+4.  Select **Apply security update to all impacted files.**
+5.  Uncheck the **Allow users to remove/apply the security update for files they own or manage** checkbox.
+6.  Select **Save**.
+
+## 4. Drive SDK
+
+This section covers whether users have access to Google Drive with the Drive SDK API, which allows third-party applications to work on the files stored in Google Drive. The Drive SDK API is used by developers to access Google Drive through third-party applications that they have created.
+
+### Policies
+
+#### GWS.DRIVEDOCS.4.1v1
+Agencies SHOULD disable Google Drive SDK access.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ The Google Drive SDK allows third-party applications to access Google Drive data, potentially leading to unintentional information sharing and data leakage. By disabling the Google Drive SDK, agencies can decrease the risk of internal documents being distributed externally without explicit consent and approval.
+- _Last modified:_ January 2024
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1059: Command and Scripting Interpreter](https://attack.mitre.org/techniques/T1059/)
+    - [T1059:009: Command and Scripting Interpreter: Cloud API](https://attack.mitre.org/techniques/T1059/009/)
+
+### Resources
+
+-   [Google Drive for Developers](https://developers.google.com/drive/)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To configure the settings for Drive SDK:
+
+#### GWS.DRIVEDOCS.4.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Drive and Docs.**
+3.  Select **Features and Applications -\> Drive SDK.**
+4.  Uncheck the **Allow users to access Google Drive with the Drive SDK API** checkbox.
+5.  Select **Save**.
+
+## 5. Drive for Desktop
+
+This section addresses Google Drive for Desktop, a feature that enables users to interact with their Drive files directly through their desktop's file explorer or finder, rather than through an internet browser.
+
+### Policies
+
+#### GWS.DRIVEDOCS.5.1v1
+Google Drive for Desktop SHALL be enabled for authorized devices only.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Some users may attempt to use Google Drive for Desktop to connect unapproved devices (e.g., a personal computer) to the agency's Google Drive. Even if unintentional, this poses a security risk as the agency lacks the ability to audit or secure personal devices. Implementing this policy helps reduce these risks.
+- _Last modified:_ August 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+#### GWS.DRIVEDOCS.5.2v1
+Monitoring for potential ransomware corruption SHALL be enabled.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols52v06-instructions)
+
+- _Rationale:_ This setting helps protect against malware and ransomware by auto-detecting potential attacks. This strengthens the overall security posture and limits potential damage from ransomware.
+- _Last modified:_ April 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CP-9, CP-10
+- MITRE ATT&CK TTP Mapping
+  - [T1486: Data Encrypted for Impact](https://attack.mitre.org/techniques/T1486/)
+  - [T1490: Inhibit System Recovery](https://attack.mitre.org/techniques/T1490/)
+
+
+### Resources
+
+-   [Use Google Drive for desktop - Google Drive Help](https://support.google.com/drive/answer/10838124?sjid=7721208110884477761-NA&visit_id=638192503824884459-786860809&rd=1)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+-   [Detect ransomware and recover files in Drive for desktop](https://knowledge.workspace.google.com/admin/drive/detect-ransomware-and-recover-files-in-drive-for-desktop)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.DRIVEDOCS.5.1v1 Instructions
+To Disable Google Drive for Desktop:
+
+1.  Sign in to the [Google Admin console](https://admin.google.com).
+2.  Select **Menu-\>Apps-\>Google Workspace-\>Drive and Docs**.
+3.  Select **Google Drive for Desktop**.
+4.  Select **Enable Drive for Desktop**.
+5.  Uncheck the **Allow Google Drive for desktop in your organization** checkbox.
+6.  Select **Save**.
+
+To limit Google Drive for Desktop to authorized devices:
+
+1.  Sign in to the [Google Admin console](https://admin.google.com).
+2.  Select **Menu-\>Apps-\>Google Workspace-\>Drive and Docs**.
+3.  Select **Google Drive for Desktop**.
+4.  Select **Enable Drive for Desktop**.
+5.  Check the **Allow Google Drive for desktop in your organization** checkbox.
+6.  Check the **Only allow Google Drive for desktop on authorized devices checkbox**.
+7.  Ensure authorized devices are added to [company-owned inventory](https://support.google.com/a/answer/7129612?hl=en).
+8.  Select Save.
+
+Alternatively, [Context-Aware access policies](https://support.google.com/a/answer/9275380?hl=en) can be configured for more granular controls around authorized devices. The access level applied to Google Drive must have the "Apply to Google desktop and mobile apps" enabled to meet this requirement. For additional guidance, see [Context-Aware Access](/scubagoggles/baselines/commoncontrols.md#2-context-aware-access).
+
+#### GWS.DRIVEDOCS.5.2v1 Instructions:
+1.  Sign in to the [Google Admin console](https://admin.google.com).
+2.  Select **Menu-\>Apps-\>Google Workspace-\>Drive and Docs**.
+3.  Select **Malware and Ransomware**.
+4.  Ensure **Drive automatically monitors unusual file changes to identify potential ransomware corruption** is set to ON.
+5.  Select **Save**.

--- a/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gemini.md
+++ b/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gemini.md
@@ -1,0 +1,217 @@
+# CISA Google Workspace Secure Configuration Baseline for Google Gemini
+
+Google Gemini is the Google Workspace (GWS) Artificial Intelligence (AI) platform intended to assist with tasks in Gmail, Drive, Docs, and Meet. This Secure Configuration Baseline (SCB) provides specific policies to strengthen Gemini security.
+
+The Cybersecurity and Infrastructure Security Agency's (CISA) Secure Cloud Business Applications (SCuBA) project provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies' cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for GWS help secure federal information assets stored within GWS cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government's threats and risk tolerance. Organizations outside of the federal government may also find these baselines to be useful references to help reduce risks even if such organizations have different risk tolerances or face different threats.
+
+For non-federal users, the information in this document is being provided "as is" for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products. CISA has no control over vendor changes to products offerings or features. Accordingly, these SCuBA SCBs for GWS may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+This baseline is based on Google documentation available at [Google Workspace Admin Help: Gemini for Google Workspace](https://support.google.com/a/topic/13853688?hl=en&ref_topic=9197&sjid=1480967616439197109-NA) and addresses the following:
+
+-   [Gemini App Access](#1-gemini-app-access)
+-   [Gemini Alpha features](#2-gemini-alpha-features)
+-   [Gemini Conversation History](#3-gemini-conversation-history)
+-   [Gemini Conversation Sharing](#4-gemini-conversation-sharing)
+
+## Assumptions
+
+This document assumes the organization is using GWS Enterprise Plus.
+
+This document does not address, ensure compliance with, or supersede any law, regulation, or other authority.  Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology.  This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+## Key Terminology
+
+The key words "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services) (**BOD 25-01 Requirement**): This indicator means that the policy is required under CISA BOD 25-01.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology) (**Automated Check**): This indicator means that the policy can be automatically checked via ScubaGoggles. See [our documentation](../../README.md) for help getting started.
+
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#break-glass-accounts)(**Configurable**): This indicator means that the policy can be customized via a configuration file.
+
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)(**Log-Based Check**): This indicator means that ScubaGoggles will check the policy by reviewing admin audit logs. See [Limitations](../../docs/usage/Limitations.md#log-based-policy-checks).
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols83v06-instructions)(**Manual**): This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. Gemini App Access
+Data for users with a license providing Gemini access under the Google Workspace (GWS)
+or Workspace for Education terms cannot be used by Google for training generative
+AI models. However, GWS supports enabling Gemini access, regardless
+of license. Only Gemini data for users with one of the above license types will be protected
+by the GWS Terms of Service.
+
+Gemini access to Google services outside of the GWS core
+services, Google Maps, Data Studio, Google Flow, etc., can be restricted in the administrative center. These additional services
+are not covered by the GWS agreement and could represent data leakage risk of user data and use for training generative AI. See
+[Additional Google Services](https://github.com/cisagov/ScubaGoggles/blob/main/scubagoggles/baselines/commoncontrols.md#16-additional-google-services)
+for more details on configuring these additional services.
+
+### Policies
+
+#### GWS.GEMINI.1.1v1
+Gemini app user access SHALL be set to OFF for everyone without a license.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)
+
+- _Rationale:_ Only Gemini data for users with the appropriate license will be
+protected from use in generative AI training by the Google Workspace Terms of Service. Data for users without the
+appropriate license can be used to improve Google's generative AI models.
+Allowing user access to Gemini under any license creates the risk of data leakage but restricting it to licensed users will grant protection by the GWS Terms of Service.
+- _Last modified:_ July 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)(a)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+### Resources
+-   [Turn the Gemini app on or off](https://support.google.com/a/answer/14571493)
+-   [Turn Google apps in Gemini on or off](https://support.google.com/a/answer/15293691)
+-   [Google Workspace Terms of Service](https://workspace.google.com/terms/premier_terms/)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.GEMINI.1.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Generative AI** -\> **Gemini App**.
+3.  Select **User Access**.
+4.  Ensure **Allow all users to access the Gemini app, regardless of license** is **Unchecked**.
+5.  Select **Save**.
+
+
+## 2. Gemini Alpha features
+GWS permits administrators to restrict or enable access to Gemini Alpha features
+before they're made generally available.
+
+Note that Gemini Alpha features are subject to the Pre-General Availability
+Offering Terms (excluding Section 6.1(b)) of the Google Workspace Service
+Specific Terms. Section 6.1(d) prohibits government customers from using live or
+production data in connection with Pre-Gemini Alpha Offerings.
+
+### Policies
+
+#### GWS.GEMINI.2.1v1
+Gemini Alpha features SHALL be disabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)
+
+- _Rationale:_ Allowing access to Gemini Alpha features may expose users to features that
+have not yet been fully vetted and may still need to undergo robust testing to verify
+compliance with applicable security standards. Additionally, government customers are
+prohibited from using production data with pre-general availability offerings, per the Google Workspace
+Service Specific Terms.
+- _Last modified:_ July 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)(a)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+### Resources
+
+-   [Turn access to Google Workspace with Gemini Alpha on or off](https://support.google.com/a/answer/14170809)
+-   [Google Workspace Service Specific Terms](https://workspace.google.com/terms/service-terms/index.html)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.GEMINI.2.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Generative AI** -\> **Gemini for Workspace.**
+3.  Select **Alpha features.**
+4.  Ensure **Turn off access to Alpha features in Gemini for Google Workspace** is selected.
+5.  Select **Save**.
+
+## 3. Gemini Conversation History
+This section covers Gemini conversation history retention.
+
+### Policies
+
+#### GWS.GEMINI.3.1v1
+Gemini conversation history SHALL be enabled.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwsgemini31v1-instructions)
+
+- _Rationale:_ Users engaged in Gemini conversations may inadvertently share sensitive or private information. Enabling conversation history may mitigate this risk by providing a traceable record of Gemini conversations, enhancing information accountability and security. Additionally, this may help meet data retention requirements.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AU-2, AU-11
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+#### GWS.GEMINI.3.2v1
+Gemini conversation retention SHALL be set to minimum of 18 months.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwsgemini32v1-instructions)
+
+- _Rationale:_ Users engaged in Gemini conversations may inadvertently share sensitive or private information. Enabling conversation history may mitigate this risk by providing a traceable record of Gemini conversations, enhancing information accountability and security. Additionally, this may help meet data retention requirements.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AU-2, AU-11
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+### Resources
+
+-   [Manage Gemini in Workspace conversation history settings](https://knowledge.workspace.google.com/admin/gemini/manage-gemini-in-workspace-conversation-history-settings)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.GEMINI.3.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Generative AI** -\> **Gemini App**.
+3.  Select **Gemini Conversation History**
+4.  Ensure **Gemini conversation history** is selected.
+5.  Select **Save**.
+
+#### GWS.GEMINI.3.2v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Generative AI** -\> **Gemini App**.
+3.  Select **Gemini Conversation History**
+4.  Ensure **Conversation retention** is set to at least 18 months.
+5.  Select **Save**.
+
+## 4. Gemini Conversation Sharing
+This section covers Gemini conversation sharing.
+
+### Policies
+
+#### GWS.GEMINI.4.1v1
+Conversation sharing SHALL be set to OFF.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwsgemini41v1-instructions)
+
+- _Rationale:_ Users engaged in Gemini conversations may inadvertently share sensitive or private information. Disabling conversation sharing may prevent sensitive data from being shared with unauthorized individuals.
+- _Last modified:_ April 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)a
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+### Resources
+
+-   [Turn conversation sharing on or off](https://knowledge.workspace.google.com/admin/gemini/turn-conversation-sharing-on-or-off)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.GEMINI.4.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Generative AI** -\> **Gemini App**.
+3.  Select **Sharing**
+4.  Ensure **Allow conversation sharing via link** is set to OFF.
+5.  Select **Save**.
+

--- a/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md
+++ b/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/gmail.md
@@ -1,0 +1,1208 @@
+# CISA Google Workspace Secure Configuration Baseline for Gmail
+
+Gmail is the Google Workspace offering for sending and receiving email. Users can upload attachments to emails and send them to a given email address. Additional Gmail features include integrating with other Google applications, such as Meet and Chat. This Secure Configuration Baseline (SCB) provides specific policies to strengthen Gmail security.
+
+The Cybersecurity and Infrastructure Security Agency's (CISA) Secure Cloud Business Applications (SCuBA) project provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies' cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for GWS help secure federal information assets stored within GWS cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government's threats and risk tolerance. Organizations outside of the federal government may also find these baselines to be useful references to help reduce risks even if such organizations have different risk tolerances or face different threats.
+
+For non-federal users, the information in this document is being provided "as is" for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products. CISA has no control over vendor changes to products offerings or features. Accordingly, these SCuBA SCBs for GWS may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+This baseline is based on Google documentation available in the [Gmail Google Workspace Admin Help Center](https://support.google.com/a/topic/9202?hl=en&ref_topic=9197) and addresses the following:
+
+- [Mail Delegation](#1-mail-delegation)
+- [Domain Keys Identified Mail](#2-domainkeys-identified-mail)
+- [Sender Policy Framework](#3-sender-policy-framework)
+- [Domain Based Message Authentication, Reporting, and Conformance](#4-domain-based-message-authentication-reporting-and-conformance)
+- [Attachment Protections](#5-attachment-protections)
+- [Links and External Images Protections](#6-links-and-external-images-protection)
+- [Spoofing and Authentication Protection](#7-spoofing-and-authentication-protection)
+- [User Email Uploads](#8-user-email-uploads)
+- [POP and IMAP Access](#9-pop-and-imap-access-for-users)
+- [Workspace Sync](#10-google-workspace-sync)
+- [Automatic Forwarding](#11-automatic-forwarding)
+- [Per User Outbound Gateways](#12-per-user-outbound-gateways)
+- [Unintended External Reply Warning](#13-unintended-external-reply-warning)
+- [Email Allowlist](#14-email-allowlist)
+- [Enhanced Pre-Delivery Message Scanning](#15-enhanced-pre-delivery-message-scanning)
+- [Security Sandbox](#16-security-sandbox)
+- [Comprehensive Mail Storage](#17-comprehensive-mail-storage)
+- [Spam Filtering](#18-spam-filtering)
+
+
+Within Google Workspace, settings can be assigned to users through organizational units, configuration groups, or individually. Before changing a setting, the user can select the organizational unit, configuration group, or individual users to which they want to apply changes.
+
+## Assumptions
+
+This document assumes the organization is using GWS Enterprise Plus.
+
+This document does not address, ensure compliance with, or supersede any law, regulation, or other authority.  Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology.  This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+## Key Terminology
+
+The key words "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services) (**BOD 25-01 Requirement**): This indicator means that the policy is required under CISA BOD 25-01.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology) (**Automated Check**): This indicator means that the policy can be automatically checked via ScubaGoggles. See [our documentation](../../README.md) for help getting started.
+
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#break-glass-accounts)(**Configurable**): This indicator means that the policy can be customized via a configuration file.
+
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)(**Log-Based Check**): This indicator means that ScubaGoggles will check the policy by reviewing admin audit logs. See [Limitations](../../docs/usage/Limitations.md#log-based-policy-checks).
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols83v06-instructions)(**Manual**): This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. Mail Delegation
+
+This section determines whether users can delegate access to their mailbox to others within the same domain. This delegation includes access to read, send, and delete messages on the account owner's behalf. This delegation can be done via a command line tool (GAM) if enabled in the admin console.
+
+### Policies
+
+#### GWS.GMAIL.1.1v1
+Mail delegation SHOULD be disabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Granting mail delegation can inadvertently lead to disclosure of sensitive information, impersonation of delegated accounts, or malicious alteration or deletion of emails. By controlling mail delegation, these risks can be significantly reduced, improving the security and integrity of email communications.
+- _Last modified:_ October 2023
+- _Note:_ Exceptions should be limited to individuals authorized by existing agency policy, such as Senior Executive Service (SES) or politically appointed staff. Other considerations include ensuring that delegated accounts require phishing-resistant multifactor authentication (MFA), limiting delegated account permissions (e.g. allowing view/reply, prohibiting delete), monitoring delegated accounts regularly, and disabling them if no longer required.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
+    - [T098:002: Account Manipulation: Additional Email Delegate Permissions](https://attack.mitre.org/techniques/T1098/002/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Turn Gmail delegation on or off](https://support.google.com/a/answer/7223765?hl=en)
+-   [GAM: Example Email Settings - Creating a Gmail delegate](https://github.com/GAM-team/GAM/wiki/ExamplesEmailSettings#creating-a-gmail-delegate)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.GMAIL.1.1v1 Instructions
+To configure the settings for Mail Delegation:
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **User Settings -\> Mail delegation**.
+4.  Ensure that the **Let users delegate access to their mailbox to other users in the domain** checkbox is unchecked.
+5.  Select **Save**.
+
+
+## 2. DomainKeys Identified Mail
+
+This section enables DomainKeys Identified Mail (DKIM) to help prevent spoofing of outgoing messages sent from a specific domain. DKIM allows digital signatures to be added to email messages in the message header, providing a layer of both authenticity and integrity to emails. Without DKIM, messages that are sent from a specific domain are more likely to be marked as spam by receiving mail servers. DKIM relies on Domain Name System (DNS) records and its deployment depends on how an agency manages its DNS.
+
+### Policies
+
+#### GWS.GMAIL.2.1v1
+DKIM SHOULD be enabled for all domains.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#dns-configuration)
+
+- _Rationale:_ Enabling DKIM for all domains can help prevent email spoofing and phishing attacks. Without DKIM, threat actors could manipulate email headers to appear as if they are from a legitimate source, potentially leading to the disclosure of sensitive information. By enabling DKIM, the authenticity of emails can be verified, reducing this risk.
+- _Last modified:_ November 2023
+- _Note:_ This policy is not applicable to user alias domains. Emails sent from user alias domains will be signed by a Google-managed DKIM signing domain (gappssmtp.com) even if DKIM is disabled.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-8
+- MITRE ATT&CK TTP Mapping
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+  - [T1434: Internal Spear Phishing](https://attack.mitre.org/techniques/T1434/)
+  - [T1672: Email Spoofing](https://attack.mitre.org/techniques/T1672/)
+
+### Resources
+
+-   [Binding Operational Directive 18-01 - Enhance Email and Web Security \| DHS](https://cyber.dhs.gov/bod/18-01/)
+-   [Trustworthy Email \| NIST 800-177 Rev. 1](https://csrc.nist.gov/publications/detail/sp/800-177/rev-1/final)
+-   [Google Workspace Admin Help: Help prevent spoofing and spam with DKIM](https://support.google.com/a/answer/174124)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.GMAIL.2.1v1 Instructions
+To configure the settings for DKIM:
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **Authenticate email -\> DKIM authentication**.
+4.  Select a domain listed in the **Selected** domain drop-down menu.
+5.  Select **START AUTHENTICATION**.
+6.  Select **Save**.
+7.  Add the DNS TXT record listed in Admin Console to the domain, via the domain provider's DNS settings page. Note that it can take up to 48 hours for DNS changes to fully propagate.
+
+Note that step 7 requires action taken outside of the Google Admin Console, dependent on the agency's domain provider. Thus, the exact final step needed to set up DKIM varies from agency to agency. See [Turn on DKIM for your domain](https://support.google.com/a/answer/180504) for more details.
+
+To test your DKIM configuration, consider using a web-based tool, such as the [Google Admin Toolbox](https://toolbox.googleapps.com/apps/checkmx/).
+
+## 3. Sender Policy Framework
+
+The Sender Policy Framework (SPF) is a mechanism that allows administrators to specify which IP addresses are explicitly approved to send emails on behalf of the domain, facilitating detection of spoofed emails. SPF isn't configured through the Google admin console but rather via DNS records hosted by the agency's domain. The exact steps needed to set up SPF vary from agency to agency. Google's documentation provides helpful starting points.
+
+### Policies
+
+#### GWS.GMAIL.3.1v1
+An SPF policy SHALL be published for each domain that fails all non-approved senders.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#dns-configuration)
+
+- _Rationale:_ Threat actors could potentially manipulate an email "from" field to appear as a legitimate sender, increasing the risk of phishing attacks. By publishing an SPF policy that fails all non-approved senders for each domain, this risk can be reduced as it helps to detect and block deceptive emails. Additionally, an SPF policy is required for FCEB agencies by BOD 18-01.
+- _Last modified:_ February 2024
+- _Note:_
+  - SPF defines two different "fail" mechanisms: fail (indicated by `-`, sometimes referred to as hardfail) and softfail (indicated by `~`). Either hard or soft fail may be used to comply with this baseline policy.
+  - This policy is not applicable to user alias domains. Gmail uses the primary domain as the `envelope-from` domain and the alias domain as the `header-from` domain. SPF only verifies the `envelope-from` domain.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-2d
+- MITRE ATT&CK TTP Mapping
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078:004: Valid Accounts: Cloud Accounts](https://attack.mitre.org/techniques/T1078/004/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+    - [T1566:003: Phishing: Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)
+  - [T1672: Email Spoofing](https://attack.mitre.org/techniques/T1672/)
+  - [T1598: Phishing for Information](https://attack.mitre.org/techniques/T1598/)
+    - [T1598.003: Phishing for Information: Spearphishing Link](https://attack.mitre.org/techniques/T1598/003/)
+
+### Resources
+
+-   [Binding Operational Directive 18-01 - Enhance Email and Web Security \| DHS](https://cyber.dhs.gov/bod/18-01/)
+-   [Trustworthy Email \| NIST 800-177 Rev. 1](https://csrc.nist.gov/publications/detail/sp/800-177/rev-1/final)
+-   [Google Workspace Admin Help: Help prevent spoofing and spam with SPF](https://support.google.com/a/answer/33786#to-do)
+
+### Prerequisites
+-   A list of approved IP addresses for sending mail must be maintained. Failing to maintain an accurate list of authorized IP addresses may result in spoofed email messages or failure to deliver legitimate messages when SPF is enabled. Maintaining a list helps to enable unauthorized servers sending spoofed messages to be detected and permits message delivery from legitimate senders.
+
+### Implementation
+
+#### GWS.GMAIL.3.1v1 Instructions
+First, identify any approved senders specific to your agency (see [Identify all email senders for your organization](https://support.google.com/a/answer/10686639#senders) for tips). SPF allows you to indicate approved senders by IP address or CIDR range. However, note that SPF allows you to [include](https://www.rfc-editor.org/rfc/rfc7208#section-5.2) the IP addresses indicated by a separate SPF policy, refered to by domain name. See [Define your SPF record—Basic setup](https://support.google.com/a/answer/10685031) for inclusions required for Google to send email on behalf of your domain.
+
+SPF is not configured through the Google Workspace admin center, but rather via DNS records hosted by the agency's domain. Thus, the exact steps needed to set up SPF varies from agency to agency. See [Add your SPF record at your domain provider](https://support.google.com/a/answer/10684623) for more details.
+
+To test your SPF configuration, consider using a web-based tool, such as the [Google Admin Toolbox](https://toolbox.googleapps.com/apps/checkmx/).  Additionally, SPF records can be requested using the command line tool `dig`. For example:
+```
+dig example.com txt
+```
+If SPF is configured, a response resembling `v=spf1 include:_spf.google.com -all` will be returned; though by necessity, the contents of the SPF policy may vary by agency. In this example, the SPF policy indicates the IP addresses listed by the policy for "_spf.google.com" are the only approved senders for "example.com." These IPs can be determined via additional SPF lookups, starting with "_spf.google.com."
+
+Ensure the IP addresses listed as approved senders for your domains are correct. Additionally, ensure that each policy either ends in `-all` or [redirects](https://www.rfc-editor.org/rfc/rfc7208#section-6.1) to one that does; this directive indicates that all IPs that don't match the policy should fail. See [Define your SPF record—Advanced setup](https://support.google.com/a/answer/10683907) for a more in-depth discussion of SPF record syntax.
+
+## 4. Domain-based Message Authentication, Reporting, and Conformance
+
+
+Domain-based Message Authentication, Reporting, and Conformance (DMARC) works with SPF and DKIM to authenticate mail senders and ensure that destination email systems can validate messages sent from your domain. DMARC helps receiving mail systems determine what to do with messages sent from your domain that fail SPF or DKIM checks.
+
+### Policies
+
+#### GWS.GMAIL.4.1v1
+A DMARC policy SHALL be published at the full domain or the second-level domain for all Google Workspace domains, including user alias domains.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#dns-configuration)
+
+- _Rationale:_ Without proper authentication and a DMARC policy available for each domain, recipients may improperly handle SPF and DKIM failures, possibly enabling threat actors to send deceptive emails that appear to be from your domain. Publishing a DMARC policy for every domain further reduces the risk posed by authentication failures.
+- _Last modified:_ September 2025
+- _Note:_
+  - A DMARC record published at the second-level domain applies to all subdomains by default. In other words, a DMARC record published for `example.com` will protect both `a.example.com` and `b.example.com`, but a separate record would need to be published for `c.example.gov`. In this example `a.example.com` is the full domain, or fully qualified domain name (FQDN), whereas `example.com` is the second-level domain.
+  - User alias domains provide an alternative email address to send or receive email and therefore must have a DMARC policy in place.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1672: Email Spoofing](https://attack.mitre.org/techniques/T1672/)
+  - [T1598: Phishing for Information](https://attack.mitre.org/techniques/T1598/)
+    - [T1598.003: Phishing for Information: Spearphishing Link](https://attack.mitre.org/techniques/T1598/003/)
+
+#### GWS.GMAIL.4.2v1
+The DMARC message rejection option SHALL be p=reject.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#dns-configuration)
+
+- _Rationale:_ Without stringent email authentication, threat actors could potentially send deceptive emails that appear to be from the organization's domain, increasing the risk of phishing attacks. This policy reduces risk as it automatically rejects emails that fail SPF or DKIM checks, preventing potentially harmful emails from reaching recipients. Additionally, "reject" is the level of protection required by BOD 18-01 for federal civilian executive branch (FCEB) agencies.
+- _Last modified:_ November 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+    - [T1566:003: Phishing: Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)
+  - [T1586: Compromise Accounts](https://attack.mitre.org/techniques/T1586/)
+    - [T1586:002: Compromise Accounts: Email Accounts](https://attack.mitre.org/techniques/T1586/002/)
+  - [T1672: Email Spoofing](https://attack.mitre.org/techniques/T1672/)
+
+#### GWS.GMAIL.4.3v1
+The DMARC point of contact for aggregate reports SHALL include `reports@dmarc.cyber.dhs.gov`.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#dns-configuration)
+
+- _Rationale:_ Without a centralized point of contact for DMARC aggregate reports, potential email security issues may go unnoticed, increasing the risk of phishing attacks. As required by BOD 18-01, FCEB users should set reports@dmarc.cyber.dhs.gov as the DMARC aggregate report recipient. This allows CISA to monitor and address email authentication issues.
+- _Last modified:_ November 2023
+- _Note:_ Only FCEB agencies should include this email address in their DMARC record.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-4(5)
+- MITRE ATT&CK TTP Mapping
+  - None
+
+#### GWS.GMAIL.4.4v1
+An agency point of contact SHOULD be included for aggregate and failure reports.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#dns-configuration)
+
+- _Rationale:_ Without a designated agency point of contact for DMARC aggregate and failure reports, potential email security issues may not be promptly addressed, increasing the risk of phishing attacks. This risk can be reduced by including an agency point of contact, facilitating timely response to email authentication issues and enhancing overall email security.
+- _Last modified:_ November 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-4(5)
+- MITRE ATT&CK TTP Mapping
+  - None
+
+### Resources
+
+-   [Binding Operational Directive 18-01 - Enhance Email and Web Security \| DHS](https://cyber.dhs.gov/bod/18-01/)
+-   [Trustworthy Email \| NIST 800-177 Rev. 1](https://csrc.nist.gov/publications/detail/sp/800-177/rev-1/final)
+-   [Domain-based Message Authentication, Reporting, and Conformance (DMARC) \| RFC 7489](https://datatracker.ietf.org/doc/html/rfc7489)
+-   [Google Workspace Admin Help: Help prevent spoofing and spam with DMARC](https://support.google.com/a/answer/2466580)
+
+### Prerequisites
+
+-   DKIM or SPF must be enabled
+
+### Implementation
+
+[//]: # (Keep the version suffix out of the anchor.)
+[//]: # (https://stackoverflow.com/questions/5319754/cross-reference-named-anchor-in-markdown)
+<a name="gmail41-instructions"></a>
+#### GWS.GMAIL.4.1v1 Instructions
+DMARC is not configured through the Google Admin Console, but rather via DNS records hosted by the agency's domain(s). As such, implementation varies depending on how an agency manages its DNS records. See [Add your DMARC record](https://support.google.com/a/answer/2466563) for Google guidance.
+
+To test your DMARC configuration, consider using one of many publicly available web-based tools, such as the [Google Admin Toolbox](https://toolbox.googleapps.com/apps/checkmx/). Additionally, DMARC records can be requested using the command line tool `dig`. For example:
+
+```
+dig _dmarc.example.com txt
+```
+
+If DMARC is configured, a response resembling `v=DMARC1; p=reject; pct=100; rua=mailto:reports@dmarc.cyber.dhs.gov, mailto:reports@example.com; ruf=mailto:reports@example.com` will be returned, though by necessity, the contents of the record will vary by agency. In this example, the policy indicates all emails failing the SPF/DKIM checks are to be rejected and aggregate reports sent to reports@dmarc.cyber.dhs.gov and reports@example.com. Failure reports will be sent to reports@example.com.
+
+#### GWS.GMAIL.4.2v1 Instructions
+See [GWS.GMAIL.4.1 instructions](#gmail41-instructions) for an overview of how to publish and check a DMARC record. Ensure the record published includes `p=reject`.
+
+#### GWS.GMAIL.4.3v1 Instructions
+See [GWS.GMAIL.4.1 instructions](#gmail41-instructions) for an overview of how to publish and check a DMARC record. Ensure the record published includes reports@dmarc.cyber.dhs.gov as one of the emails for the `rua` field.
+
+#### GWS.GMAIL.4.4v1 Instructions
+See [GWS.GMAIL.4.1 instructions](#gmail41-instructions) for an overview of how to publish and check a DMARC record. Ensure the record published includes a point of contact specific to your agency, in addition to reports@dmarc.cyber.dhs.gov, as one of the emails for the `rua` field and one or more agency-defined points of contact for the `ruf` field.
+
+## 5. Attachment Protections
+
+This section enables protections against suspicious attachments and scripts from untrusted senders, including encrypted attachments, documents with malicious scripts, and attachment file types that are uncommon and/or archaic. Malware can be spread through these attachments. These messages can be kept in the inbox with a warning label (default), moved to spam, or quarantined.
+
+A Google Workspace solution is not strictly required to satisfy this baseline control, but the solution selected by an agency should offer services comparable to those offered by Google.
+
+### Policies
+
+#### GWS.GMAIL.5.1v1
+"Protect against encrypted attachments from untrusted senders" SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Attachments from untrusted senders, especially encrypted ones, may contain malicious content that poses a security risk. By enabling protection against encrypted attachments from untrusted senders, this risk can be reduced, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3, SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+    - [T1566:003: Phishing: Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)
+  - [T1204: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204:001: User Execution: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+    - [T1204:002: User Execution: Malicious File](https://attack.mitre.org/techniques/T1204/002/)
+    - [T1204:003: User Execution: Malicious Image](https://attack.mitre.org/techniques/T1204/003/)
+
+#### GWS.GMAIL.5.2v1
+"Protect against attachments with scripts from untrusted senders" SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Attachments with scripts from untrusted senders may contain malicious content that poses a security risk. By enabling protection against such attachments, this risk can be reduced, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3, SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+    - [T1566:003: Phishing: Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)
+  - [T1204: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204:001: User Execution: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+    - [T1204:002: User Execution: Malicious File](https://attack.mitre.org/techniques/T1204/002/)
+    - [T1204:003: User Execution: Malicious Image](https://attack.mitre.org/techniques/T1204/003/)
+
+#### GWS.GMAIL.5.3v1
+"Protect against anomalous attachment types in emails" SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Anomalous attachment types in emails may contain malicious content that poses a security risk. By enabling protection against such attachments, this risk can be reduced, enhancing the safety and integrity of the user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3, SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+    - [T1566:003: Phishing: Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)
+  - [T1204: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204:001: User Execution: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+    - [T1204:002: User Execution: Malicious File](https://attack.mitre.org/techniques/T1204/002/)
+    - [T1204:003: User Execution: Malicious Image](https://attack.mitre.org/techniques/T1204/003/)
+
+#### GWS.GMAIL.5.4v1
+Google SHOULD be allowed to automatically apply future recommended settings for attachments.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ By enabling this feature, the system can automatically stay updated with the latest security measures recommended by Google, reducing the risk of security breaches.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3, SI-8
+- MITRE ATT&CK TTP Mapping
+  - None
+
+#### GWS.GMAIL.5.5v1
+Emails flagged by SCuBA policies GWS.GMAIL.5.1 through GWS.GMAIL.5.3 SHALL NOT be kept in inbox.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Keeping emails flagged by attachment protection controls in the inbox could potentially expose users to malicious content. Removing these emails from the inbox enhances the safety and integrity of user data and systems.
+- _Last modified:_ September 2023
+- _Note:_ Agencies/organizations can choose whether to send these emails to spam or quarantine.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3, SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+    - [T1566:003: Phishing: Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)
+  - [T1204: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204:001: User Execution: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+    - [T1204:002: User Execution: Malicious File](https://attack.mitre.org/techniques/T1204/002/)
+    - [T1204:003: User Execution: Malicious Image](https://attack.mitre.org/techniques/T1204/003/)
+
+
+### Resources
+
+-   [Google Workspace Admin Help: Advanced phishing and malware protection](https://support.google.com/a/answer/9157861?product_name=UnuFlow&hl=en&visit_id=637831282628458101-2078141803&rd=1&src=supportwidget0&hl=en#zippy=%2Cturn-on-attachment-protection)
+
+### Prerequisites
+
+-   N/A
+
+### Implementation
+
+To configure the settings for Attachment Protections:
+
+#### Policies Group 5 common Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **Safety -\> Attachments**.
+4.  Follow implementation for each individual policy
+5.  Select **Save**.
+
+#### GWS.GMAIL.5.1v1 Instructions
+1.  Check the **Protect against encrypted attachments from untrusted senders** checkbox.
+
+#### GWS.GMAIL.5.2v1 Instructions
+1.  Check the **Protect against attachments with scripts from untrusted senders** checkbox.
+
+#### GWS.GMAIL.5.3v1 Instructions
+1.  Check the **Protect against anomalous attachment types in emails** checkbox.
+
+#### GWS.GMAIL.5.4v1 Instructions
+1.  Check the **Apply future recommended settings automatically** checkbox.
+
+#### GWS.GMAIL.5.5v1 Instructions
+1.  Under the setting for Policy 5.1 through Policy 5.3, ensure either "Move email to spam" or "Quarantine" is selected.
+
+
+## 6. Links and External Images Protection
+
+This section enables extra protections to prevent email phishing due to links and external images. Specific settings for this control include identifying hidden malicious links behind shortened URLs, scanning linked images to find hidden malicious content, showing a warning prompt when clicking links to untrusted domains, and applying future recommended settings automatically.
+
+A Google Workspace solution is not strictly required to satisfy this baseline control, but the solution selected by an agency should offer services comparable to those offered by Google.
+
+### Policies
+
+#### GWS.GMAIL.6.1v1
+"Identify links behind shortened URLs" SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Shortened URLs can hide malicious links, posing a security risk. This risk can be reduced by identifying links behind shortened URLs, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3, SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1434: Internal Spearphishing](https://attack.mitre.org/techniques/T1434/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+  - [T1204: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204:001: User Execution: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+
+#### GWS.GMAIL.6.2v1
+"Scan linked images" SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Linked images in emails can contain malicious content, posing a security risk. By enabling the scanning of linked images, this risk can be reduced, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3, SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1434: Internal Spearphishing](https://attack.mitre.org/techniques/T1434/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+  - [T1204: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204:002: User Execution: Malicious File](https://attack.mitre.org/techniques/T1204/002/)
+
+#### GWS.GMAIL.6.3v1
+"Show warning prompt for any click on links to untrusted domains" SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Clicking on links to unfamiliar domains can expose users to malicious content, posing a security risk. This risk can be reduced by enabling a warning prompt for any click on such links, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-4, SI-8, AT-2b
+- MITRE ATT&CK TTP Mapping
+  - [T1434: Internal Spearphishing](https://attack.mitre.org/techniques/T1434/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+  - [T1204: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204:001: User Execution: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+
+#### GWS.GMAIL.6.4v1
+Google SHALL be allowed to automatically apply future recommended settings for links and external images.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ By enabling this feature, the system can automatically stay updated with the latest recommended security measures from Google, reducing the risk of security breaches and enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3, SI-8
+- MITRE ATT&CK TTP Mapping
+  - None
+
+
+### Resources
+
+-   [Google Workspace Admin Help: Advanced phishing and malware protection](https://support.google.com/a/answer/9157861?product_name=UnuFlow&hl=en&visit_id=637831282628458101-2078141803&rd=1&src=supportwidget0&hl=en#zippy=%2Cturn-on-attachment-protection)
+-   [Google Workspace Admin Help: Set up rules to detect harmful attachments](https://support.google.com/a/answer/7676854?product_name=UnuFlow&hl=en&visit_id=637831464632988595-2408633144&rd=1&src=supportwidget0&hl=en)
+-   [Google Workspace Admin Help: Monitor the health of your Gmail settings](https://support.google.com/a/answer/7490901?product_name=UnuFlow&hl=en&visit_id=637831464698491311-452219641&rd=1&src=supportwidget0&hl=en)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   N/A
+
+### Implementation
+
+To configure the settings for Links and External Images Protection:
+
+#### Policies Group 6 common Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **Safety -\> Links and external images**.
+4.  Follow implementation for each individual policy.
+5.  Select **Save**
+
+#### GWS.GMAIL.6.1v1 Instructions
+1.  Check the **Identify links behind shortened URLs** checkbox.
+
+#### GWS.GMAIL.6.2v1 Instructions
+1.  Check the **Scan linked images** checkbox.
+
+#### GWS.GMAIL.6.3v1 Instructions
+1.  Check the **Show warning prompt for any click on links to untrusted domains** checkbox.
+
+#### GWS.GMAIL.6.4v1 Instructions
+1.  Check the **Apply future recommended settings automatically** checkbox.
+
+
+## 7. Spoofing and Authentication Protection
+
+This control enables extra protections to prevent spoofing of a domain name, employee names, email pretending to be from a specific domain, and unauthenticated email from any domain. These messages can be kept in the inbox with a warning label (default), moved to spam, or quarantined.
+
+A Google Workspace solution is not strictly required to satisfy this baseline control, but the solution selected by an agency should offer services comparable to those offered by Google.
+
+### Policies
+
+#### GWS.GMAIL.7.1v1
+"Protect against domain spoofing based on similar domain names" SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Emails sent from domains that look similar to the user's domain can deceive users into interacting with malicious content, posing a security risk. Enabling protection against such spoofing can reduce this risk, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1434: Internal Spearphishing](https://attack.mitre.org/techniques/T1434/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+#### GWS.GMAIL.7.2v1
+"Protect against spoofing of employee names" SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Spoofing of employee identities (e.g., CEO and IT staff) can deceive users into interacting with malicious content, posing a security risk. Enabling protection against such spoofing can reduce this risk, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1434: Internal Spearphishing](https://attack.mitre.org/techniques/T1434/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+#### GWS.GMAIL.7.3v1
+"Protect against inbound emails spoofing your domain" SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Inbound emails appearing to come from the user's domain can deceive users into interacting with malicious content, posing a security risk. This risk can be reduced by enabling protection against such spoofing, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1434: Internal Spearphishing](https://attack.mitre.org/techniques/T1434/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+#### GWS.GMAIL.7.4v1
+"Protect against any unauthenticated emails" SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Unauthenticated emails can contain malicious content, posing a security risk. This risk can be reduced by enabling protection against such emails, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1434: Internal Spearphishing](https://attack.mitre.org/techniques/T1434/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+#### GWS.GMAIL.7.5v1
+"Protect your Groups from inbound emails spoofing your domain" SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Inbound emails spoofing the user's domain can deceive users into interacting with malicious content, posing a security risk. This risk can be reduced by enabling protection against such spoofing, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1434: Internal Spearphishing](https://attack.mitre.org/techniques/T1434/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+#### GWS.GMAIL.7.6v1
+Emails flagged by SCuBA policies GWS.GMAIL.7.1 through GWS.GMAIL.7.5 SHALL NOT be kept in inbox.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Retaining emails flagged by spoofing and authentication controls in the inbox could potentially expose users to malicious content. Moving emails out of the main inbox, to either spam or quarantine, can reduce this risk, enhancing the safety and integrity of the user's data and systems.
+- _Last modified:_ September 2023
+- _Note:_ Agencies/organizations can choose whether to send the emails to spam or quarantine.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1434: Internal Spearphishing](https://attack.mitre.org/techniques/T1434/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+
+#### GWS.GMAIL.7.7v1
+Google SHALL be allowed to automatically apply future recommended settings for spoofing and authentication.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ By enabling this feature, the system can automatically stay updated with the latest Google recommended security measures, reducing the risk of security breaches and enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1434: Internal Spearphishing](https://attack.mitre.org/techniques/T1434/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Advanced phishing and malware protection](https://support.google.com/a/answer/9157861?product_name=UnuFlow&hl=en&visit_id=637831282628458101-2078141803&rd=1&src=supportwidget0&hl=en#zippy=%2Cturn-on-attachment-protection)
+
+### Prerequisites
+
+-   N/A
+
+### Implementation
+
+To configure the settings for Spoofing and Authentication Protection:
+
+#### Policies Group 7 common Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **Safety -\> Spoofing and authentication**.
+4.  Follow steps for individual policies below.
+5.  Select **Save**
+
+#### GWS.GMAIL.7.1v1 Instructions
+1.  Check the **Protect against domain spoofing based on similar domain names** checkbox.
+
+#### GWS.GMAIL.7.2v1 Instructions
+1.  Check the **Protect against spoofing of employee names** checkbox.
+
+#### GWS.GMAIL.7.3v1 Instructions
+1.  Check the **Protect against inbound emails spoofing your domain** checkbox.
+
+#### GWS.GMAIL.7.4v1 Instructions
+1.  Check the **Protect against any unauthenticated emails** checkbox.
+
+#### GWS.GMAIL.7.5v1 Instructions
+1.  Check the **Protect your groups from inbound emails spoofing your domain** checkbox.
+
+#### GWS.GMAIL.7.6v1 Instructions
+1.  Under each setting from Policy 7.1 through Policy 7.5, make sure either "Move email to spam" or "Quarantine" is selected.
+
+#### GWS.GMAIL.7.7v1 Instructions
+1.  Check the **Apply future recommended settings automatically** checkbox.
+
+
+## 8. User Email Uploads
+
+This section addresses a feature that enables users to import their email and contacts from non-Google webmail accounts such as Yahoo!, Hotmail, or AOL.
+
+### Policies
+
+#### GWS.GMAIL.8.1v1
+User email uploads SHALL be disabled to protect against unauthorized files being introduced into the secured environment.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Allowing user email uploads could potentially introduce unauthorized or malicious files into the secured environment, posing a security risk. By disabling user email uploads, this risk can be reduced, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7, SI-3, SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1199: Trusted Relationship](https://attack.mitre.org/techniques/T1199/)
+  - [T1204: User Execution](https://attack.mitre.org/techniques/T1204/)
+    - [T1204:001: User Execution: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+    - [T1204:002: User Execution: Malicious File](https://attack.mitre.org/techniques/T1204/002/)
+    - [T1204:003: User Execution: Malicious Image](https://attack.mitre.org/techniques/T1204/003/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Advanced Gmail settings reference for admins](https://support.google.com/a/answer/2786758#zippy=%2Csetup-settings)
+-   [Google Workspace Admin Help: Turn imports from webmail hosts on or off](https://support.google.com/a/answer/2525613?product_name=UnuFlow&hl=en&visit_id=637832286168108072-385761693&rd=1&src=supportwidget0&hl=en)
+
+### Prerequisites
+
+-   N/A
+
+### Implementation
+
+To configure the settings for User Email Uploads:
+
+#### GWS.GMAIL.8.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **Setup -\> User email uploads**.
+4.  Uncheck the **Show users the option to import mail and contacts from Yahoo!, Hotmail, AOL, or other webmail or POP3 accounts from the Gmail settings page** checkbox.
+5.  Select **Save**.
+
+
+## 9. POP and IMAP Access for Users
+
+This section determines whether users have POP3 and IMAP access. Granting POP3 or IMAP access allows the user to access Gmail emails from outside of protected/hardened environments and from older versions of Gmail applications or other third-party mail applications.
+
+### Policies
+
+#### GWS.GMAIL.9.1v1
+POP and IMAP access SHALL be disabled to protect sensitive agency or organization emails from being accessed through legacy applications or other third-party mail clients.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#imap-exclusions)
+
+- _Rationale:_ Enabling POP and IMAP access could potentially expose sensitive agency or organization emails to unauthorized access through legacy applications or third-party mail clients, posing a security risk. This risk can be reduced by disabling POP and IMAP access, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ October 2025
+- _Note:_ IMAP access MAY be enabled on a per-OU or per-group basis when there is a specific need, e.g., to support users that require specialized software for accessibility purposes.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+    - [T1048:002: Exfiltration Over Alternative Protocol: Exfiltration Over Asymmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/002/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Turn POP and IMAP on and off for users](https://support.google.com/a/answer/105694?hl=en)
+
+### Prerequisites
+
+-   N/A
+
+### Implementation
+
+To configure the settings for POP and IMAP access:
+
+
+#### GWS.GMAIL.9.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **End User Access -\> POP and IMAP access**.
+4.  Uncheck the **Enable IMAP access for all users** checkbox.
+5.  Uncheck the **Enable POP access for all users** checkbox.
+6.  Select **Save**.
+
+
+## 10. Google Workspace Sync
+
+This section determines whether Google Workspace Sync allows data synchronization between Google Workspace and Microsoft Outlook. The data includes email, calendar, and contacts. Data synchronizes each time users start Outlook. This is an additional plugin that must be downloaded.
+
+### Policies
+
+#### GWS.GMAIL.10.1v1
+Google Workspace Sync SHOULD be disabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Enabling Google Workspace Sync could potentially expose sensitive agency or organization data to unauthorized access or loss, posing a security risk. This risk can be reduced by disabling Google Workspace Sync, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ April 2025
+- _Note:_ Google Workspace Sync MAY be enabled on a per-user basis as needed.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+    - [T1048:001: Exfiltration Over Alternative Protocol: Exfiltration Over Symmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/001/)
+    - [T1048:002: Exfiltration Over Alternative Protocol: Exfiltration Over Asymmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/002/)
+    - [T1048:003: Exfiltration Over Alternative Protocol: Exfiltration Over Unencrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/003/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1199: Trusted Relationship](https://attack.mitre.org/techniques/T1199/)
+
+### Resources
+
+-   [Google Workspace Sync for Microsoft Outlook](https://tools.google.com/dlpage/gssmo)
+
+### Prerequisites
+
+-   N/A
+
+### Implementation
+
+To configure the settings for Google Workspace Sync:
+
+#### GWS.GMAIL.10.1v1 Instructions
+1.  Sign in to the [Google Admin console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **End User Access -\> Google Workspace Sync**.
+4.  Uncheck the **Enable Google Workspace Sync for Microsoft Outlook for my users** checkbox.
+5.  Select **Save**.
+
+
+## 11. Automatic Forwarding
+
+This section determines whether emails can be automatically forwarded from a user's inbox to another of their choosing, possibly to external domains.
+
+### Policies
+
+#### GWS.GMAIL.11.1v1
+Automatic forwarding SHOULD be disabled, especially to external domains.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ By enabling automatic forwarding, especially to external domains, threat actors could gain persistent access to a victim's email, potentially exposing sensitive agency or organization emails to unauthorized access or loss. This risk can be reduced by disabling automatic forwarding, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-4
+- MITRE ATT&CK TTP Mapping
+  - [T1114: Email Collection](https://attack.mitre.org/techniques/T1114/)
+    - [T1114:003: Email Collection: Email Forwarding Rule](https://attack.mitre.org/techniques/T1114/003/)
+
+### Resources
+-   [Google Workspace Admin Help: Disable automatic forwarding](https://support.google.com/a/answer/2491924?hl=en)
+
+### Prerequisites
+
+-   N/A
+
+### Implementation
+
+To configure the settings for Automatic Forwarding:
+
+#### GWS.GMAIL.11.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **End User Access -\> Automatic forwarding**.
+4.  Uncheck the **Allow users to automatically forward incoming email to another address** checkbox.
+5.  Select **Save**.
+
+## 12. Per-user Outbound Gateways
+
+This section determines whether outgoing mail is delivered only through Google Workspace mail servers or through another specified external SMTP server. With this setting, a user can choose which email address displays in the "From" field.
+
+### Policies
+
+#### GWS.GMAIL.12.1v1
+The option to use a per-user outbound gateway that is a mail server other than the Google Workspace (GWS) mail servers SHALL be disabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Using a per-user outbound gateway that is a mail server other than the GWS mail servers could potentially expose sensitive agency or organization emails to unauthorized access or loss, posing a security risk. Disabling this feature can reduce the risk, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-4
+- MITRE ATT&CK TTP Mapping
+  - [T1114: Email Collection](https://attack.mitre.org/techniques/T1114/)
+    - [T1114:002: Email Collection: Remote Email Collection](https://attack.mitre.org/techniques/T1114/002/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+    - [T1204:001: User Execution: Malicious Link](https://attack.mitre.org/techniques/T1204/001/)
+    - [T1204:002: User Execution: Malicious File](https://attack.mitre.org/techniques/T1204/002)
+
+### Resources
+
+-   [Google Workspace Admin Help: Allow per-user outbound gateways](https://support.google.com/a/answer/176054?hl=en#zippy=%2Cwhy-youd-disallow-use-of-an-outbound-gateway%2Cwhy-youd-allow-use-of-an-outbound-gateway)
+
+### Prerequisites
+
+-   N/A
+
+### Implementation
+
+To configure the settings for Per-user Outbound Gateways:
+
+#### GWS.GMAIL.12.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **End User Access -\> Allow per-user outbound gateways**.
+4.  Uncheck the **Allow users to send mail through an external SMTP server when configuring a "from" address hosted outside your email domain** checkbox.
+5.  Select **Save**.
+
+
+## 13. Unintended External Reply Warning
+
+This section determines whether users are prompted with a warning for messages that include external recipients (users with email addresses that are outside of the organization). However, the warning is not shown if the external recipient is in the organization's directory, personal contacts, or other contacts, or if a secondary domain or domain alias address is used.
+
+### Policies
+
+#### GWS.GMAIL.13.1v1
+Unintended external reply warnings SHALL be enabled.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)
+
+- _Rationale:_ Unintended external reply warnings can help reduce the risk of exposing sensitive information in replies to external messages. Enabling these warnings reminds users to treat external messages with caution, reducing this risk and enhancing the safety and integrity of user data and systems.
+- _Last modified:_ June 2024
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AT-2b
+- MITRE ATT&CK TTP Mapping
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+    - [T1566:003: Phishing: Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Control Gmail external recipient warnings](https://support.google.com/a/answer/7380041?amp;ref_topic=9974443&product_name=UnuFlow&hl=en&ref_topic=9974443&visit_id=637832389706060412-548862041&rd=1&src=supportwidget0&hl=en)
+-   [Capacity Enhancement Guide Counter-Phishing Recommendations for Federal Agencies \| CISA](https://www.cisa.gov/sites/default/files/publications/Capacity_Enhancement_Guide-Counter-Phishing_Recommendations_for_Federal_Agencies.pdf)
+-   [Actions to Counter Email-Based Attacks on Election-Related Entities \| CISA](https://www.cisa.gov/sites/default/files/publications/CISA_Insights_Actions_to_Counter_Email-Based_Attacks_on_Election-Related_S508C.pdf)
+
+### Prerequisites
+
+-   N/A
+
+### Implementation
+
+To configure the settings to warn users of external recipients:
+
+#### GWS.GMAIL.13.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **End User Access -\> Warn for external recipients**.
+4.  Check the **Highlight any external recipients in a conversation. Warn users before they reply to email with external recipients who aren't in their contacts** checkbox.
+5.  Select **Save**.
+
+
+## 14. Email Allowlist
+
+This section determines whether an email allowlist allows Gmail to avoid marking messages from certain IP addresses as spam. If implemented, emails from these senders will bypass important security mechanisms, such as SPF, DKIM, and DMARC.
+
+### Policies
+
+#### GWS.GMAIL.14.1v1
+An email allowlist SHOULD NOT be implemented.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Implementing an email allowlist could potentially expose users to security risks as allowlisted senders bypass important security mechanisms, including spam filtering and sender authentication checks. This risk can be reduced by not implementing an allowlist, enhancing the safety and integrity of the user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-4
+- MITRE ATT&CK TTP Mapping
+  - [T1562: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562:001: Impair Defenses: Disable or Modify Tools](https://attack.mitre.org/techniques/T1562/001/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+    - [T1566:003: Phishing: Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Add IP addresses to allowlists in Gmail](https://support.google.com/a/answer/60751?product_name=UnuFlow&hl=en&visit_id=637832433423162856-2822445044&rd=1&src=supportwidget0&hl=en)
+
+### Prerequisites
+
+-   N/A
+
+### Implementation
+
+To configure the settings for Email Allowlists:
+
+#### GWS.GMAIL.14.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **Spam, phishing, and malware -\> Email allowlist**.
+4.  Under the **Enter the IP addresses for your email allowlist** field, ensure **no IP addresses** are listed.
+5.  Select **Save**.
+
+
+## 15. Enhanced Pre-Delivery Message Scanning
+
+This section determines whether Gmail can screen and identify suspicious content that may be phishing attempts. In doing so, Google can either show a warning or move the email to spam. Email delivery will experience a short delay due to the additional checks.
+
+A Google Workspace solution is not strictly required to satisfy this baseline control, but the solution selected by an agency should offer services comparable to those offered by Google.
+
+### Policies
+
+#### GWS.GMAIL.15.1v1
+Enhanced pre-delivery message scanning SHALL be enabled to prevent phishing.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Without enhanced pre-delivery message scanning, users may be exposed to phishing attempts, posing a security risk. By enabling this feature, potential phishing emails can be identified and blocked before reaching the user, reducing the risk and enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3, SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+    - [T1566:003: Phishing: Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)
+
+
+### Resources
+
+-   [Google Workspace Admin Help: Help prevent phishing with pre-delivery message scanning](https://support.google.com/a/answer/7380368?product_name=UnuFlow&hl=en&visit_id=637835839970922069-4253681586&rd=1&src=supportwidget0&hl=en)
+
+### Prerequisites
+
+-   N/A
+
+### Implementation
+
+To configure the settings for Enhanced Pre-Delivery Message Scanning:
+
+#### GWS.GMAIL.15.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **Spam, phishing, and malware -\> Enhanced pre-delivery message scanning**.
+4.  Check the **Enables improved detection of suspicious content prior to delivery** checkbox.
+5.  Select **Save**.
+
+
+## 16. Security Sandbox
+
+This section determines whether certain messages and their associated attachments are executed in a sandbox environment for protection against malware, ransomware, and zero-day threats. Malicious software may be missed by traditional antivirus programs. However, this may cause some messages to get delayed before final delivery. Some of the file types scanned include Microsoft executables, Microsoft Office, PDF, and archives (zip, rar).
+
+A Google Workspace solution is not strictly required to satisfy this baseline control, but the solution selected by an agency should offer services comparable to those offered by Google.
+
+### Policies
+
+#### GWS.GMAIL.16.1v1
+Security sandbox SHOULD be enabled to provide additional email protections.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)
+
+- _Rationale:_ Without a security sandbox, emails with malicious content could potentially interact directly with the users' systems, posing a security risk. By enabling the security sandbox, additional protections are provided for email messages, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-3, SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+
+
+### Resources
+
+-   [Google Workspace Admin Help: Set up rules to detect harmful attachments](https://support.google.com/a/answer/7676854?amp;visit_id=637866938191629894-2885947509&amp;rd=1&product_name=UnuFlow&hl=en&visit_id=637866938191629894-2885947509&rd=2&src=supportwidget0&hl=en)
+
+### Prerequisites
+
+-   N/A
+
+### Implementation
+
+To configure the settings for Security sandbox or Security sandbox rules:
+
+#### GWS.GMAIL.16.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **Spam, phishing, and malware -\> Security sandbox**.
+4.  Check the **Enable virtual execution of attachments in a sandbox environment for all the users of the Organizational Unit for protection against malware, ransomware, and zero-day threats** checkbox.
+5.  Either **Security sandbox** or **Security sandbox rules** may be enabled but enabling **Security sandbox** takes precedence.
+6.  If **Security sandbox** rules are enabled, then the configuration needs to be completed and consists of the following fields **:**
+    1. A short description.
+    2. Email messages to affect.
+    3. Expressions to describe the content to search for in each message.
+    4. Action to take if expressions match.
+7. Select **Save**.
+
+
+## 17. Comprehensive Mail Storage
+
+This section allows for email messages sent through other Google Workspace applications (i.e., Calendar, Drive, Docs, Sheets, Slides, Drawings, Forms, and Keep) to be stored in the associated users' Gmail mailboxes. This includes a copy of all sent or received messages within a specified domain (including messages sent or received by non-Gmail mailboxes).
+
+### Policies
+
+#### GWS.GMAIL.17.1v1
+Comprehensive mail storage SHOULD be enabled to allow information traceability across applications.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwsgmail171v06-instructions)
+
+- _Rationale:_ The absence of comprehensive mail storage could compromise the ability for information traceability across applications, posing a security risk. Enabling comprehensive mail storage can reduce this risk, enhancing the safety and integrity of user data and systems.
+- _Last modified:_ November 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-12, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - None
+
+### Resources
+
+-   [Google Workspace Admin Help: Set up comprehensive mail storage](https://support.google.com/a/answer/3547347?product_name=UnuFlow&hl=en&visit_id=637835896823763789-338955802&rd=1&src=supportwidget0&hl=en)
+
+### Prerequisites
+
+-   N/A
+
+### Implementation
+
+To configure the settings for Comprehensive Mail Storage:
+
+#### GWS.GMAIL.17.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **Compliance -\> Comprehensive mail storage**.
+4.  Check the **Ensure that a copy of all sent and received mail is stored in associated users' mailboxes** checkbox.
+5.  Select **Save**.
+
+
+## 18. Spam Filtering
+
+This section covers the settings relating to bypassing spam filters.
+
+### Policies
+
+#### GWS.GMAIL.18.1v1
+Domains SHALL NOT be added to lists that bypass spam filters.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+- _Rationale:_ Spam protections may incorrectly filter legitimate emails. Adding allowed senders is an acceptable method of combating these false positives. Allowing an entire domain, especially a common domain like office.com, could enable numerous unknown users to bypass spam protections.
+- _Last modified:_ April 2024
+- _Note:_ Allowed senders MAY be added.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+  - [T1534: Internal Spearphishing](https://attack.mitre.org/techniques/T1534/)
+
+#### GWS.GMAIL.18.2v1
+Domains SHALL NOT be added to lists that bypass spam filters and hide warnings.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Spam protections may incorrectly filter legitimate emails. Adding allowed senders is an acceptable method of combating these false positives. Allowing an entire domain, especially a common domain like office.com, could enable numerous unknown users to bypass spam protections.
+- _Last modified:_ April 2024
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+  - [T1534: Internal Spearphishing](https://attack.mitre.org/techniques/T1534/)
+
+#### GWS.GMAIL.18.3v1
+"Bypass spam filters" and "hide warnings for all messages from internal and external senders" SHALL NOT be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+
+- _Rationale:_ Bypassing spam filters and hiding warnings for all messages from internal and external senders creates a security risk by allowing all messages to bypass filters. Disabling this feature mitigates the risk.
+- _Last modified:_ April 2024
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SI-8
+- MITRE ATT&CK TTP Mapping
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Phishing: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+  - [T1534: Internal Spearphishing](https://attack.mitre.org/techniques/T1534/)
+
+### Resources
+
+-   [How to bypass the spam filter for incoming emails using the spam settings ](https://knowledge.workspace.google.com/kb/how-to-bypass-the-spam-filter-for-incoming-emails-000006661)
+
+### Prerequisites
+
+-   N/A
+
+### Implementation
+
+To configure the settings for spam filtering:
+
+#### Policy Group 18 Common Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps -\> Google Workspace -\> Gmail**.
+3.  Select **Spam, Phishing, and Malware**.
+
+#### GWS.GMAIL.18.1v1 Instructions
+For each rule listed under **Spam**:
+1. Ensure that either:
+    * **Bypass spam filters for messages from senders or domains in selected lists** is not selected, or
+    * None of the lists shown under **Bypass spam filters for messages from senders or domains in selected lists** contain an entire domain. For example, the entire domain "example.com" is not acceptable, but the specific address, john.doe@example.com, would be.
+2. Modify the rule or lists associated with the rule as needed, then select **Save.**
+
+#### GWS.GMAIL.18.2v1 Instructions
+For each rule listed under **Spam**:
+1. Ensure that either:
+    * **Bypass spam filters and hide warnings for messages from senders or domains in selected lists** is not selected, or
+    * None of the lists shown under **Bypass spam filters and hide warnings for messages from senders or domains in selected lists** contain an entire domain. For example, the entire domain "example.com" is not acceptable, but the specific address, john.doe@example.com, would be.
+2. Modify the rule or lists associated with the rule as needed, then select **Save.**
+
+#### GWS.GMAIL.18.3v1 Instructions
+For each rule listed under **Spam**:
+1. Ensure that **Bypass spam filters and hide warnings for all messages from internal and external sender** is not selected.
+2. Select **Save.**

--- a/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/groups.md
+++ b/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/groups.md
@@ -1,0 +1,245 @@
+# CISA Google Workspace Secure Configuration Baseline for Groups for Business
+
+Groups for Business is a Google Workspace (GWS) collaboration tool that supports the storage, access, and sharing of files, document management, and email. Groups for Business allows administrators to control and manage collaboration efforts among groups within their organizations. This Secure Configuration Baseline (SCB) provides specific policies to strengthen Groups for Business security.
+
+The Cybersecurity and Infrastructure Security Agency's (CISA) Secure Cloud Business Applications (SCuBA) project provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies' cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for GWS help secure federal information assets stored within GWS cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government's threats and risk tolerance. Organizations outside of the federal government may also find these baselines to be useful references to help reduce risks even if such organizations have different risk tolerances or face different threats.
+
+For non-federal users, the information in this document is being provided "as is" for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products. CISA has no control over vendor changes to products offerings or features. Accordingly, these SCuBA SCBs for GWS may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+This baseline is based on Google documentation available at [Google Workspace Admin Help: Set up and manage Groups for Business](https://support.google.com/a/topic/9400092?hl=en&ref_topic=25838) and addresses the following:
+
+-   [External Group Access](#1-external-group-access)
+-   [Group Creation](#2-group-creation)
+-   [Default Permissions for Viewing Conversations](#3-default-permissions-for-viewing-conversations)
+-   [Ability to Hide Groups from the Directory](#4-ability-to-hide-groups-from-the-directory)
+
+Settings can be assigned to certain GWS users individually, through organizational units, or through configuration groups. Before changing a setting, the user can select the organizational unit, configuration group, or individual users to which they want to apply changes.
+
+## Assumptions
+
+This document assumes the organization is using GWS Enterprise Plus.
+
+This document does not address, ensure compliance with, or supersede any law, regulation, or other authority.  Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology.  This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+## Key Terminology
+
+The key words "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services) (**BOD 25-01 Requirement**): This indicator means that the policy is required under CISA BOD 25-01.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology) (**Automated Check**): This indicator means that the policy can be automatically checked via ScubaGoggles. See [our documentation](../../README.md) for help getting started.
+
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#break-glass-accounts)(**Configurable**): This indicator means that the policy can be customized via a configuration file.
+
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)(**Log-Based Check**): This indicator means that ScubaGoggles will check the policy by reviewing admin audit logs. See [Limitations](../../docs/usage/Limitations.md#log-based-policy-checks).
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols83v06-instructions)(**Manual**): This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. External Group Access
+GWS provides several options for managing internal group access by people external to the organization.
+These settings are addressed in the following policies.
+
+### Policies
+
+#### GWS.GROUPS.1.1v1
+Group access from outside the organization SHALL be disabled unless explicitly granted by the group owner.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Groups may contain private or sensitive information. Restricting group access reduces the risk of data loss.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+#### GWS.GROUPS.1.2v1
+Group owners' ability to add external members to groups SHOULD be disabled unless necessary for agency mission fulfillment.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Groups may contain private or sensitive information. Restricting group access reduces the risk of data loss.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7, AC-6(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+    - [T1048:001: Exfiltration Over Alternative Protocol: Exfiltration Over Symmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/001/)
+    - [T1048:002: Exfiltration Over Alternative Protocol: Exfiltration Over Asymmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/002/)
+
+#### GWS.GROUPS.1.3v1
+Group owners' ability to allow external, non-group members to post in the group SHOULD be disabled unless necessary for agency mission fulfillment.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Allowing external users to post in a group allows for potential phishing or other malicious activity to be shared via groups. Restricting posting by external, non-group members reduces this risk.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7, AC-6(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+    - [T1048:001: Exfiltration Over Alternative Protocol: Exfiltration Over Symmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/001/)
+    - [T1048:002: Exfiltration Over Alternative Protocol: Exfiltration Over Asymmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/002/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:001: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
+    - [T1566:002: Spearphishing Link](https://attack.mitre.org/techniques/T1566/002/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Set organization-wide policies for using groups](https://support.google.com/a/answer/167097?hl=en&ref_topic=9400092)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.GROUPS.1.1v1 Instructions
+To configure the settings for sharing options:
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Groups for Business**.
+3.  Select **Sharing settings** -\> **Sharing options**.
+4.  Select **Accessing groups from outside this organization** -\> **Private**.
+5.  Select **Save**.
+
+#### GWS.GROUPS.1.2v1 Instructions
+To configure the settings for sharing options:
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Groups for Business**.
+3.  Select **Sharing settings** -\> **Sharing options**.
+4.  **Uncheck** the **Group owners can allow external members** checkbox.
+5.  Select **Save**.
+
+#### GWS.GROUPS.1.3v1 Instructions
+To configure the settings for sharing options:
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Groups for Business**.
+3.  Select **Sharing settings** -\> **Sharing options**.
+4.  **Uncheck** the **Group owners can allow incoming mail from outside the organization** checkbox.
+5.  Select **Save**.
+
+## 2. Group Creation
+
+This section covers who can create a new group within the organization.
+
+### Policies
+
+#### GWS.GROUPS.2.1v1
+Group creation SHOULD be restricted to administrators within the organization unless alternative creators are necessary for agency mission fulfillment.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Many Google Workspace product settings can be set at the "Group" level. However, allowing unrestricted group creation can complicate setting management and open channels of unmanaged communication. Restricting group creation to organization administrators helps reduce this risk.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1069: Permission Groups Discovery](https://attack.mitre.org/techniques/T1069/)
+    - [T1069:003: Permission Groups Discovery: Cloud Groups](https://attack.mitre.org/techniques/T1069/003/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Set organization-wide policies for using groups](https://support.google.com/a/answer/167097?hl=en&ref_topic=9400092)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.GROUPS.2.1v1 Instructions
+To configure the settings for Sharing options:
+
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Groups for Business**.
+3.  Select **Sharing settings** -\> **Sharing options**.
+4.  Select **Creating groups** -\> **Only organization admins can create groups**.
+5.  Select **Save**.
+
+## 3. Default Permissions for Viewing Conversations
+
+This section covers the default permissions assigned to the viewing of conversations within a group.
+
+### Policies
+
+#### GWS.GROUPS.3.1v1
+The default permission to view conversations SHOULD be set to "All group members."
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Groups may contain private or sensitive information not appropriate for the entire Google Workspace (GWS) organization. Restricting access to group members reduces the risk of data loss.
+- _Last modified:_ July 2023
+- _Note:_ This setting can be changed by group owners and group managers.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-6
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+    - [T1048:001: Exfiltration Over Alternative Protocol: Exfiltration Over Symmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/001/)
+    - [T1048:002: Exfiltration Over Alternative Protocol: Exfiltration Over Asymmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/002/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Set organization-wide policies for using groups](https://support.google.com/a/answer/167097?hl=en&ref_topic=9400092)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.GROUPS.3.1v1 Instructions
+To configure the settings for Sharing options:
+
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Groups for Business**.
+3.  Select **Sharing settings** -\> **Sharing options**.
+4.  Select **Default for permission to view conversations** -\> **All group members**.
+5.  Select **Save**.
+
+## 4. Ability to Hide Groups from the Directory
+
+This section covers whether the owner of a group can hide the group from the directory.
+
+### Policies
+
+#### GWS.GROUPS.4.1v1
+The ability for groups to be hidden from the directory SHALL be disabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Hidden groups are not visible, even to administrators, in the list of groups found at groups.google.com, though they are still visible on the directory page at admin.google.com. Allowing for hidden groups increases the risk of groups being created without administrator oversight.
+- _Last modified:_ July 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+    - [T1048:001: Exfiltration Over Alternative Protocol: Exfiltration Over Symmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/001/)
+    - [T1048:002: Exfiltration Over Alternative Protocol: Exfiltration Over Asymmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/002/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Set organization-wide policies for using groups](https://support.google.com/a/answer/167097?hl=en&ref_topic=9400092)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+#### GWS.GROUPS.4.1v1 Instructions
+To configure the settings for Sharing options:
+
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Groups for Business**.
+3.  Select **Sharing settings** -\> **Sharing options**.
+4.  **Uncheck** the **Group owners can hide groups from the directory** checkbox.
+5.  **Ensure** that the **hide newly created groups from the directory** checkbox is not selected.
+6.  Select **Save**.

--- a/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/meet.md
+++ b/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/meet.md
@@ -1,0 +1,333 @@
+# CISA Google Workspace Secure Configuration Baseline for Google Meet
+
+Google Meet is a video conferencing service in Google Workspace (GWS) that supports real-time video, desktop, and presentation sharing. Google Meet allows administrators to control and manage their video meetings. This Secure Configuration Baseline (SCB) provides specific policies to strengthen Google Meet security.
+
+The Cybersecurity and Infrastructure Security Agency's (CISA) Secure Cloud Business Applications (SCuBA) project provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies' cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for GWS help secure federal information assets stored within GWS cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government's threats and risk tolerance. Organizations outside of the federal government may also find these baselines to be useful references to help reduce risks even if such organizations have different risk tolerances or face different threats.
+
+For non-federal users, the information in this document is being provided "as is" for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products. CISA has no control over vendor changes to products offerings or features. Accordingly, these SCuBA SCBs for GWS may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+This baseline is based on Google documentation available at [Google Meet settings reference for admins](https://support.google.com/a/answer/7304109?product_name=UnuFlow&hl=en&visit_id=637812507975083818-2789839413&rd=1&src=supportwidget0&hl=en#:~:text=From%20the%20Admin%20console%20Home%20page%2C%20go%20to,to%20everyone%2C%20leave%20the%20top%20organizational%20unit%20selected) and addresses the following:
+
+-   [Meeting Access](#1-meeting-access)
+-   [Internal Access to External Meetings](#2-internal-access-to-external-meetings)
+-   [Host Management Meeting Features](#3-host-management-meeting-features)
+-   [External Participants](#4-external-participants)
+-   [Video Meeting Settings](#5-video-meeting-settings)
+-   [Gemini Settings](#6-gemini-settings)
+
+
+Settings can be assigned to certain users within Google Workspace (GWS) individually, through organizational units, or through configuration groups. Before changing a setting, the user can select the organizational unit, configuration group, or individual users to which they want to apply changes.
+
+## Assumptions
+
+This document assumes the organization is using GWS Enterprise Plus.
+
+This document does not address, ensure compliance with, or supersede any law, regulation, or other authority.  Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology.  This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+## Key Terminology
+
+The key words "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services) (**BOD 25-01 Requirement**): This indicator means that the policy is required under CISA BOD 25-01.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology) (**Automated Check**): This indicator means that the policy can be automatically checked via ScubaGoggles. See [our documentation](../../README.md) for help getting started.
+
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#break-glass-accounts)(**Configurable**): This indicator means that the policy can be customized via a configuration file.
+
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)(**Log-Based Check**): This indicator means that ScubaGoggles will check the policy by reviewing admin audit logs. See [Limitations](../../docs/usage/Limitations.md#log-based-policy-checks).
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols83v06-instructions)(**Manual**): This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. Meeting Access
+
+This control limits external users not explicitly invited to the meeting from joining without permission.
+
+### Policies
+
+#### GWS.MEET.1.1v1
+External users who were not explicitly invited to a Google Meet meeting SHALL be required to ask to join.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Allowing users external to an organization or not on the invite list to join meetings without asking permission diminishes host control of meeting participation, reduces user accountability, and invites potential data leaks. This policy reduces that risk by requiring users external to the organization or without an invitation to request organizer permission prior to joining meetings.
+- _Last modified:_ November 2025
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-2, IA-8
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1123: Audio Capture](https://attack.mitre.org/techniques/T1123/)
+  - [T1113: Screen Capture](https://attack.mitre.org/techniques/T1113/)
+  - [T1125: Video Capture](https://attack.mitre.org/techniques/T1125/)
+
+### Resources
+
+-   [Google Meet security & privacy for admins](https://support.google.com/a/answer/7582940?hl=en&ref_topic=7302923#zippy=%2Cprivacy-compliance%2Cincident-response%2Csecure-deployment-access-controls%2Canti-abuse-measures%2Cencryption%2Csafety-best-practices)
+-   [Google Meet settings reference for admins](https://support.google.com/a/answer/7304109?product_name=UnuFlow&hl=en&visit_id=637812507975083818-2789839413&rd=1&src=supportwidget0&hl=en#:~:text=From%20the%20Admin%20console%20Home%20page%2C%20go%20to,to%20everyone%2C%20leave%20the%20top%20organizational%20unit%20selected)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To configure the settings for Access type Meet safety settings:
+
+#### GWS.MEET.1.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Google Meet**.
+3.  Select **Meet safety settings** -\> **Access Type**.
+4.  In **Meeting access type (subject to restrictions set in Domain)**, select **Trusted** or **Restricted**.
+5.  Select **Save**.
+
+
+## 2. Internal Access to External Meetings
+
+This control determines which external meetings can be joined by users within the agency's organization.
+
+### Policies
+
+#### GWS.MEET.2.1v1
+Meeting access SHALL be disabled for meetings created by users who are not members of any Google Workspace (GWS) tenant or organization.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Contact with unmanaged users can pose the risk of data leakage and other security threats. This policy reduces such contact by not allowing agency users to join meetings created by users' personal accounts.
+- _Last modified:_ September 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ IA-8, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+  - [T1123: Audio Capture](https://attack.mitre.org/techniques/T1123/)
+  - [T1113: Screen Capture](https://attack.mitre.org/techniques/T1113/)
+  - [T1125: Video Capture](https://attack.mitre.org/techniques/T1125/)
+
+### Resources
+
+-   [Google Meet security & privacy for admins](https://support.google.com/a/answer/7582940?hl=en&ref_topic=7302923#zippy=%2Cprivacy-compliance%2Cincident-response%2Csecure-deployment-access-controls%2Canti-abuse-measures%2Cencryption%2Csafety-best-practices)
+-   [Google Meet settings reference for admins](https://support.google.com/a/answer/7304109?product_name=UnuFlow&hl=en&visit_id=637812507975083818-2789839413&rd=1&src=supportwidget0&hl=en#:~:text=From%20the%20Admin%20console%20Home%20page%2C%20go%20to,to%20everyone%2C%20leave%20the%20top%20organizational%20unit%20selected)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To configure the settings for Access within Meet safety settings:
+
+#### GWS.MEET.2.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Google Meet**.
+3.  Select **Meet safety settings** -\> **Access**.
+4.  Select **Meetings created in your organization only** or **Meetings created in any Workspace organization**.
+5.  Select **Save**.
+
+## 3. Host Management Meeting Features
+
+This control enables hosts to utilize the following features during meetings: prevent participants from sharing their screen, turn chat messages on or off, end the meeting for all, and mute all. By default, this control is disabled.
+
+Note: When this control is disabled, any attendee that is a member of the host's organization can record the meeting.
+
+### Policies
+
+#### GWS.MEET.3.1v1
+Host management meeting features SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ When host management features are disabled, any internal participant can take control of meetings, performing actions such as recording the meeting, disabling or enabling the chat, and ending the meeting. When host management features are enabled, these options are only available to meeting hosts.
+- _Last modified:_ January 2024
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1562:001: Impair Defenses](https://attack.mitre.org/techniques/T1562/)
+    - [T1562:001: Impair Defenses: Disable or Modify Tools](https://attack.mitre.org/techniques/T1562/001/)
+  - [T1123: Audio Capture](https://attack.mitre.org/techniques/T1123/)
+  - [T1113: Screen Capture](https://attack.mitre.org/techniques/T1113/)
+  - [T1125: Video Capture](https://attack.mitre.org/techniques/T1125/)
+
+### Resources
+
+-   [Google Meet security & privacy for admins](https://support.google.com/a/answer/7582940?hl=en&ref_topic=7302923#zippy=%2Cprivacy-compliance%2Cincident-response%2Csecure-deployment-access-controls%2Canti-abuse-measures%2Cencryption%2Csafety-best-practices)
+-   [Google Meet settings reference for admins](https://support.google.com/a/answer/7304109?product_name=UnuFlow&hl=en&visit_id=637812507975083818-2789839413&rd=1&src=supportwidget0&hl=en#:~:text=From%20the%20Admin%20console%20Home%20page%2C%20go%20to,to%20everyone%2C%20leave%20the%20top%20organizational%20unit%20selected)
+-   [Record a Video Meeting](https://support.google.com/meet/answer/9308681?hl=en)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To enable Host Management meeting features:
+
+#### GWS.MEET.3.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Google Meet**.
+3.  Select **Meet safety settings** -\> **Host management**.
+4.  Check the **Start video calls with host management turned on** checkbox.
+5.  Select **Save**.
+
+## 4. External Participants
+
+This control provides a warning label for any meeting participants who are not members of the organization or whose identity is unconfirmed.
+
+### Policies
+
+#### GWS.MEET.4.1v1
+"Warn for external participants" SHALL be enabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Users may inadvertently include external users in meetings or not be aware that external users are present. When enabled, external or unidentified participants in a meeting are given a visible label. This increases situational awareness amongst meeting participants and can help prevent inadvertent data leaks.
+- _Last modified:_ September 2023
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-15
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1566: Phishing](https://attack.mitre.org/techniques/T1566/)
+    - [T1566:004: Phishing: Spearphishing Voice](https://attack.mitre.org/techniques/T1566/004/)
+  - [T1598: Phishing for Information](https://attack.mitre.org/techniques/T1598/)
+    - [T1598:004: Phishing for Information: Spearphishing Voice](https://attack.mitre.org/techniques/T1598/004/)
+  - [T1123: Audio Capture](https://attack.mitre.org/techniques/T1123/)
+  - [T1113: Screen Capture](https://attack.mitre.org/techniques/T1113/)
+  - [T1125: Video Capture](https://attack.mitre.org/techniques/T1125/)
+
+### Resources
+
+-   [Manage Meet settings (for admins)](https://support.google.com/a/answer/7304109?fl=1&sjid=1761497708922707326-NA)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To enable Host Management meeting features:
+
+#### GWS.MEET.4.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Google Meet**.
+3.  Select **Meet safety settings** -\> **Warn for external participants**.
+4.  Check the **External or unidentified participants in a meeting are given a label** checkbox.
+5.  Select **Save**.
+
+## 5. Video Meeting Settings
+
+This section covers Google Meet video settings such as automatic video recording and automatic transcription.
+
+### Policies
+
+#### GWS.MEET.5.1v1
+Automatic recordings for Google Meet SHALL be disabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Automatic recordings could record sensitive information. By selecting this setting, it potentially mitigates unauthorized data leakage.
+- _Last modified:_ April 2026
+- _Note:_ The meeting owner retains the ability to modify this setting for their own meetings.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1123: Audio Capture](https://attack.mitre.org/techniques/T1123/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+
+#### GWS.MEET.5.2v1
+Automatic transcripts for Google Meet SHALL be disabled.
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services)
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+
+- _Rationale:_ Automatic transcripts could record sensitive information. By selecting this setting, it potentially mitigates unauthorized data leakage.
+- _Last modified:_ April 2026
+- _Note:_ The meeting owner retains the ability to modify this setting for their own meetings.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1113: Screen Capture](https://attack.mitre.org/techniques/T1113/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+
+
+### Resources
+- [Choose automatic meeting artifact settings for your organization](https://support.google.com/a/answer/15496523?p=automaticmeetingrecords)
+
+### Prerequisites
+-   None
+
+### Implementation
+
+#### GWS.MEET.5.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Meet**.
+3.  Click **Meet video settings**.
+4.  Click **Automatic recording**.
+5.  Ensure **Meetings are recorded by default** is unselected.
+6.  Click **Save**.
+
+#### GWS.MEET.5.2v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Meet**.
+3.  Click **Meet video settings**.
+4.  Click **Automatic transcription**.
+5.  Ensure **Meetings are transcribed by default** is unselected.
+6.  Click **Save**.
+
+## 6. Gemini Settings
+
+This section covers Google Gemini features within the Google Meet app.
+
+### Policies
+
+#### GWS.MEET.6.1v1
+Administrators SHOULD NOT be allowed to override the default sharing level for meeting notes set by the organization.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)
+
+- _Rationale:_ Meeting notes may contain sensitive information that should not be shared outside of the organization. Preventing administrators from overriding the default sharing level reduces the risk of inadvertent meeting note sharing.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1567:002: Exfiltration Over Web Service: Exfiltration to Cloud Storage](https://attack.mitre.org/techniques/T1567/002/)
+
+#### GWS.MEET.6.2v1
+Default sharing setting for Google AI notes SHALL be restricted to "Guests in your organization."
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)
+
+- _Rationale:_ Meeting notes may contain sensitive information that should not be shared outside of the organization. Setting a secure default sharing level reduces the risk of inadvertent meeting note sharing.
+- _Last modified:_ March 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1567:002: Exfiltration Over Web Service: Exfiltration to Cloud Storage](https://attack.mitre.org/techniques/T1567/002/)
+
+
+### Resources
+- [Take notes for me in Google Meet](https://support.google.com/meet/answer/14754931)
+
+### Prerequisites
+-   None
+
+### Implementation
+
+#### GWS.MEET.6.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Meet**.
+3.  Click **Gemini Settings**.
+4.  Click **Google AI notes sharing**.
+5.  Ensure **Allow hosts to change who notes are shared to** is unselected.
+6.  Click **Save**.
+
+#### GWS.MEET.6.2v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Meet**.
+3.  Click **Gemini Settings**.
+4.  Click **Google AI notes sharing**.
+5.  Ensure **Default sharing setting for Google AI notes** is set to "The hosts and co-hosts" or "Invited Guests in your Organization".
+6.  Click **Save**.

--- a/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/sites.md
+++ b/vendor/scuba/scubagoggles/95d80462699e469b569e5b5caf921c4b8c6c884a/baselines/sites.md
@@ -1,0 +1,79 @@
+# CISA Google Workspace Secure Configuration Baseline for Google Sites
+
+Google Sites is a collaborative tool in Google Workspace (GWS) that supports the creation of websites (i.e., internal project hubs, team sites, and public-facing websites) without the need for a designer, programmer, or IT help. Google Sites allows administrators to control and manage their files and documents. Google Drive manages sharing and publishing settings for new Sites. This Secure Configuration Baseline (SCB) provides specific policies to strengthen Sites security.
+
+The Cybersecurity and Infrastructure Security Agency's (CISA) Secure Cloud Business Applications (SCuBA) project provides guidance and capabilities to secure federal civilian executive branch (FCEB) agencies' cloud business application environments and protect federal information that is created, accessed, shared, and stored in those environments.
+
+The CISA SCuBA SCBs for GWS help secure federal information assets stored within GWS cloud business application environments through consistent, effective, and manageable security configurations. CISA created baselines tailored to the federal government's threats and risk tolerance. Organizations outside of the federal government may also find these baselines as useful references to help reduce risks even if such organizations have different risk tolerances or face different threats.
+
+For non-federal users, the information in this document is being provided "as is" for INFORMATIONAL PURPOSES ONLY. CISA does not endorse any commercial product or service, including any subjects of analysis. Any reference to specific commercial entities or commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply endorsement, recommendation, or favoritism by CISA. Without limiting the generality of the foregoing, some controls and settings are not available in all products. CISA has no control over vendor changes to products offerings or features. Accordingly, these SCuBA SCBs for GWS may not be applicable to the products available to you. This document does not address, ensure compliance with, or supersede any law, regulation, or other authority. Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology. This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+This baseline is based on Google documentation available at [Google Workspace Admin Help: Sites](https://support.google.com/sites/?sjid=11348526400392778786-NA#topic=7184580) and addresses the following:
+
+-   [Sites Service Status](#1-sites-service-status)
+
+Google is currently transitioning from classic Sites to new Sites. For more information, view [Google Workspace Admin Help: Transition from classic Sites to new Sites](https://support.google.com/a/answer/9958187?hl=en&ref_topic=25684#zippy=%2Cstarting-july-previously-january-classic-sites-transition%2Cstarting-june-previously-december-editing-of-remaining-classic-sites-will-be-disabled). Starting December 1, 2022, classic Sites will no longer be editable. Starting January 1, 2023, classic Sites will no longer be viewable unless converted to new Google Sites. All remaining classic Sites will be automatically archived as HTML files, saved to the site owner's Google Drive, and replaced with a draft in new Sites to be reviewed and published.
+
+Settings can be assigned to certain users within Google Workspace (GWS) through organizational units, configuration groups, or individually. Before changing a setting, the user can select the organizational unit, configuration group, or individual users to which they want to apply changes.
+
+## Assumptions
+
+This document assumes the organization is using GWS Enterprise Plus.
+
+This document does not address, ensure compliance with, or supersede any law, regulation, or other authority.  Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology.  This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
+
+## Key Terminology
+
+The key words "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+[![BOD 25-01 Requirement](https://img.shields.io/badge/BOD_25--01_Requirement-C41230)](https://www.cisa.gov/news-events/directives/bod-25-01-implementation-guidance-implementing-secure-practices-cloud-services) (**BOD 25-01 Requirement**): This indicator means that the policy is required under CISA BOD 25-01.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology) (**Automated Check**): This indicator means that the policy can be automatically checked via ScubaGoggles. See [our documentation](../../README.md) for help getting started.
+
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#break-glass-accounts)(**Configurable**): This indicator means that the policy can be customized via a configuration file.
+
+[![Log-Based Check](https://img.shields.io/badge/Log--Based_Check-F6E8E5)](../../docs/usage/Limitations.md#log-based-policy-checks)(**Log-Based Check**): This indicator means that ScubaGoggles will check the policy by reviewing admin audit logs. See [Limitations](../../docs/usage/Limitations.md#log-based-policy-checks).
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols83v06-instructions)(**Manual**): This indicator means that the policy requires manual verification of configuration settings.
+
+# Baseline Policies
+
+## 1. Sites Service Status
+
+This section covers whether users can access Google Sites.
+
+### Policies
+
+#### GWS.SITES.1.1v1
+Sites Service SHOULD be disabled for all users.
+
+[![Automated Check](https://img.shields.io/badge/Automated_Check-5E9732)](#key-terminology)
+[![Configurable](https://img.shields.io/badge/Configurable-005288)](../../docs/usage/Config.md#sites-exclusions)
+
+- _Rationale:_ Google Sites can increase the attack surface of Google Workspace (GWS). Disabling the "Sites Service" feature, unless it is needed, conforms to the principle of least functionality.
+- _Last modified:_ December 2025
+- _Note:_ Google Sites MAY be enabled on a per-group and per-Organizational Unit (OU) basis.
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ CM-7
+- MITRE ATT&CK TTP Mapping
+  - [T1526: Cloud Service Discovery](https://attack.mitre.org/techniques/T1526/)
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+
+### Resources
+
+-   [Google Workspace Admin Help: Manage users' access in Sites](https://support.google.com/a/answer/6399230?hl=en)
+-   [CIS Google Workspace Foundations Benchmark](https://www.cisecurity.org/benchmark/google_workspace)
+
+### Prerequisites
+
+-   None
+
+### Implementation
+
+To configure the settings for Google Sites creation and editing:
+
+#### GWS.SITES.1.1v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Apps** -\> **Google Workspace** -\> **Sites**.
+3.  Select **Service Status**
+4.  Select **OFF for everyone**.
+5.  Select **Save**.


### PR DESCRIPTION
## Summary

PR-3 of the platform-procedures plan (§7 revised sequencing): vendoring + parser + platform bank — the first PR that stamps license values onto records, legal because PR-2 (#310) landed the license class + obligations schema. **Zero egress surfaces touched**: nothing writes `procedureSource`; `src/pages/Assessments.js`, `src/utils/dataExport.js`, the stores, the community bank, and its generator are byte-untouched.

**Vendored SCuBA pair, byte-frozen.** `vendor/scuba/` carries the CISA baseline markdown at pinned commits — ScubaGoggles `95d8046` (11 files) and ScubaGear `d7cf55f` (8 files) — with per-file sha256 pins, per-source `licenseId`, an independent regex policy census (137 GWS + 128 M365 = 265, exactly the plan-time census), and the parser + license-schema versions in `MANIFEST.json`, so any future tightening is a re-derivation over retained inputs, not data loss. `scripts/vendor-scuba.mjs --update` is the only network-touching step and is developer-time only; `scripts/verify-vendor-integrity.mjs` recomputes every sha256 in CI (no npm install, no network), so editing vendored text — or an unlisted file appearing in the tree — is a build failure, never a silent fork. Baseline TEXT only is imported; `removedpolicies.md` (deprecated policies) and `README.md` are excluded. `.gitattributes` freezes `vendor/scuba/**` (`-text`) so CRLF conversion can never break the pins.

**One parser, both dialects, per-file license detection.** `src/utils/scubaBaseline.mjs` (in `src/` so jest collects it — `relatedSection.mjs` precedent) parses both policy-ID forms (`GWS.*` / `MS.*`, `v<n>` suffix incl. the corpus's one `v2`), both MITRE mapping-line forms (ScubaGoggles bare, ScubaGear underscored) with sub-technique normalization to dot form via the dialect-free URL path, and every punctuation variant measured in the corpus (`_Rationale_:`, `_Last Modified:_`, double-space bullets, double-space/trailing-colon instruction headings, four spellings of group-common instruction headings). License comes from **per-file detection, never the repo label** (plan §7 R-1): the manifest's per-source `licenseId` is the positively-recorded floor, and an in-file "License Compliance and Copyright" section declaring CC BY portions tightens it — all 8 ScubaGear M365 files do, so their 128 records stamp `CC0-1.0 AND CC-BY-4.0` (SPDX) with component obligations `{attribution, changeIndication}` and a complete 5-field attribution block whose text carries the CC BY §3(a)(1)(B) modification indication; the 137 GWS records stamp `CC0-1.0`. Records carry the **raw license string + declared obligation components — never the computed classification join** (PR-2 entry condition 2); `recordLicense()` derives the class at read. ScubaGear's `### License Requirements` sections are Microsoft **product** licensing ("requires Entra ID P2") and parse into `productLicenseNotes`, fenced off every egress surface by a structural test that walks `src/`.

**Deterministic reference-shaped bank.** `scripts/generate-platform-bank.mjs` → `src/data/platformProcedures.json`: 265 records (`bankFormat: platform-procedures-v1`), sorted keys, content-hash `bankVersion`, zero timestamps (`retrievedAt` flows from the manifest), `--check` drift gate in CI. The generator refuses to write a corpus that fails the production license validation gate (`validateLicensedRecords` — the same code the notices CI gate runs), refuses duplicate policy IDs, and refuses any parse count diverging from the manifest census. Records are reference-shaped (§7 R-3): the bank holds full content (assertion, obligation, rationale, notes, details, instructions, raw `nist80053[]`, raw `mitreAttack[]`) for PR-5 to reference — **no `subcategories` field exists; the 800-53 → CSF mapping is PR-4's** (§7 R-2), and no `readOnly`/`privilegeRequired` claims are made because the vendored text states neither (R-10).

**Sanitizer-fixpoint normalization, proven not promised.** Generated text is normalized to a measured fixpoint of the app's DOMPurify input sanitizer (comments stripped, `<pre>` → fences, `<b>` → markdown, `<domain>`-class placeholder tokens → inline code, anchors/images dropped, autolink/email/`<br>` per community rules) and the contract suite asserts `sanitizeInput(field) === field` for every text field of every record with the REAL sanitizer — plus a non-vacuousness control and exact conversion-evidence pins (18 fenced records, 227 bold, 25 inline-code, golden click-path spot-check) so a normalizer that deletes instead of converts goes red.

**Bank registered, notices regenerated, disclaimer reconciled.** The bank is enumerated in the notices `BANKS` (the PR-2 unregistered-bank guard demanded it), putting all 265 records under the license validation gate; `THIRD-PARTY-NOTICES.md` regenerates with the structural CISA disclaimer and per-record attributions. The disclaimer wording was reconciled against the vendored baselines' own text (PR-2 ratification item 3 — see item 3 below).

## Verification

- 908/908 tests green (51 suites; +74 over the 834 baseline).
- Exact-census contract: 265 records pinned, 137/128 per platform, 21 empty-MITRE (upstream "None" mappings), 100% NIST 800-53 coverage (265/265 measured), 128 attribution-obligated records all attribution-complete via the production schema.
- Mutation-killing fixtures (test-analyzer round, both mutants empirically confirmed surviving before the fix): a license section restating only CC0 stays at the floor; the CC BY sentence outside a license section stamps nothing — a presence-only or whole-file-grep detector now fails the suite. Repo-label and prefix-keyed mutants killed by the cross-wired discrimination pair.
- Drift/tamper guards promoted into jest: committed bank equals a fresh parse of the vendored tree (record grain); every sha256 pin recomputed; one-byte-tamper polarity. Script-level polarity proven by probe: tampered vendored file ⇒ integrity exit 1; hand-edited bank ⇒ `--check` exit 1; parser-version bump without re-vendor ⇒ generator exit 1; notices and bank double-runs byte-identical.
- Changed files lint at `--max-warnings=0` (.mjs linted locally; CI lint glob gap known); `CI=false npm run build` compiles; deny-token scan clean; zero diff to every protected egress surface; no `packFormat` token.
- Code-reviewer round: zero CRITICAL/MAJOR; all 7 hard constraints verified mechanically; its NIST continuation-line fragility fixed (wrapped control lists now scan like MITRE's) with a fixture. Advisor round: SPDX license strings and licenseId-floor adopted (items a-d dispositioned with evidence).

## Ratification items (merging ratifies)

1. **The fail-open-unknown ruling is now baked into a stamped corpus** (PR-2 entry condition 1, ratified before this build started). Records carry raw strings + components + parser/schema versions, so a future tightening is a re-derivation — but it is a corpus regeneration, not a flag flip.
2. **License strings are SPDX expressions** (`CC0-1.0 AND CC-BY-4.0` on M365 records), not prose: an advisor-round adoption — a composed phrase is a derivation wearing a raw label. The floor is the manifest's per-source `licenseId` (positively recorded at vendoring), tightened per file; CC0 is never inferred from the mere absence of a CC BY marker.
3. **CISA disclaimer wording updated** (PR-2 ratification item 3 discharged): added the "as is"/informational-purposes clause and broadened no-endorsement to "any commercial product or service" — both verbatim-supported by the disclaimer text the vendored baselines carry (truth-checked by the reviewer agent against source).
4. **GWS CC0 records carry full attribution blocks and appear in the notices file** (all 265 records listed, ~2,400 generated lines). CC0 requires none of this; uniform records mean no consumer ever branches on license class, and the blocks are provenance-typed — no attribution *obligation* is declared on CC0 records.
5. **`removedpolicies.md` is excluded from vendoring** — deprecated policies are not procedures.
6. **Group-common instructions fallback**: policies without a per-policy instructions block (e.g. Common Controls groups 9/10) carry their group's common block; policies with their own block do not additionally carry the common preamble.
7. **Entry condition 4 (export-envelope discriminator) stays deferred to PR-5**, with evidence rather than assertion: nothing in this PR writes `procedureSource`; egress is allowlist-shaped (PR-0 disposition registry + appearance-completeness test), and `procedureSource.license` is already registry-declared (PR-2). Named for the PR-5 checklist alongside PR-2 ratification item 6 (`resetToCommunityUpdate`/`resolvePristine` gate coverage).

## Named for later PRs (not gaps in this one)

- **PR-4**: the 800-53 → CSF subcategory mapping (signature-dedup review queue, 4-control gap table, unranked presentation — §7 R-2). The raw `nist80053[]`/`mitreAttack[]` facts on every record are its input.
- **PR-5**: attach/UI; corpus snapshot/withdrawal policy on upstream refresh (the bank fully regenerates, so schema additions are regenerations, not data migrations); load-time schema-version assertion when the app starts importing the JSON; the envelope discriminator (item 7).

## Sequencing

PR-0 (#308) registry, PR-1 (#309) predicates, PR-2 (#310) license schema are in. This PR stamps the first licensed corpus against that schema. Next: PR-4 mapping.
