### PR TITLE
Attach platform procedures by reference with a single expansion choke point

### DIFF
--- a/PRIVATE_DATA.md
+++ b/PRIVATE_DATA.md
@@ -121,6 +121,22 @@ the crown-jewel list plus your tooling reads like an attacker's shopping list. I
   as-is (that is what makes them useful to you). The scrubbed artifact is the **Share
   export** only — hand people `csf_share_*.json`, not a CSV, when org context must stay out.
 
+### Platform procedure references (format 5)
+
+Platform addenda (SCuBA baselines) attach as **references**, never copies:
+`platformProcedures: [{ corpusId, corpusVersion, policyId, contentHash }]` on the
+observation, with the composition recipe recorded in `procedureSource.components`. One
+expansion function turns references into text at render and at every text egress (CSV,
+Jira, share export), asserting upstream attribution from provenance each time; a reference
+this install cannot resolve renders an explicit placeholder carrying its identity — never a
+silent drop. **Share exports are self-contained** (format 5): the references are expanded
+into the procedure text so a receiving install never depends on corpus presence or version,
+and the reference list itself never rides a share. **Complete backups carry references
+verbatim** (wholesale by design). Editing an addendum forks it copy-on-write into a
+concrete value you own, so nothing user-authored can ever become unresolvable. There are no
+corpus snapshots: when upstream revises or withdraws a policy, the fix is re-attaching from
+the regenerated corpus, not migrating old text.
+
 ### Procedure provenance and staleness (v1 non-goal)
 
 Attached community procedures are **copies** (`copy-on-attach`) with a provenance object:

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -28,6 +28,7 @@ import useAIStore from '../stores/aiStore';
 import useUIStore from '../stores/uiStore';
 import { formatInlineMarkdown, stripMarkdown } from '../utils/markdownText';
 import { bankCoverage, getBankProcedure, canResetToCommunity, resetToCommunityUpdate, sourceUrlFor } from '../utils/procedureBank';
+import { expandProcedureText } from '../utils/platformBank';
 import { canUseProfileWithProvider, buildTailorPrompt, tailoredProvenance, deriveStackTargets, describeStackPlan, bankAttachObservation, deterministicTailorUpdate } from '../utils/procedureTailor';
 import { getScoringScale, scoreBand, CMMI_LEVELS } from '../utils/scoringScale';
 import { SYSTEM_NAME_MAX_LENGTH } from '../utils/externalLinks';
@@ -783,8 +784,14 @@ Format as a numbered list. Be specific and actionable.`;
     const existing = getObservation(currentAssessmentId, selectedItemId);
     const update = resetToCommunityUpdate(selectedItemId, existing?.procedureSource);
     if (!update) return;
-    if (existingText && existingText.trim() &&
-        !window.confirm('Replace the current test procedures with the community version?')) {
+    // The confirm says exactly what resets (plan §7 R-6): the procedure text
+    // goes back to the pristine community version; platform addenda recorded
+    // on the observation are NOT destroyed — they stay attached as their
+    // pristine referenced versions (edits to them are reset too).
+    const confirmMessage = update.platformProcedures?.length
+      ? 'Reset the test procedure text to the pristine community version? Platform addenda stay attached and are reset to their pristine referenced versions (any edits to the text or the addenda are discarded).'
+      : 'Reset the test procedure text to the pristine community version? Any edits to it are discarded.';
+    if (existingText && existingText.trim() && !window.confirm(confirmMessage)) {
       return;
     }
     updateObservation(currentAssessmentId, selectedItemId, update);
@@ -1639,11 +1646,13 @@ Format as a numbered list. Be specific and actionable.`;
                       />
                     ) : (
                       <div className="prose prose-sm max-w-none text-gray-700 dark:text-gray-300">
-                        {/* Bank-attached procedures are real markdown — render as-is;
-                            the reformat helper is only for legacy free-text blobs. */}
+                        {/* Bank-attached procedures are real markdown — render as-is
+                            through the expansion choke point (platform addendum
+                            references expand to text + attribution here); the
+                            reformat helper is only for legacy free-text blobs. */}
                         <Markdown>
-                          {(currentObservation.procedureSource
-                            ? currentObservation.testProcedures
+                          {(currentObservation.procedureSource || currentObservation.platformProcedures?.length
+                            ? expandProcedureText(currentObservation)
                             : formatTestProcedures(currentObservation.testProcedures)) || 'No test procedures defined'}
                         </Markdown>
                       </div>

--- a/src/stores/assessmentsStore.egress.test.js
+++ b/src/stores/assessmentsStore.egress.test.js
@@ -1,0 +1,165 @@
+/**
+ * CSV/Jira egress × the expansion choke point (plan §7 R-3/R-9; PR-5).
+ *
+ * Every text egress of procedure text must route through
+ * expandProcedureText: an observation carrying platform REFERENCES must ship
+ * the expanded addendum text (with attribution) in the exported artifact,
+ * and an unresolvable reference must ship its explicit placeholder — never
+ * silently drop. One test per exporter, so an expansion-skipping mutant in
+ * ANY of the four egresses fails its own test.
+ *
+ * Capture harness: the exporters build a Blob and hand it to
+ * URL.createObjectURL — jsdom implements neither, so both are stubbed and
+ * the CSV text is read back from the captured Blob parts.
+ */
+import useAssessmentsStore from './assessmentsStore';
+import useControlsStore from './controlsStore';
+import useRequirementsStore from './requirementsStore';
+import useUserStore from './userStore';
+import bank from '../data/platformProcedures.json';
+import { buildPlatformRef } from '../utils/platformBank';
+import { getBankProcedure } from '../utils/procedureBank';
+import { bankAttachObservation } from '../utils/procedureTailor';
+
+const REAL_POLICY = 'ms.aad.1.1v1';
+const realRecord = bank.procedures[REAL_POLICY];
+const DEAD_REF = {
+  corpusId: 'foreign-corpus',
+  corpusVersion: 'ffffffffffffffff',
+  policyId: 'gone.policy.1.1v1',
+  contentHash: '0123456789abcdef'
+};
+
+let captured;
+const OriginalBlob = global.Blob;
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+// jsdom's Blob has no .text(); retain the constructor parts for read-back.
+class CapturingBlob extends OriginalBlob {
+  constructor(parts, opts) {
+    super(parts, opts);
+    this.capturedParts = parts;
+  }
+}
+
+beforeAll(() => {
+  global.Blob = CapturingBlob;
+  URL.createObjectURL = (blob) => {
+    captured.push(blob);
+    return 'blob:test';
+  };
+  URL.revokeObjectURL = () => {};
+});
+
+afterAll(() => {
+  global.Blob = OriginalBlob;
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+});
+
+const capturedText = async () => {
+  expect(captured.length).toBeGreaterThan(0);
+  const blob = captured[captured.length - 1];
+  return blob.capturedParts.map((p) => String(p)).join('');
+};
+
+let assessmentId;
+
+beforeEach(() => {
+  captured = [];
+  const assessments = useAssessmentsStore.getState();
+  const created = assessments.createAssessment({
+    name: 'Egress expansion assessment',
+    scopeType: 'requirements'
+  });
+  assessmentId = created.id;
+  assessments.addToScope(assessmentId, 'PR.DS-01 Ex1');
+  // Real attach producer for the trunk, then the reference lane: one
+  // resolvable corpus ref + one dead ref on the same observation.
+  assessments.updateObservation(assessmentId, 'PR.DS-01 Ex1', {
+    ...bankAttachObservation(getBankProcedure('PR.DS-01')),
+    platformProcedures: [buildPlatformRef(realRecord), DEAD_REF]
+  });
+  assessments.updateQuarterlyObservation(assessmentId, 'PR.DS-01 Ex1', 'Q1', {
+    actualScore: 3,
+    targetScore: 4,
+    observations: 'Quarter note',
+    testingStatus: 'Complete',
+    examine: true,
+    interview: false,
+    test: true
+  });
+});
+
+afterEach(() => {
+  const assessments = useAssessmentsStore.getState();
+  assessments.setAssessments(
+    assessments.assessments.filter((a) => a.id !== assessmentId)
+  );
+});
+
+const expectExpandedProcedureText = (csv) => {
+  // resolvable ref: addendum substance + attribution assert from provenance
+  expect(csv).toContain(realRecord.assertion);
+  expect(csv).toContain('Portions adapted from Microsoft');
+  // unresolvable ref: explicit identity-carrying placeholder, never dropped
+  expect(csv).toContain('Unresolved platform procedure reference');
+  expect(csv).toContain(DEAD_REF.policyId);
+  // trunk still present
+  expect(csv).toContain('PR.DS-01');
+};
+
+describe('the four CSV/Jira egresses expand through the choke point', () => {
+  test('exportAssessmentCSV', async () => {
+    useAssessmentsStore
+      .getState()
+      .exportAssessmentCSV(assessmentId, useControlsStore, useRequirementsStore, useUserStore);
+    expectExpandedProcedureText(await capturedText());
+  });
+
+  test('exportForJiraCSV (custom field AND description)', async () => {
+    useAssessmentsStore
+      .getState()
+      .exportForJiraCSV(assessmentId, useControlsStore, useRequirementsStore, useUserStore);
+    const csv = await capturedText();
+    expectExpandedProcedureText(csv);
+    // the Description column embeds the expanded text too — assert the
+    // assertion appears at least twice (field + description)
+    expect(csv.split(realRecord.assertion).length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('exportAllForJiraCSV', async () => {
+    useAssessmentsStore
+      .getState()
+      .exportAllForJiraCSV(useControlsStore, useRequirementsStore, useUserStore);
+    expectExpandedProcedureText(await capturedText());
+  });
+
+  test('exportAllAssessmentsCSV', async () => {
+    useAssessmentsStore
+      .getState()
+      .exportAllAssessmentsCSV(useControlsStore, useRequirementsStore, useUserStore);
+    expectExpandedProcedureText(await capturedText());
+  });
+});
+
+describe('store passthrough safety', () => {
+  test('updateObservation persists references unmangled; quarterly-shaped observations never re-migrate', () => {
+    const obs = useAssessmentsStore.getState().getObservation(assessmentId, 'PR.DS-01 Ex1');
+    expect(obs.platformProcedures).toHaveLength(2);
+    expect(obs.platformProcedures[1]).toEqual(DEAD_REF);
+    // the getter default for an untouched item has no platform keys
+    const fresh = useAssessmentsStore.getState().getObservation(assessmentId, 'ZZ.ZZ-99 Ex1');
+    expect('platformProcedures' in fresh).toBe(false);
+  });
+
+  test('a text-only edit keeps the references and flips modified (provenance honesty unchanged)', () => {
+    useAssessmentsStore.getState().updateObservation(assessmentId, 'PR.DS-01 Ex1', {
+      testProcedures: 'hand-edited trunk'
+    });
+    const obs = useAssessmentsStore.getState().getObservation(assessmentId, 'PR.DS-01 Ex1');
+    expect(obs.platformProcedures).toHaveLength(2);
+    expect(obs.procedureSource.modified).toBe(true);
+  });
+});

--- a/src/stores/assessmentsStore.js
+++ b/src/stores/assessmentsStore.js
@@ -12,6 +12,11 @@ import {
   COMPREHENSIVE_OBSERVATIONS
 } from './comprehensiveAssessmentData';
 import { getBankProcedure, BANK_VERSION } from '../utils/procedureBank';
+// The single expansion choke point (plan §7 R-3/R-9): every text egress of
+// procedure text below routes through it so platform addendum REFERENCES
+// expand to text + attribution (or the explicit placeholder) instead of
+// silently dropping from CSV/Jira artifacts.
+import { expandProcedureText } from '../utils/platformBank';
 import { cleanCommunityMarkdown } from '../utils/relatedSection.mjs';
 import useAuditLogStore from './auditLogStore';
 
@@ -1019,7 +1024,7 @@ const useAssessmentsStore = create(
             'Scope Type': escapeCSVValue(assessment.scopeType),
             'Scoring Scale': assessment.scoringScale === 5 ? 5 : 10,
             'Auditor': escapeCSVValue(getUserName(obs.auditorId)),
-            'Test Procedure(s)': escapeCSVValue(obs.testProcedures || '')
+            'Test Procedure(s)': escapeCSVValue(expandProcedureText(obs) || '')
           };
 
           // Add quarterly columns
@@ -1511,7 +1516,7 @@ const useAssessmentsStore = create(
 
             // Build description
             let description = `Control Evaluation for ${controlDetails.id} - ${quarter}\n\n`;
-            description += `Test Procedures:\n${obs.testProcedures || 'N/A'}\n\n`;
+            description += `Test Procedures:\n${expandProcedureText(obs) || 'N/A'}\n\n`;
             description += `Observations:\n${qData.observations || 'N/A'}\n\n`;
             description += `Assessment Methods: ${methods.join(', ') || 'None'}\n\n`;
             if (controlDetails.linkedReqs) {
@@ -1541,7 +1546,7 @@ const useAssessmentsStore = create(
               'Custom field (Q4 Actual Score)': quarter === 'Q4' ? qData.actualScore : '',
               'Custom field (Q4 Target Score)': quarter === 'Q4' ? qData.targetScore : '',
               'Custom field (Testing Status)': qData.testingStatus,
-              'Custom field (Test Procedures)': escapeCSVValue(obs.testProcedures || ''),
+              'Custom field (Test Procedures)': escapeCSVValue(expandProcedureText(obs) || ''),
               'Custom field (Observations)': escapeCSVValue(qData.observations || ''),
               'Custom field (Assessment Methods)': methods.join(', '),
               'Custom field (Artifacts)': escapeCSVValue((obs.linkedArtifacts || []).join('; ')),
@@ -1658,7 +1663,7 @@ const useAssessmentsStore = create(
                 'Custom field (Actual Score)': qData.actualScore,
                 'Custom field (Target Score)': qData.targetScore,
                 'Custom field (Testing Status)': qData.testingStatus,
-                'Custom field (Test Procedures)': obs.testProcedures || '',
+                'Custom field (Test Procedures)': expandProcedureText(obs) || '',
                 'Custom field (Observations)': qData.observations || '',
                 'Custom field (Assessment Methods)': methods.join(', '),
                 'Custom field (Artifacts)': (obs.linkedArtifacts || []).join('; '),
@@ -1722,7 +1727,7 @@ const useAssessmentsStore = create(
               'Framework Filter': escapeCSVValue(assessment.frameworkFilter || ''),
               'Scoring Scale': assessment.scoringScale === 5 ? 5 : 10,
               'Auditor': escapeCSVValue(getUserName(obs.auditorId)),
-              'Test Procedure(s)': escapeCSVValue(obs.testProcedures || '')
+              'Test Procedure(s)': escapeCSVValue(expandProcedureText(obs) || '')
             };
 
             // Add quarterly columns

--- a/src/utils/__snapshots__/dataExportGolden.test.js.snap
+++ b/src/utils/__snapshots__/dataExportGolden.test.js.snap
@@ -441,7 +441,7 @@ Object {
   },
   "dataType": "Complete Assessment Database",
   "exportDate": "<stripped>",
-  "formatVersion": 4,
+  "formatVersion": 5,
   "metadata": Object {
     "applicationName": "CSF Profile Assessment Tool",
     "assessmentCount": 3,
@@ -762,7 +762,7 @@ Alma's position as a continuous authentication SaaS company creates a unique dyn
   },
   "dataType": "Shareable Assessment Database (private pack data excluded)",
   "exportDate": "<stripped>",
-  "formatVersion": 4,
+  "formatVersion": 5,
   "metadata": Object {
     "applicationName": "CSF Profile Assessment Tool",
     "assessmentCount": 2,
@@ -1186,7 +1186,7 @@ Object {
   },
   "dataType": "Complete Assessment Database (private pack data INCLUDED; restricted-license metrics still excluded)",
   "exportDate": "<stripped>",
-  "formatVersion": 4,
+  "formatVersion": 5,
   "metadata": Object {
     "applicationName": "CSF Profile Assessment Tool",
     "assessmentCount": 3,

--- a/src/utils/dataExport.js
+++ b/src/utils/dataExport.js
@@ -15,8 +15,17 @@ import { SHARE_SECTIONS, OMIT, foldSection, buildShareContext } from './shareReg
  * Format 4: adds the orgProfile section (object, not array) to COMPLETE
  *   backups. Share exports NEVER carry it, and tailored procedures are
  *   swapped back to the pristine community text (see PRIVATE_DATA.md).
+ * Format 5: the platform-procedures envelope discriminator. Share-export
+ *   procedure text is SELF-CONTAINED — platform addendum references are
+ *   expanded into testProcedures (trunk + addendum text + attribution) and
+ *   the refs themselves never ride a share; procedureSource.components
+ *   records the composition recipe; complete backups carry
+ *   observation.platformProcedures references verbatim (wholesale by
+ *   design). From format 5 on, ABSENCE is meaningful: a file with no
+ *   components / license metadata / platformProcedures genuinely had none,
+ *   where a format ≤4 file simply predates the machinery.
  */
-export const EXPORT_FORMAT_VERSION = 4;
+export const EXPORT_FORMAT_VERSION = 5;
 
 // zustand persist keys whose schema versions travel with the export so a
 // restore can detect version drift between the exporting and importing app.

--- a/src/utils/dataImport.test.js
+++ b/src/utils/dataImport.test.js
@@ -544,3 +544,139 @@ describe('importCompleteDatabase safety semantics', () => {
     expect(setters.setUsers).not.toHaveBeenCalled();
   });
 });
+
+describe('PR-5: platform references on the restore path (format 5)', () => {
+  const REF = {
+    corpusId: 'foreign-corpus',
+    corpusVersion: 'ffffffffffffffff',
+    policyId: 'gone.policy.1.1v1',
+    contentHash: '0123456789abcdef'
+  };
+  const withRefs = () => ({
+    ...SAMPLE,
+    assessments: [
+      {
+        id: 'a1',
+        name: 'Assessment',
+        observations: {
+          'PR.DS-01 Ex1': {
+            testProcedures: 'Trunk text.',
+            platformProcedures: [REF],
+            procedureSource: {
+              bank: 'community',
+              bankId: 'PR.DS-01',
+              components: [
+                { kind: 'trunk', bank: 'community', bankId: 'PR.DS-01' },
+                { kind: 'platform-ref', ...REF }
+              ]
+            },
+            quarters: {}
+          }
+        }
+      }
+    ]
+  });
+
+  test('the export format is 5 — the platform-procedures envelope discriminator', () => {
+    expect(EXPORT_FORMAT_VERSION).toBe(5);
+  });
+
+  test('a format-5 backup carrying references restores them VERBATIM (never dropped, never crashes)', () => {
+    const { stores } = makeStores(withRefs());
+    const exported = exportAllDataJSON(stores);
+    const parsed = JSON.parse(JSON.stringify(exported));
+    const { stores: targetStores, setters } = makeStores();
+    const result = importCompleteDatabase(parsed, targetStores, { backupFirst: false });
+    expect(result.applied).toEqual(expect.arrayContaining(['assessments']));
+    const restored = setters.setAssessments.mock.calls[0][0];
+    const obs = restored[0].observations['PR.DS-01 Ex1'];
+    expect(obs.platformProcedures).toEqual([REF]);
+    expect(obs.procedureSource.components).toHaveLength(2);
+  });
+
+  test('restore-side render: a corpus-less reference renders the explicit placeholder through the production choke point', () => {
+    // What a receiving install WITHOUT the corpus does with refs — the
+    // placeholder, never a silent drop, never a crash (plan §7 R-3).
+    // eslint-disable-next-line global-require
+    const { expandProcedureText } = require('./platformBank');
+    const { stores } = makeStores(withRefs());
+    const parsed = JSON.parse(JSON.stringify(exportAllDataJSON(stores)));
+    const obs = parsed.data.assessments[0].observations['PR.DS-01 Ex1'];
+    const out = expandProcedureText(obs);
+    expect(out).toContain('Trunk text.');
+    expect(out).toContain('Unresolved platform procedure reference');
+    expect(out).toContain(REF.policyId);
+    expect(out).toContain(REF.corpusVersion);
+    expect(out).toContain(REF.contentHash);
+  });
+
+  test('a file from a newer format (6) is still rejected with the newer-version message', () => {
+    const result = validateDatabaseExport({ formatVersion: 6, data: { users: [] } });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/newer version/i);
+  });
+});
+
+describe('PR-5: share-import round trip is NOT permanently detached (recipe rides)', () => {
+  test('resetToCommunityUpdate on an imported share observation re-references from the recipe', () => {
+    // The share consumed the refs (expansion-on-export), but the recipe in
+    // procedureSource.components rides the share — so a receiving install
+    // that Resets gets the trunk pristine AND the addenda back as pristine
+    // REFERENCES. Import of a share is a re-referenceable state, not a
+    // permanent detach.
+    // eslint-disable-next-line global-require
+    const { buildShareableExport } = require('./dataExport');
+    // eslint-disable-next-line global-require
+    const { resetToCommunityUpdate } = require('./procedureBank');
+    const REF_A = {
+      corpusId: 'scuba',
+      corpusVersion: 'aaaaaaaaaaaaaaaa',
+      policyId: 'ms.aad.1.1v1',
+      contentHash: '1111111111111111'
+    };
+    const { stores } = makeStores({
+      ...SAMPLE,
+      assessments: [
+        {
+          id: 'a1',
+          name: 'Assessment',
+          observations: {
+            'PR.DS-01 Ex1': {
+              testProcedures: 'Trunk.',
+              platformProcedures: [REF_A],
+              procedureSource: {
+                bank: 'community',
+                bankId: 'PR.DS-01',
+                tailored: false,
+                modified: false,
+                components: [
+                  { kind: 'trunk', bank: 'community', bankId: 'PR.DS-01' },
+                  { kind: 'platform-ref', ...REF_A }
+                ]
+              },
+              quarters: {}
+            }
+          }
+        }
+      ]
+    });
+    const share = JSON.parse(JSON.stringify(buildShareableExport(stores)));
+    const sharedObs = share.data.assessments[0].observations['PR.DS-01 Ex1'];
+    expect(sharedObs.platformProcedures).toBeUndefined(); // consumed by expansion
+
+    const { stores: targetStores, setters } = makeStores();
+    const result = importCompleteDatabase(share, targetStores, { backupFirst: false });
+    expect(result.applied).toEqual(expect.arrayContaining(['assessments']));
+    const imported = setters.setAssessments.mock.calls[0][0][0].observations['PR.DS-01 Ex1'];
+    expect(imported.platformProcedures).toBeUndefined();
+    expect(imported.procedureSource.components).toHaveLength(2);
+
+    const update = resetToCommunityUpdate('PR.DS-01 Ex1', imported.procedureSource);
+    expect(update.platformProcedures).toEqual([REF_A]); // re-referenced from the recipe
+  });
+
+  test('a format-4 backup is still accepted (heal-in-place, not stranded at the gate)', () => {
+    const result = validateDatabaseExport({ formatVersion: 4, data: { users: [] } });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/utils/egressCensus.test.js
+++ b/src/utils/egressCensus.test.js
@@ -111,3 +111,74 @@ describe('egress census', () => {
     expect(EGRESS_PATTERN.test(stripComments('// URL.createObjectURL( in prose'))).toBe(false);
   });
 });
+
+describe('report surfaces never render procedure text (plan §7 R-9 rot-stopper)', () => {
+  // The claim "no report/PDF surface renders testProcedures" was a grep FACT
+  // with no pin — so it could rot silently the day a report gained the
+  // field. This turns it into an invariant: the report generators must not
+  // reference testProcedures (or the platform reference field) at all. If a
+  // report legitimately needs procedure text one day, it must consume the
+  // expansion choke point (expandProcedureText) so attribution and
+  // placeholder semantics ride along — update this test deliberately then.
+  const REPORT_SURFACES = ['utils/auditReportMarkdown.js', 'utils/executiveSummaryPDF.js'];
+
+  test.each(REPORT_SURFACES)('%s does not reference testProcedures or platformProcedures', (rel) => {
+    const code = stripComments(fs.readFileSync(path.join(SRC, rel), 'utf8'));
+    expect(code).not.toMatch(/testProcedures/);
+    expect(code).not.toMatch(/platformProcedures/);
+  });
+});
+
+describe('choke-point wiring rot-stoppers (PR-5)', () => {
+  const read = (rel) => stripComments(fs.readFileSync(path.join(SRC, rel), 'utf8'));
+
+  test('the detail-panel render egress routes through expandProcedureText (positive pin)', () => {
+    // The fifth choke-point consumer. A revert of the render call-site swap
+    // to raw currentObservation.testProcedures would show trunk-only text on
+    // screen while every export carries the full expansion — this pin makes
+    // that revert red without mounting the page.
+    const page = read('pages/Assessments.js');
+    expect(page).toMatch(/expandProcedureText\(currentObservation\)/);
+  });
+
+  test('every store egress emission routes through the choke point (residual count-pin)', () => {
+    // assessmentsStore.js legitimately reads obs.testProcedures in exactly
+    // FOUR non-egress places: the frozen v14 migration block (3 reads) and
+    // the observations→evaluations migration (1 read). The four CSV/Jira
+    // egress emissions all call expandProcedureText(obs) — 5 call sites
+    // (exportForJiraCSV emits twice: custom field + description). Pin both
+    // counts: a NEW exporter written against obs.testProcedures bumps the
+    // residual count and goes red here, forcing the expansion decision at
+    // commit time instead of a silent trunk-only artifact.
+    const store = read('stores/assessmentsStore.js');
+    const residualReads = (store.match(/obs\.testProcedures/g) || []).length;
+    const chokeCalls = (store.match(/expandProcedureText\(obs\)/g) || []).length;
+    expect(chokeCalls).toBe(5);
+    expect(residualReads).toBe(4);
+  });
+
+  test('composition-writer guard: only sanctioned modules write the reference/recipe keys', () => {
+    // Reset replays procedureSource.components verbatim, so the recipe and
+    // the live platformProcedures array must be written together — funneled
+    // through the compose/reset producers. A new writer outside this set
+    // (e.g. a PR-6 UI splicing the live array without re-recording the
+    // recipe) must show up here and force the review.
+    const WRITERS = new Set([
+      'utils/procedureBank.js', // resetToCommunityUpdate recipe replay
+      'utils/procedureTailor.js', // composeAttachObservation
+      'utils/shareRegistry.js' // registry DECLARATION of the field (not a write)
+    ]);
+    // Write-shaped matches only: an object-literal key (`platformProcedures:`
+    // on one line) or a property assignment (`.platformProcedures =`).
+    // Multiline ternary READS (expansion) deliberately do not match.
+    const WRITE_PATTERN = /platformProcedures:|\.platformProcedures\s*=[^=]/;
+    const offenders = [];
+    walk(SRC).forEach((full) => {
+      const rel = path.relative(SRC, full);
+      if (WRITE_PATTERN.test(stripComments(fs.readFileSync(full, 'utf8'))) && !WRITERS.has(rel)) {
+        offenders.push(rel);
+      }
+    });
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/utils/platformBank.js
+++ b/src/utils/platformBank.js
@@ -1,0 +1,300 @@
+/**
+ * Platform procedure bank — runtime access to the generated
+ * src/data/platformProcedures.json (SCuBA baselines, one record per policy)
+ * and the committed policy→subcategory map, plus the REFERENCE machinery
+ * (plan §7 R-3): observations never copy platform text — they carry
+ * references, and every render/text-egress expands them here.
+ *
+ * Attach semantics are reference-on-attach (unlike the community bank's
+ * copy-on-attach): reverse cardinality is untenable for copies — attractor
+ * subcategories receive up to 122 policy addenda (PR.DS-10; measured on the
+ * committed map). A reference is {corpusId, corpusVersion, policyId,
+ * contentHash}; expansion resolves it against the CURRENT corpus (v1
+ * durability model: no corpus snapshots — withdrawal/rev is
+ * regeneration-not-migration, and an unresolvable reference renders an
+ * explicit placeholder carrying its identity, never a silent drop).
+ * User edits fork copy-on-write to a concrete provenance-flagged value, so
+ * nothing user-authored can ever become unresolvable.
+ *
+ * expandProcedureText is the SINGLE choke point (plan §7 R-9): render, the
+ * JSON share export, and every CSV/Jira text egress call it, and it is where
+ * attribution is (re)asserted from provenance and where modification
+ * indication derives from the tailored/modified flags.
+ */
+import platformBankJson from '../data/platformProcedures.json';
+import subcategoryMap from '../data/platformSubcategoryMap.json';
+import { licenseGate, mayTailor, refusalPlaceholder } from './licenseClass.mjs';
+import { CISA_NOTICE_KEY, CISA_DISCLAIMER } from './thirdPartyNotices.mjs';
+
+/**
+ * Corpus identity. 'scuba' names the vendored SCuBA-baseline corpus; a future
+ * corpus (e.g. a manifest-gated myctrl lane, plan PR-8) registers its own id
+ * here. References carry the id so resolution is a POSITIVE registry match —
+ * a ref from a corpus this build does not know resolves to the placeholder,
+ * never against some other corpus (the R-6 inversion class).
+ */
+export const PLATFORM_CORPUS_ID = 'scuba';
+const CORPORA = { [PLATFORM_CORPUS_ID]: platformBankJson };
+
+export const PLATFORM_CORPUS_VERSION = platformBankJson.bankVersion;
+
+/** Display labels for map platform ids; unknown ids fall back to the raw id
+ *  so a record from a newer corpus never loses its label silently. */
+const PLATFORM_LABELS = {
+  'google-workspace': 'Google Workspace',
+  'microsoft-365': 'Microsoft 365'
+};
+export const platformLabel = (platformId) => PLATFORM_LABELS[platformId] || String(platformId);
+
+/**
+ * Positive corpus lookup: record for (corpusId, policyId), or null.
+ * Null means "cannot resolve — do not substitute": unknown corpus ids and
+ * withdrawn/revised policy ids both land here, and callers render the
+ * explicit placeholder rather than guessing.
+ */
+export const getPlatformRecord = (corpusId, policyId) => {
+  const corpus = CORPORA[corpusId];
+  const record = corpus?.procedures?.[policyId];
+  return record || null;
+};
+
+/**
+ * Invert the committed policy→subcategory map at runtime: every policy of an
+ * in-scope platform whose pairs name this subcategory is OFFERED. Unranked by
+ * ratified doctrine (G22: an arbitrary ranking is noise with an authority
+ * veneer) — the order is the committed map's key order and carries no
+ * semantics. Each offer passes the pair through so consumers that rank or
+ * filter on grain read grainVias (the lossless multiset); grain itself is
+ * display-only.
+ *
+ * @param {string} subcategoryId - CSF subcategory (e.g. 'PR.AA-05')
+ * @param {string[]} platforms - map platform ids (e.g. ['google-workspace'])
+ * @returns {Array<{corpusId, policyId, record, pair}>}
+ */
+export const getPlatformProcedures = (subcategoryId, platforms) => {
+  const wanted = new Set(Array.isArray(platforms) ? platforms : []);
+  if (!subcategoryId || wanted.size === 0) return [];
+  const offers = [];
+  Object.entries(subcategoryMap.policies).forEach(([policyId, entry]) => {
+    if (!wanted.has(entry.platform)) return;
+    const pair = entry.pairs.find((p) => p.subcategoryId === subcategoryId);
+    if (!pair) return;
+    const record = getPlatformRecord(PLATFORM_CORPUS_ID, policyId);
+    if (!record) return; // map/bank drift — impossible while the freshness pin holds
+    offers.push({ corpusId: PLATFORM_CORPUS_ID, policyId, record, pair });
+  });
+  return offers;
+};
+
+/**
+ * Content fields the reference hash covers — the substance a user attached.
+ * Deliberately excludes license/attribution metadata (attribution is asserted
+ * from the CURRENT corpus at egress, not pinned at attach) and sourcePath
+ * (vendoring layout is not content).
+ */
+const CONTENT_HASH_FIELDS = [
+  'policyId',
+  'group',
+  'assertion',
+  'obligation',
+  'rationale',
+  'instructions',
+  'lastModified'
+];
+
+/* FNV-1a 64-bit over the picked-field JSON — deterministic, dependency-free,
+ * synchronous (crypto.subtle is async and node-only hashes don't bundle).
+ * The hash is OUR artifact-drift fingerprint, not a security boundary. */
+/* global BigInt */
+const fnv1a64 = (str) => {
+  let hash = 0xcbf29ce484222325n;
+  const prime = 0x100000001b3n;
+  const mask = 0xffffffffffffffffn;
+  for (let i = 0; i < str.length; i += 1) {
+    hash ^= BigInt(str.charCodeAt(i));
+    hash = (hash * prime) & mask;
+  }
+  return hash.toString(16).padStart(16, '0');
+};
+
+/** Deterministic fingerprint of a record's content fields. */
+export const platformRecordContentHash = (record) =>
+  fnv1a64(JSON.stringify(CONTENT_HASH_FIELDS.map((f) => record?.[f] ?? null)));
+
+/**
+ * Build the reference an observation stores for one corpus record — the R-3
+ * shape, exactly: {corpusId, corpusVersion, policyId, contentHash}. Never
+ * text. contentHash rides so drift between the attach-time content and a
+ * regenerated corpus is detectable (and travels into the placeholder when a
+ * ref stops resolving).
+ */
+export const buildPlatformRef = (record, corpusId = PLATFORM_CORPUS_ID) => ({
+  corpusId,
+  corpusVersion: CORPORA[corpusId]?.bankVersion ?? PLATFORM_CORPUS_VERSION,
+  policyId: record.id,
+  contentHash: platformRecordContentHash(record)
+});
+
+/**
+ * Copy-on-write fork: the concrete, provenance-flagged value a reference
+ * becomes on FIRST user edit. Keeps the ref identity fields (provenance for
+ * attribution + drift evidence) and adds the user's text; `modified: true`
+ * is what the egress choke point derives the change-indication line from
+ * (CC BY §3(a)(1)(B) is a runtime behavior, not a static line — §7 R-9).
+ * A fork owns its text, so it can never become unresolvable.
+ *
+ * POSITIVE guard (plan §7 R-3): forking requires a truthy corpus lookup —
+ * you can only edit content that resolved (a placeholder has no base text)
+ * — AND the resolved record's license must permit derivatives (editing IS a
+ * derivative; the transform binding of the license gate). Returns null when
+ * either fails; callers treat null as "cannot fork — do not write".
+ */
+export const forkPlatformProcedure = (ref, text) => {
+  const record = getPlatformRecord(ref.corpusId, ref.policyId);
+  if (!record || !mayTailor(record)) return null;
+  return {
+    corpusId: ref.corpusId,
+    corpusVersion: ref.corpusVersion,
+    policyId: ref.policyId,
+    contentHash: ref.contentHash,
+    text,
+    modified: true,
+    forkedAt: new Date().toISOString()
+  };
+};
+
+/**
+ * Content drift between a reference's attach-time fingerprint and the
+ * CURRENT corpus record: true (drifted), false (byte-stable), or null when
+ * the ref does not resolve (drift is unknowable — the placeholder already
+ * carries the identity). PR-5 stores and detects drift but deliberately does
+ * NOT surface it in expansion output — the drift badge/notice is PR-7 UI
+ * (pinned by the drift-silent expansion test so the deferral is a stated
+ * decision, not an assumption).
+ */
+export const platformRefDrift = (entry) => {
+  const record = getPlatformRecord(entry?.corpusId, entry?.policyId);
+  if (!record) return null;
+  return platformRecordContentHash(record) !== entry.contentHash;
+};
+
+/** A fork carries its own text; everything else is still a reference. */
+export const isPlatformFork = (entry) => typeof entry?.text === 'string';
+
+/**
+ * Explicit placeholder for a reference this installation cannot resolve
+ * (unknown corpus, withdrawn or revised policy). Carries the full ref
+ * identity — policyId, corpusVersion, contentHash — and is NEVER a silent
+ * drop (§7 R-3; ratified v1 durability model).
+ */
+export const unresolvedRefPlaceholder = (entry) =>
+  `> ⚠ Unresolved platform procedure reference: policy \`${entry.policyId}\` ` +
+  `(corpus \`${entry.corpusId}\` @ ${entry.corpusVersion}, content ${entry.contentHash}). ` +
+  'This installation\'s platform corpus does not contain the referenced policy — the corpus is ' +
+  'absent, or the policy was withdrawn or revised upstream. The reference is preserved; ' +
+  're-attach from a current platform pack to replace it.';
+
+/* One addendum block. Attribution is asserted HERE, from provenance —
+ * the current corpus record's attribution block for references, the ref
+ * identity fields for forks whose corpus is gone. Record text is emitted
+ * VERBATIM (never truncated/reflowed), which is also what a noDerivatives
+ * license permits, so the verbatim-or-omit rule holds by construction. */
+const renderAddendum = (entry) => {
+  const record = getPlatformRecord(entry.corpusId, entry.policyId);
+
+  if (isPlatformFork(entry)) {
+    // User-owned concrete value: the text always renders (nothing
+    // user-authored can become unresolvable). Attribution re-asserts from
+    // the current corpus when it still resolves, from the ref fields when
+    // it does not; the change-indication line derives from the flag.
+    const lines = [entry.text];
+    if (record?.attribution?.attributionText) {
+      lines.push(`*${record.attribution.attributionText}*`);
+    } else {
+      lines.push(
+        `*Adapted from platform policy ${entry.policyId} (corpus ${entry.corpusId}); upstream attribution applies.*`
+      );
+    }
+    if (entry.modified) {
+      lines.push('*This platform procedure has been modified from the referenced original.*');
+    }
+    return lines.join('\n\n');
+  }
+
+  if (!record) return unresolvedRefPlaceholder(entry);
+
+  const gate = licenseGate(record);
+  const header = `**Platform procedure — ${record.policyId} (${platformLabel(record.platform)})**`;
+  if (!gate.allow) {
+    // Fail-closed: zero licensed text, explicit and visible.
+    return [header, refusalPlaceholder(gate.reason)].join('\n\n');
+  }
+
+  const lines = [header, record.assertion, record.instructions].filter(Boolean);
+  const attribution = record.attribution || {};
+  const credit = [];
+  if (attribution.attributionText) credit.push(`*${attribution.attributionText}*`);
+  if (record.license) credit.push(`License: ${record.license}.`);
+  if (attribution.sourceUrl) credit.push(`[Source](${attribution.sourceUrl})`);
+  if (credit.length) lines.push(credit.join(' '));
+  return lines.join('\n\n');
+};
+
+/* Notice obligations across the expansion, emitted once per output rather
+ * than once per addendum. The CISA key resolves to the canonical disclaimer;
+ * literal notice strings pass through. Forks are NOT skipped: adapted
+ * content still derives from the notice-bearing upstream, so a fork whose
+ * record resolves carries the record's notices (an orphan fork has no
+ * resolvable record and therefore no knowable notices — its attribution
+ * falls back to the ref fields in renderAddendum). */
+const noticeLines = (entries) => {
+  const keys = new Set();
+  entries.forEach((entry) => {
+    const record = getPlatformRecord(entry.corpusId, entry.policyId);
+    (record?.licenseObligations?.noticeText || []).forEach((n) => keys.add(n));
+  });
+  const lines = [];
+  if (keys.delete(CISA_NOTICE_KEY)) lines.push(`> ${CISA_DISCLAIMER}`);
+  keys.forEach((literal) => lines.push(`> ${literal}`));
+  return lines;
+};
+
+/**
+ * THE expansion choke point (plan §7 R-3/R-9). Render and every text egress
+ * — the JSON share export, the four CSV/Jira exporters — pass an observation
+ * through here; no surface composes platform text on its own.
+ *
+ * Contract:
+ *  - no platform entries → returns testProcedures byte-identical (pinned);
+ *  - references expand from the CURRENT corpus with attribution asserted
+ *    from provenance; a gate-refused record renders the fail-closed refusal;
+ *  - unresolvable references render the explicit identity-carrying
+ *    placeholder — never a silent drop, never a throw;
+ *  - forks render their own text with flag-derived modification indication;
+ *  - a licensed TRUNK with a changeIndication obligation and modified or
+ *    tailored flags gets its indication line here too (no trunk carries
+ *    license obligations today; the community bank is unlicensed own-content).
+ */
+export const expandProcedureText = (observation) => {
+  if (!observation || typeof observation !== 'object') return '';
+  const trunk = typeof observation.testProcedures === 'string' ? observation.testProcedures : '';
+  const entries = Array.isArray(observation.platformProcedures)
+    ? observation.platformProcedures
+    : [];
+  const source = observation.procedureSource;
+  const trunkIndication =
+    source?.licenseObligations?.changeIndication && (source.modified || source.tailored)
+      ? '*This procedure text has been modified from the attached source version.*'
+      : null;
+  if (entries.length === 0 && !trunkIndication) return trunk;
+
+  const parts = [];
+  if (trunk) parts.push(trunk);
+  if (trunkIndication) parts.push(trunkIndication);
+  entries.forEach((entry) => {
+    parts.push('---');
+    parts.push(renderAddendum(entry));
+  });
+  parts.push(...noticeLines(entries));
+  return parts.join('\n\n');
+};

--- a/src/utils/platformBank.js
+++ b/src/utils/platformBank.js
@@ -105,7 +105,7 @@ const CONTENT_HASH_FIELDS = [
 /* FNV-1a 64-bit over the picked-field JSON — deterministic, dependency-free,
  * synchronous (crypto.subtle is async and node-only hashes don't bundle).
  * The hash is OUR artifact-drift fingerprint, not a security boundary. */
-/* global BigInt */
+/* eslint-env es2020 */
 const fnv1a64 = (str) => {
   let hash = 0xcbf29ce484222325n;
   const prime = 0x100000001b3n;

--- a/src/utils/platformBank.test.js
+++ b/src/utils/platformBank.test.js
@@ -1,0 +1,450 @@
+/**
+ * Platform bank reference machinery + THE expansion choke point (plan §7
+ * R-3/R-9; PR-5).
+ *
+ * Every expansion assertion here executes expandProcedureText — the
+ * PRODUCTION render path (the detail panel, the JSON share transform, and
+ * all four CSV/Jira egresses call this exact function) — never a
+ * re-implementation (standing doctrine, G19).
+ *
+ * Decorrelation fixtures target the named mutant classes:
+ *  - negative-guard COW: an implementation that treats corpus-lookup FAILURE
+ *    as "concrete value" renders nothing for an unresolvable ref — the
+ *    placeholder assertions kill it; one that treats lookup SUCCESS as
+ *    "render corpus text" for a fork loses the user's edit — the
+ *    fork-beats-corpus fixture kills it.
+ *  - placeholder-dropping: silent-drop and throw are both asserted against.
+ */
+import bank from '../data/platformProcedures.json';
+import subcategoryMap from '../data/platformSubcategoryMap.json';
+import {
+  PLATFORM_CORPUS_ID,
+  PLATFORM_CORPUS_VERSION,
+  getPlatformRecord,
+  getPlatformProcedures,
+  platformRecordContentHash,
+  buildPlatformRef,
+  forkPlatformProcedure,
+  isPlatformFork,
+  unresolvedRefPlaceholder,
+  expandProcedureText,
+  platformLabel,
+  platformRefDrift
+} from './platformBank';
+import { CISA_DISCLAIMER } from './thirdPartyNotices.mjs';
+
+const REAL_POLICY = 'ms.aad.1.1v1'; // CC0+CC-BY M365 record: attribution + notice obligations
+const realRecord = bank.procedures[REAL_POLICY];
+const realRef = () => buildPlatformRef(realRecord);
+
+describe('corpus identity + freshness', () => {
+  test('cross-artifact freshness pin: the committed map derives from the committed bank', () => {
+    expect(subcategoryMap.derivedFromBankVersion).toBe(bank.bankVersion);
+    expect(PLATFORM_CORPUS_VERSION).toBe(bank.bankVersion);
+  });
+
+  test('positive lookup: real (corpusId, policyId) resolves; anything else is null', () => {
+    expect(getPlatformRecord(PLATFORM_CORPUS_ID, REAL_POLICY)).toBe(realRecord);
+    expect(getPlatformRecord(PLATFORM_CORPUS_ID, 'gws.withdrawn.9.9v9')).toBeNull();
+    expect(getPlatformRecord('myctrl', REAL_POLICY)).toBeNull(); // foreign corpus
+    expect(getPlatformRecord(undefined, REAL_POLICY)).toBeNull();
+    expect(getPlatformRecord(PLATFORM_CORPUS_ID, undefined)).toBeNull();
+  });
+});
+
+describe('getPlatformProcedures — runtime map inversion, unranked', () => {
+  const BOTH = ['google-workspace', 'microsoft-365'];
+
+  test('exact reverse-cardinality pins re-derived at the committed map', () => {
+    // Derived + authored pairs, both platforms — these sizes are WHY the
+    // compose-into-text model is dead and references are mandatory (R-3).
+    expect(getPlatformProcedures('PR.DS-10', BOTH)).toHaveLength(122);
+    expect(getPlatformProcedures('DE.CM-01', BOTH)).toHaveLength(117);
+    expect(getPlatformProcedures('PR.DS-01', BOTH)).toHaveLength(95);
+    expect(getPlatformProcedures('PR.DS-02', BOTH)).toHaveLength(94);
+  });
+
+  test('platform filter partitions exactly (per-platform counts sum to both-platform count)', () => {
+    const gws = getPlatformProcedures('PR.DS-10', ['google-workspace']);
+    const m365 = getPlatformProcedures('PR.DS-10', ['microsoft-365']);
+    expect(gws.length + m365.length).toBe(122);
+    expect(gws.every((o) => o.record.platform === 'google-workspace')).toBe(true);
+    expect(m365.every((o) => o.record.platform === 'microsoft-365')).toBe(true);
+  });
+
+  test('unknown subcategory / empty platform scope offer nothing', () => {
+    expect(getPlatformProcedures('ZZ.ZZ-99', BOTH)).toEqual([]);
+    expect(getPlatformProcedures('PR.DS-10', [])).toEqual([]);
+    expect(getPlatformProcedures('PR.DS-10', undefined)).toEqual([]);
+    expect(getPlatformProcedures(null, BOTH)).toEqual([]);
+  });
+
+  test('unranked: offers ride in committed-map key order, no ordering logic', () => {
+    const offers = getPlatformProcedures('PR.DS-10', BOTH).map((o) => o.policyId);
+    const mapOrder = Object.entries(subcategoryMap.policies)
+      .filter(([, e]) => e.pairs.some((p) => p.subcategoryId === 'PR.DS-10'))
+      .map(([id]) => id);
+    expect(offers).toEqual(mapOrder);
+  });
+
+  test('offers pass the pair through — grainVias is the rank/filter surface', () => {
+    const offers = getPlatformProcedures('DE.CM-01', BOTH);
+    offers.forEach((o) => {
+      expect(o.corpusId).toBe(PLATFORM_CORPUS_ID);
+      expect(o.record).toBe(bank.procedures[o.policyId]);
+      expect(o.pair.subcategoryId).toBe('DE.CM-01');
+    });
+    // Derived pairs carry grainVias (G22 ISC-828 contract); authored pairs
+    // have no grain axis at all — both shapes pass through untouched.
+    const derived = offers.filter((o) => o.pair.provenance === 'derived');
+    const rest = offers.filter((o) => o.pair.provenance !== 'derived');
+    expect(derived.length).toBeGreaterThan(0);
+    expect(rest.length).toBeGreaterThan(0);
+    expect(derived.every((o) => o.pair.grainVias && o.pair.grain)).toBe(true);
+    expect(rest.every((o) => o.pair.provenance === 'authored')).toBe(true);
+  });
+});
+
+describe('reference shape + content hash', () => {
+  test('buildPlatformRef is exactly {corpusId, corpusVersion, policyId, contentHash}', () => {
+    const ref = realRef();
+    expect(Object.keys(ref).sort()).toEqual([
+      'contentHash',
+      'corpusId',
+      'corpusVersion',
+      'policyId'
+    ]);
+    expect(ref.corpusId).toBe(PLATFORM_CORPUS_ID);
+    expect(ref.corpusVersion).toBe(bank.bankVersion);
+    expect(ref.policyId).toBe(REAL_POLICY);
+    expect(ref.contentHash).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test('contentHash is deterministic and content-sensitive', () => {
+    expect(platformRecordContentHash(realRecord)).toBe(platformRecordContentHash(realRecord));
+    const revised = { ...realRecord, assertion: `${realRecord.assertion} (revised)` };
+    expect(platformRecordContentHash(revised)).not.toBe(platformRecordContentHash(realRecord));
+    // Metadata-only changes (attribution refresh, vendoring layout) do NOT
+    // re-fingerprint content — the ref means "this substance", not this path.
+    const relocated = { ...realRecord, sourcePath: 'vendor/elsewhere/aad.md' };
+    expect(platformRecordContentHash(relocated)).toBe(platformRecordContentHash(realRecord));
+  });
+});
+
+describe('expandProcedureText — the choke point (production render path)', () => {
+  test('no platform entries: trunk returns byte-identical (pinned pass-through)', () => {
+    const trunk = '## Trunk text\n\nExamine the things.';
+    expect(expandProcedureText({ testProcedures: trunk })).toBe(trunk);
+    expect(
+      expandProcedureText({ testProcedures: trunk, platformProcedures: [] })
+    ).toBe(trunk);
+    expect(
+      expandProcedureText({
+        testProcedures: trunk,
+        procedureSource: { bank: 'community', bankId: 'GV.OC-01', modified: true }
+      })
+    ).toBe(trunk); // community trunk carries no changeIndication obligation
+  });
+
+  test('total on junk: null/undefined/non-object/non-string never throw', () => {
+    expect(expandProcedureText(null)).toBe('');
+    expect(expandProcedureText(undefined)).toBe('');
+    expect(expandProcedureText({})).toBe('');
+    expect(expandProcedureText({ testProcedures: 42 })).toBe('');
+  });
+
+  test('resolvable ref expands CURRENT corpus text with attribution asserted from provenance', () => {
+    const out = expandProcedureText({
+      testProcedures: 'Trunk first.',
+      platformProcedures: [realRef()]
+    });
+    expect(out.startsWith('Trunk first.')).toBe(true);
+    expect(out).toContain('---');
+    expect(out).toContain(`**Platform procedure — ${realRecord.policyId} (Microsoft 365)**`);
+    expect(out).toContain(realRecord.assertion);
+    expect(out).toContain(realRecord.instructions);
+    // R-9: attribution re-asserted at the egress, from the corpus record
+    expect(out).toContain(realRecord.attribution.attributionText);
+    expect(out).toContain(`License: ${realRecord.license}.`);
+    // notice obligation rides the expansion (once per output)
+    expect(out).toContain(CISA_DISCLAIMER);
+    expect(out.split(CISA_DISCLAIMER)).toHaveLength(2);
+  });
+
+  test('notice emitted once even when several notice-bearing addenda expand', () => {
+    const other = bank.procedures['ms.aad.2.1v1'] || bank.procedures[REAL_POLICY];
+    const out = expandProcedureText({
+      testProcedures: 't',
+      platformProcedures: [realRef(), buildPlatformRef(other)]
+    });
+    expect(out.split(CISA_DISCLAIMER)).toHaveLength(2);
+  });
+
+  test('unresolvable ref renders the explicit identity-carrying placeholder — never a silent drop, never a throw', () => {
+    const withdrawn = { ...realRef(), policyId: 'ms.aad.99.9v9' };
+    const foreign = { ...realRef(), corpusId: 'myctrl' };
+    [withdrawn, foreign].forEach((ref) => {
+      const out = expandProcedureText({ testProcedures: 'Trunk.', platformProcedures: [ref] });
+      expect(out).not.toBe('Trunk.'); // not silently dropped
+      expect(out).toContain('Unresolved platform procedure reference');
+      expect(out).toContain(ref.policyId); // identity travels
+      expect(out).toContain(ref.corpusVersion);
+      expect(out).toContain(ref.contentHash);
+    });
+  });
+
+  test('placeholder helper itself carries all three identity fields', () => {
+    const ref = { corpusId: 'x', corpusVersion: 'v', policyId: 'p.1v1', contentHash: 'abc123' };
+    const text = unresolvedRefPlaceholder(ref);
+    expect(text).toContain('p.1v1');
+    expect(text).toContain('x');
+    expect(text).toContain('v');
+    expect(text).toContain('abc123');
+  });
+
+  test('resolvable and unresolvable refs coexist: both blocks render, order preserved', () => {
+    const out = expandProcedureText({
+      testProcedures: 'Trunk.',
+      platformProcedures: [realRef(), { ...realRef(), policyId: 'gone.1v1' }]
+    });
+    expect(out).toContain(realRecord.assertion);
+    expect(out).toContain('Unresolved platform procedure reference');
+    expect(out.indexOf(realRecord.assertion)).toBeLessThan(
+      out.indexOf('Unresolved platform procedure reference')
+    );
+  });
+});
+
+describe('copy-on-write forks (production render path)', () => {
+  test('forkPlatformProcedure produces the concrete provenance-flagged value', () => {
+    const fork = forkPlatformProcedure(realRef(), 'My edited addendum text.');
+    expect(fork.corpusId).toBe(PLATFORM_CORPUS_ID);
+    expect(fork.corpusVersion).toBe(bank.bankVersion);
+    expect(fork.policyId).toBe(REAL_POLICY);
+    expect(fork.contentHash).toBe(realRef().contentHash);
+    expect(fork.text).toBe('My edited addendum text.');
+    expect(fork.modified).toBe(true);
+    expect(typeof fork.forkedAt).toBe('string');
+    expect(isPlatformFork(fork)).toBe(true);
+    expect(isPlatformFork(realRef())).toBe(false);
+  });
+
+  test('COW polarity: forked entry renders the USER text (not corpus text) with flag-derived modification indication', () => {
+    // Kills the negative-guard mutant in the truthy-lookup direction: the
+    // corpus RESOLVES for this fork, yet the user's fork text must win.
+    const fork = forkPlatformProcedure(realRef(), 'USER-FORKED addendum body.');
+    const out = expandProcedureText({ testProcedures: 't', platformProcedures: [fork] });
+    expect(out).toContain('USER-FORKED addendum body.');
+    expect(out).not.toContain(realRecord.instructions);
+    expect(out).toContain('modified from the referenced original');
+    // attribution still re-asserts from the resolvable corpus record
+    expect(out).toContain(realRecord.attribution.attributionText);
+  });
+
+  test('COW polarity, other direction: unedited entry stays a reference (corpus text current, storage ref-shaped)', () => {
+    const ref = realRef();
+    const out = expandProcedureText({ testProcedures: 't', platformProcedures: [ref] });
+    expect(out).toContain(realRecord.instructions);
+    expect(out).not.toContain('modified from the referenced original');
+    expect(Object.keys(ref)).not.toContain('text'); // never became concrete
+  });
+
+  test('fork whose corpus vanished still renders the user text — nothing user-authored becomes unresolvable', () => {
+    const orphan = { ...forkPlatformProcedure(realRef(), 'Survivor text.'), corpusId: 'gone-corpus' };
+    const out = expandProcedureText({ testProcedures: 't', platformProcedures: [orphan] });
+    expect(out).toContain('Survivor text.');
+    expect(out).not.toContain('Unresolved platform procedure reference');
+    expect(out).toContain('upstream attribution applies'); // ref-field attribution fallback
+    expect(out).toContain('modified from the referenced original');
+  });
+
+  test('negative-guard discrimination: an unresolvable REF (no text) is a placeholder, never treated as concrete', () => {
+    // A wrong implementation guarding "corpus lookup failed ⇒ concrete
+    // value" renders undefined/empty text here and no placeholder.
+    const ref = { ...realRef(), corpusId: 'unknown-corpus' };
+    const out = expandProcedureText({ testProcedures: 't', platformProcedures: [ref] });
+    expect(out).toContain('Unresolved platform procedure reference');
+    expect(out).not.toContain('undefined');
+  });
+});
+
+describe('license gate + verbatim rule at the choke point (synthetic corpora)', () => {
+  const syntheticBank = (record) => ({
+    bankFormat: 'platform-procedures-v1',
+    bankVersion: 'feedfeedfeedfeed',
+    procedures: { [record.id]: record }
+  });
+
+  const expandWithCorpus = (record, entry) => {
+    let out;
+    jest.isolateModules(() => {
+      jest.doMock('../data/platformProcedures.json', () => syntheticBank(record));
+      // eslint-disable-next-line global-require
+      const mod = require('./platformBank');
+      out = mod.expandProcedureText({ testProcedures: 't', platformProcedures: [entry] });
+    });
+    jest.dontMock('../data/platformProcedures.json');
+    return out;
+  };
+
+  const baseRecord = {
+    id: 'syn.policy.1.1v1',
+    platform: 'google-workspace',
+    policyId: 'SYN.POLICY.1.1v1',
+    group: 'Synthetic',
+    assertion: 'Synthetic assertion SHALL hold.',
+    obligation: 'SHALL',
+    rationale: 'r',
+    instructions: 'Synthetic instructions body.',
+    lastModified: 'July 2026',
+    license: 'CC0-1.0'
+  };
+  const entryFor = () => ({
+    corpusId: 'scuba',
+    corpusVersion: 'feedfeedfeedfeed',
+    policyId: 'syn.policy.1.1v1',
+    contentHash: '0000000000000000'
+  });
+
+  test('gate-refused record (attribution obligation, no attribution block) expands to the fail-closed refusal — zero licensed text', () => {
+    const refused = { ...baseRecord, license: 'CC-BY-4.0' }; // attribution required, block missing
+    const out = expandWithCorpus(refused, entryFor());
+    expect(out).toContain('license requires an attribution record');
+    expect(out).not.toContain('Synthetic instructions body.');
+    expect(out).not.toContain('Synthetic assertion');
+  });
+
+  test('reference-only record expands to the reference-only refusal — zero licensed text', () => {
+    const refOnly = { ...baseRecord, license: 'CC-BY-NC-4.0' };
+    const out = expandWithCorpus(refOnly, entryFor());
+    expect(out).toContain('reference-only under its license');
+    expect(out).not.toContain('Synthetic instructions body.');
+  });
+
+  test('noDerivatives record expands byte-VERBATIM (no truncation/reflow at the choke point)', () => {
+    const nd = {
+      ...baseRecord,
+      license: 'CC-BY-ND-4.0',
+      attribution: {
+        attributionText: 'Synthetic upstream attribution.',
+        sourceUrl: 'https://example.test/baseline',
+        licenseUrl: 'https://example.test/license',
+        retrievedAt: '2026-07-20',
+        upstream: { repo: 'example/upstream', sha: 'abc123', path: 'baselines/x.md' }
+      }
+    };
+    const out = expandWithCorpus(nd, entryFor());
+    expect(out).toContain(nd.assertion); // verbatim, in full
+    expect(out).toContain(nd.instructions);
+    expect(out).toContain('Synthetic upstream attribution.');
+  });
+});
+
+describe('trunk modification indication derives from flags at egress (R-9)', () => {
+  const licensedTrunkSource = (flags) => ({
+    bank: 'future-licensed-bank',
+    bankId: 'PR.AA-05',
+    licenseObligations: { attribution: true, changeIndication: true, noticeText: [] },
+    ...flags
+  });
+
+  test('changeIndication obligation + modified flag emits the indication line', () => {
+    const out = expandProcedureText({
+      testProcedures: 'Licensed trunk text.',
+      procedureSource: licensedTrunkSource({ modified: true })
+    });
+    expect(out).toContain('Licensed trunk text.');
+    expect(out).toContain('modified from the attached source version');
+  });
+
+  test('tailored flag triggers it too; clean flags do not', () => {
+    expect(
+      expandProcedureText({
+        testProcedures: 'x',
+        procedureSource: licensedTrunkSource({ tailored: true })
+      })
+    ).toContain('modified from the attached source version');
+    expect(
+      expandProcedureText({
+        testProcedures: 'x',
+        procedureSource: licensedTrunkSource({ modified: false, tailored: false })
+      })
+    ).toBe('x');
+  });
+});
+
+describe('platform labels', () => {
+  test('known ids map to display names; unknown ids fall back to the raw id, never silently lost', () => {
+    expect(platformLabel('google-workspace')).toBe('Google Workspace');
+    expect(platformLabel('microsoft-365')).toBe('Microsoft 365');
+    expect(platformLabel('future-platform')).toBe('future-platform');
+  });
+});
+
+describe('advisor adoptions: drift, hash pin, corpus-id stability, degenerate refs, fork gate', () => {
+  test('PLATFORM_CORPUS_ID is a stable code literal, decoupled from bankVersion', () => {
+    // Resolution keys on (corpusId, policyId) against the CURRENT corpus.
+    // The id must never derive from corpus content: if regeneration changed
+    // it, every ref would placeholder simultaneously — the exact mass
+    // breakage the no-version-gating decision exists to prevent.
+    expect(PLATFORM_CORPUS_ID).toBe('scuba');
+    expect(PLATFORM_CORPUS_ID).not.toBe(PLATFORM_CORPUS_VERSION);
+  });
+
+  test('hash normalization pin: a frozen record hashes to an exact literal', () => {
+    // If the hash function or its field list/normalization ever changes,
+    // every stored ref falsely "drifts" at once. This fixture makes that a
+    // red test instead of a silent mass-drift.
+    const frozen = {
+      policyId: 'PIN.POLICY.1.1v1',
+      group: 'Pin Group',
+      assertion: 'Pinned assertion SHALL hold.',
+      obligation: 'SHALL',
+      rationale: 'Pinned rationale.',
+      instructions: 'Pinned instructions.',
+      lastModified: 'July 2026'
+    };
+    expect(platformRecordContentHash(frozen)).toBe('96f09e154cf4b8c6');
+  });
+
+  test('platformRefDrift: false on a fresh ref, true after content drift, null when unresolvable', () => {
+    expect(platformRefDrift(realRef())).toBe(false);
+    expect(platformRefDrift({ ...realRef(), contentHash: '0000000000000000' })).toBe(true);
+    expect(platformRefDrift({ ...realRef(), corpusId: 'gone' })).toBeNull();
+    expect(platformRefDrift(null)).toBeNull();
+  });
+
+  test('expansion is drift-SILENT in PR-5 (deliberate deferral — the drift badge is PR-7 UI)', () => {
+    const drifted = { ...realRef(), contentHash: '0000000000000000' };
+    const out = expandProcedureText({ testProcedures: 't', platformProcedures: [drifted] });
+    // resolves and renders the CURRENT corpus text, with no drift marker
+    expect(out).toContain(realRecord.assertion);
+    expect(out).not.toMatch(/drift/i);
+  });
+
+  test('degenerate ref entries ({} / partial) render the placeholder — never resolve by accident', () => {
+    [{}, { corpusId: PLATFORM_CORPUS_ID }, { policyId: REAL_POLICY }].forEach((entry) => {
+      const out = expandProcedureText({ testProcedures: 't', platformProcedures: [entry] });
+      expect(out).toContain('Unresolved platform procedure reference');
+      expect(out).not.toContain(realRecord.assertion);
+    });
+  });
+
+  test('fork gate: forking requires a truthy corpus lookup (positive guard) — unresolvable refs cannot fork', () => {
+    expect(forkPlatformProcedure({ ...realRef(), corpusId: 'gone' }, 'x')).toBeNull();
+    expect(forkPlatformProcedure({ ...realRef(), policyId: 'gone.1v1' }, 'x')).toBeNull();
+    expect(forkPlatformProcedure(realRef(), 'x')).not.toBeNull();
+  });
+
+  test('a fork restored byte-identical to the corpus text STAYS modified (flag-derived, never string-compare)', () => {
+    const fork = forkPlatformProcedure(realRef(), realRecord.instructions);
+    const out = expandProcedureText({ testProcedures: 't', platformProcedures: [fork] });
+    expect(out).toContain('modified from the referenced original');
+  });
+
+  test('a fork of a notice-bearing record still carries the notice (adapted content keeps obligations)', () => {
+    const fork = forkPlatformProcedure(realRef(), 'Adapted text.');
+    const out = expandProcedureText({ testProcedures: 't', platformProcedures: [fork] });
+    expect(out).toContain(CISA_DISCLAIMER);
+  });
+});

--- a/src/utils/procedureBank.js
+++ b/src/utils/procedureBank.js
@@ -123,20 +123,91 @@ export const buildProcedureSource = (bankId) => ({
 });
 
 /**
+ * The recorded composition recipe (plan §7 R-6). `procedureSource.components`
+ * is written at attach time and REPLAYED — never re-derived — by every
+ * consumer that needs the pristine composition back: the share-export
+ * pristine swap and Reset. Recording the derivation at write time is the
+ * root-cause fix for the class where every egress re-derives with its own
+ * stale copy of the composition rule.
+ *
+ * Component kinds:
+ *  - { kind: 'trunk', bank, bankId, bankVersion } — the procedure trunk
+ *  - { kind: 'platform-ref', corpusId, corpusVersion, policyId, contentHash }
+ *    — one per platform addendum reference attached alongside the trunk
+ */
+const trunkComponentOf = (source) =>
+  Array.isArray(source?.components)
+    ? source.components.find((c) => c && c.kind === 'trunk')
+    : null;
+
+const addendumComponentsOf = (source) =>
+  Array.isArray(source?.components)
+    ? source.components.filter((c) => c && c.kind === 'platform-ref')
+    : [];
+
+/**
+ * Pristine TRUNK text for a provenance source — the ONE named function the
+ * share-export registry resolves pristine text through (plan §5 C1, settled:
+ * dataExport.js is touched only via the registry and this function).
+ *
+ * Replays the recorded recipe when the source carries one (the trunk
+ * component names the bank entry to restore); legacy sources without a
+ * recipe resolve exactly as before via resolvePristine. Positive match only,
+ * and the fail-closed contract stays: an unresolvable trunk returns '' —
+ * "cannot restore — do not substitute", never some other bank's text.
+ * Flag-resetting (tailored/modified) stays in the CALLER.
+ */
+export const pristineProcedureText = (source) => {
+  const trunk = trunkComponentOf(source);
+  const resolved = resolvePristine(trunk ? { bank: trunk.bank, bankId: trunk.bankId } : source);
+  return resolved ? resolved.markdown : '';
+};
+
+/**
  * Pure producer for the detail panel's Insert / Reset-to-community action.
  * Returns the observation update (pristine markdown + pristine provenance),
  * or null when the item has no bank entry or the existing source belongs to
  * another bank — a community reset must never destroy foreign bank content
  * (plan §7 R-10). The page stays a dumb dispatcher.
+ *
+ * Reset REPLAYS the recorded recipe (plan §7 R-6 — the second destroyer,
+ * closed): the trunk goes back to the pristine community text, and every
+ * platform addendum recorded in the recipe survives as its pristine
+ * REFERENCE — copy-on-write forks of an addendum reset to the reference,
+ * they are not destroyed silently. A legacy source with no recipe produces
+ * an update without the platformProcedures key, so a merge-style caller
+ * cannot clobber addenda the recipe never recorded.
+ *
+ * CONTRACT for composition-changing writes (PR-6 and later): this replays
+ * `components[]` VERBATIM. Any UI that adds or removes an addendum must
+ * RE-RECORD the recipe in the same write — a removal that only splices the
+ * live platformProcedures array leaves the stale recipe behind, and Reset
+ * will resurrect the removed addendum. The composition-writer guard test
+ * (egressCensus.test.js) pins which modules may write these keys.
  */
 export const resetToCommunityUpdate = (itemId, existingSource) => {
   if (!canResetToCommunity(existingSource)) return null;
   const entry = getBankProcedure(itemId);
   if (!entry) return null;
-  return {
+  const update = {
     testProcedures: entry.markdown,
     procedureSource: buildProcedureSource(entry.bankId)
   };
+  const addenda = addendumComponentsOf(existingSource);
+  if (addenda.length > 0) {
+    const refs = addenda.map(({ corpusId, corpusVersion, policyId, contentHash }) => ({
+      corpusId,
+      corpusVersion,
+      policyId,
+      contentHash
+    }));
+    update.procedureSource.components = [
+      { kind: 'trunk', bank: COMMUNITY_BANK, bankId: entry.bankId, bankVersion: BANK_VERSION },
+      ...refs.map((r) => ({ kind: 'platform-ref', ...r }))
+    ];
+    update.platformProcedures = refs;
+  }
+  return update;
 };
 
 /**

--- a/src/utils/procedureBank.test.js
+++ b/src/utils/procedureBank.test.js
@@ -13,7 +13,8 @@ import {
   resolvePristine,
   canResetToCommunity,
   resetToCommunityUpdate,
-  sourceUrlFor
+  sourceUrlFor,
+  pristineProcedureText
 } from './procedureBank';
 import useAssessmentsStore from '../stores/assessmentsStore';
 
@@ -267,5 +268,141 @@ describe('resetToCommunityUpdate producer', () => {
 
   test('uncovered items produce no update', () => {
     expect(resetToCommunityUpdate('CTRL-042', undefined)).toBeNull();
+  });
+});
+
+describe('pristineProcedureText — recipe replay (plan §5 C1, §7 R-6)', () => {
+  const communityMarkdownOf = (bankId) => getBankProcedure(bankId).markdown;
+
+  test('legacy source (no recipe): byte-equal to the community bank markdown', () => {
+    const source = { bank: COMMUNITY_BANK, bankId: 'GV.OC-01', tailored: true };
+    expect(pristineProcedureText(source)).toBe(communityMarkdownOf('GV.OC-01'));
+  });
+
+  test('recipe replay: the trunk component names the entry to restore', () => {
+    const source = {
+      bank: COMMUNITY_BANK,
+      bankId: 'GV.OC-01',
+      components: [{ kind: 'trunk', bank: COMMUNITY_BANK, bankId: 'GV.OC-01', bankVersion: BANK_VERSION }]
+    };
+    expect(pristineProcedureText(source)).toBe(communityMarkdownOf('GV.OC-01'));
+  });
+
+  test('replay polarity: recipe changed ⇒ swap output changes', () => {
+    const withTrunk = (bankId) => ({
+      bank: COMMUNITY_BANK,
+      bankId: 'GV.OC-01',
+      components: [{ kind: 'trunk', bank: COMMUNITY_BANK, bankId, bankVersion: BANK_VERSION }]
+    });
+    const a = pristineProcedureText(withTrunk('GV.OC-01'));
+    const b = pristineProcedureText(withTrunk('PR.AA-05'));
+    expect(a).not.toBe(b);
+    expect(b).toBe(communityMarkdownOf('PR.AA-05'));
+  });
+
+  test('recipe-ignoring-mutant discrimination: when source.bankId and the recorded trunk diverge, the RECIPE wins', () => {
+    // A wrong implementation that re-derives from source.bankId succeeds at
+    // its wrong behavior here — it returns GV.OC-01 markdown. The recipe
+    // records PR.AA-05; replay must return PR.AA-05.
+    const source = {
+      bank: COMMUNITY_BANK,
+      bankId: 'GV.OC-01',
+      components: [{ kind: 'trunk', bank: COMMUNITY_BANK, bankId: 'PR.AA-05', bankVersion: BANK_VERSION }]
+    };
+    expect(pristineProcedureText(source)).toBe(communityMarkdownOf('PR.AA-05'));
+    expect(pristineProcedureText(source)).not.toBe(communityMarkdownOf('GV.OC-01'));
+  });
+
+  test("fail-closed '' stays: foreign trunk bank, dangling bankId, absent source", () => {
+    expect(
+      pristineProcedureText({
+        bank: 'foreign-bank',
+        bankId: 'GV.OC-01',
+        components: [{ kind: 'trunk', bank: 'foreign-bank', bankId: 'GV.OC-01' }]
+      })
+    ).toBe('');
+    expect(
+      pristineProcedureText({
+        bank: COMMUNITY_BANK,
+        bankId: 'GV.OC-01',
+        components: [{ kind: 'trunk', bank: COMMUNITY_BANK, bankId: 'ZZ.ZZ-99' }]
+      })
+    ).toBe('');
+    expect(pristineProcedureText(null)).toBe('');
+    expect(pristineProcedureText({ bank: 'unrecognized', bankId: 'GV.OC-01' })).toBe('');
+  });
+});
+
+describe('resetToCommunityUpdate — recipe replay closes the R-6 destroyer', () => {
+  const REF_A = {
+    corpusId: 'scuba',
+    corpusVersion: 'aaaaaaaaaaaaaaaa',
+    policyId: 'gws.gmail.1.1v1',
+    contentHash: '1111111111111111'
+  };
+  const REF_B = {
+    corpusId: 'scuba',
+    corpusVersion: 'aaaaaaaaaaaaaaaa',
+    policyId: 'ms.aad.1.1v1',
+    contentHash: '2222222222222222'
+  };
+  const composedSource = () => ({
+    bank: COMMUNITY_BANK,
+    bankId: 'GV.OC-01',
+    bankVersion: BANK_VERSION,
+    tailored: true,
+    modified: true,
+    components: [
+      { kind: 'trunk', bank: COMMUNITY_BANK, bankId: 'GV.OC-01', bankVersion: BANK_VERSION },
+      { kind: 'platform-ref', ...REF_A },
+      { kind: 'platform-ref', ...REF_B }
+    ]
+  });
+
+  test('replay: trunk goes pristine AND addendum refs survive from the recipe', () => {
+    const update = resetToCommunityUpdate('GV.OC-01 Ex1', composedSource());
+    expect(update.testProcedures).toBe(getBankProcedure('GV.OC-01').markdown);
+    expect(update.platformProcedures).toEqual([REF_A, REF_B]);
+    // the recipe is re-recorded on the fresh provenance, not dropped
+    expect(update.procedureSource.components).toEqual([
+      { kind: 'trunk', bank: COMMUNITY_BANK, bankId: 'GV.OC-01', bankVersion: BANK_VERSION },
+      { kind: 'platform-ref', ...REF_A },
+      { kind: 'platform-ref', ...REF_B }
+    ]);
+    expect(update.procedureSource.modified).toBe(false);
+  });
+
+  test('destroyer-closed polarity: a copy-on-write FORK resets to the pristine reference — the addendum is never destroyed', () => {
+    // The live observation may hold a fork (edited addendum); the recipe
+    // holds the pristine ref. Reset replays the recipe: the update's refs
+    // carry NO text field. A mutant that preserves the live array keeps the
+    // fork; a mutant that drops addenda loses the ref — both fail here.
+    const update = resetToCommunityUpdate('GV.OC-01 Ex1', composedSource());
+    update.platformProcedures.forEach((ref) => {
+      expect(Object.keys(ref).sort()).toEqual([
+        'contentHash',
+        'corpusId',
+        'corpusVersion',
+        'policyId'
+      ]);
+    });
+    expect(update.platformProcedures).toHaveLength(2);
+  });
+
+  test('legacy source without a recipe: update carries NO platformProcedures key (nothing clobbered)', () => {
+    const update = resetToCommunityUpdate('GV.OC-01 Ex1', {
+      bank: COMMUNITY_BANK,
+      bankId: 'GV.OC-01',
+      tailored: true
+    });
+    expect('platformProcedures' in update).toBe(false);
+    expect('components' in update.procedureSource).toBe(false);
+    expect(update.testProcedures).toBe(getBankProcedure('GV.OC-01').markdown);
+  });
+
+  test('foreign-bank source still refuses outright (R-10 unchanged)', () => {
+    expect(
+      resetToCommunityUpdate('GV.OC-01 Ex1', { bank: 'foreign-bank', bankId: 'GV.OC-01' })
+    ).toBeNull();
   });
 });

--- a/src/utils/procedureCompose.test.js
+++ b/src/utils/procedureCompose.test.js
@@ -1,0 +1,95 @@
+/**
+ * composeAttachObservation (plan §7 R-3/R-6; PR-5): trunk + platform
+ * REFERENCES + the recorded composition recipe. The addendum text must never
+ * be copied into the observation — that is the whole point of the reference
+ * model under measured reverse cardinality (122 policies on PR.DS-10).
+ */
+import bank from '../data/platformProcedures.json';
+import { bankAttachObservation, composeAttachObservation } from './procedureTailor';
+import { getBankProcedure, BANK_VERSION, COMMUNITY_BANK } from './procedureBank';
+import { getPlatformProcedures, PLATFORM_CORPUS_ID } from './platformBank';
+
+const trunkEntry = getBankProcedure('PR.AA-05');
+const offers = () => getPlatformProcedures('PR.AA-05', ['google-workspace']).slice(0, 3);
+
+describe('composeAttachObservation', () => {
+  test('writes references + recipe, never copied upstream text (byte-check on testProcedures)', () => {
+    const sample = offers();
+    expect(sample.length).toBe(3);
+    const composed = composeAttachObservation(trunkEntry, sample);
+    // trunk text is exactly the community attach — no addendum text baked in
+    expect(composed.testProcedures).toBe(bankAttachObservation(trunkEntry).testProcedures);
+    sample.forEach((offer) => {
+      expect(composed.testProcedures).not.toContain(offer.record.assertion);
+      expect(composed.testProcedures).not.toContain(offer.record.instructions);
+    });
+    // refs are the R-3 shape, exactly — no text field anywhere
+    expect(composed.platformProcedures).toHaveLength(3);
+    composed.platformProcedures.forEach((ref, i) => {
+      expect(Object.keys(ref).sort()).toEqual([
+        'contentHash',
+        'corpusId',
+        'corpusVersion',
+        'policyId'
+      ]);
+      expect(ref.corpusId).toBe(PLATFORM_CORPUS_ID);
+      expect(ref.corpusVersion).toBe(bank.bankVersion);
+      expect(ref.policyId).toBe(sample[i].policyId);
+    });
+  });
+
+  test('records the composition recipe in procedureSource.components at attach', () => {
+    const sample = offers();
+    const composed = composeAttachObservation(trunkEntry, sample);
+    const components = composed.procedureSource.components;
+    expect(components).toHaveLength(4); // trunk + 3 addenda
+    expect(components[0]).toEqual({
+      kind: 'trunk',
+      bank: COMMUNITY_BANK,
+      bankId: 'PR.AA-05',
+      bankVersion: BANK_VERSION
+    });
+    components.slice(1).forEach((c, i) => {
+      expect(c.kind).toBe('platform-ref');
+      expect(c.policyId).toBe(composed.platformProcedures[i].policyId);
+      expect(c.contentHash).toBe(composed.platformProcedures[i].contentHash);
+      expect(c.corpusId).toBe(PLATFORM_CORPUS_ID);
+      expect(c.corpusVersion).toBe(bank.bankVersion);
+    });
+    // the rest of the provenance object is the community attach, untouched
+    expect(composed.procedureSource.bank).toBe(COMMUNITY_BANK);
+    expect(composed.procedureSource.bankId).toBe('PR.AA-05');
+    expect(composed.procedureSource.tailored).toBe(false);
+    expect(composed.procedureSource.modified).toBe(false);
+  });
+
+  test('zero offers: trunk byte-identical to bankAttachObservation, trunk-only recipe, no platformProcedures key', () => {
+    const composed = composeAttachObservation(trunkEntry, []);
+    const plain = bankAttachObservation(trunkEntry);
+    expect(composed.testProcedures).toBe(plain.testProcedures);
+    expect('platformProcedures' in composed).toBe(false);
+    expect(composed.procedureSource.components).toEqual([
+      { kind: 'trunk', bank: COMMUNITY_BANK, bankId: 'PR.AA-05', bankVersion: BANK_VERSION }
+    ]);
+    // recipe aside, provenance matches the plain attach field-for-field
+    const composedRest = { ...composed.procedureSource };
+    delete composedRest.components;
+    delete composedRest.attachedAt;
+    const plainRest = { ...plain.procedureSource };
+    delete plainRest.attachedAt;
+    expect(composedRest).toEqual(plainRest);
+  });
+
+  test('tailoring options apply to the TRUNK only — addendum refs are identical either way', () => {
+    const sample = offers();
+    const profile = { orgName: 'Compose Test Org' };
+    const tailored = composeAttachObservation(trunkEntry, sample, profile, {
+      substituteName: true
+    });
+    const plain = composeAttachObservation(trunkEntry, sample);
+    expect(tailored.platformProcedures).toEqual(plain.platformProcedures);
+    expect(tailored.procedureSource.components.slice(1)).toEqual(
+      plain.procedureSource.components.slice(1)
+    );
+  });
+});

--- a/src/utils/procedureTailor.js
+++ b/src/utils/procedureTailor.js
@@ -21,6 +21,7 @@
 
 import { getBankProcedure, buildProcedureSource } from './procedureBank';
 import { licenseGate, licenseProvenance, mayTailor, refusalPlaceholder } from './licenseClass.mjs';
+import { buildPlatformRef } from './platformBank';
 import { CLOUD_TERMS, EDR_PRODUCTS, GOOGLE_EMAIL_TERMS } from './stackTailorMaps';
 
 /**
@@ -235,6 +236,41 @@ export const bankAttachObservation = (bankEntry, profile, options = {}) => {
       ...licenseProvenance(bankEntry)
     }
   };
+};
+
+/**
+ * Pure producer for the composed (trunk + platform addenda) attach path —
+ * what the PR-6 wizard Environment step will call. The trunk is the
+ * community attach exactly as bankAttachObservation produces it; platform
+ * offers (from getPlatformProcedures) attach as REFERENCES, never copied
+ * text (plan §7 R-3), and `procedureSource.components[]` records the
+ * composition recipe at attach time (plan §7 R-6) so the pristine swap and
+ * Reset replay a recorded derivation instead of re-deriving with their own
+ * copy of the composition rule.
+ *
+ * Zero offers compose to the trunk attach plus the trunk-only recipe — no
+ * platformProcedures key, so nothing rides observations that have no
+ * platform lane.
+ */
+export const composeAttachObservation = (bankEntry, platformOffers, profile, options = {}) => {
+  const trunk = bankAttachObservation(bankEntry, profile, options);
+  const offers = Array.isArray(platformOffers) ? platformOffers : [];
+  const refs = offers.map((offer) => buildPlatformRef(offer.record, offer.corpusId));
+  const components = [
+    {
+      kind: 'trunk',
+      bank: trunk.procedureSource.bank,
+      bankId: trunk.procedureSource.bankId,
+      bankVersion: trunk.procedureSource.bankVersion
+    },
+    ...refs.map((r) => ({ kind: 'platform-ref', ...r }))
+  ];
+  const composed = {
+    ...trunk,
+    procedureSource: { ...trunk.procedureSource, components }
+  };
+  if (refs.length > 0) composed.platformProcedures = refs;
+  return composed;
 };
 
 /**

--- a/src/utils/shareRegistry.js
+++ b/src/utils/shareRegistry.js
@@ -42,7 +42,8 @@
  */
 
 import { licenseIsRestricted } from './metricsImport';
-import { resolvePristine } from './procedureBank';
+import { pristineProcedureText } from './procedureBank';
+import { expandProcedureText } from './platformBank';
 
 export const SHARE = 'share';
 export const OMIT = 'omit';
@@ -53,9 +54,7 @@ export const STRIP_IF_EXCLUDED_METRIC = 'strip-if-excluded-metric';
 
 const struct = (fields) => ({ kind: 'struct', fields });
 const map = (of) => ({ kind: 'map', of });
-// A `list` node kind ({ kind: 'list', of }) is supported by the fold for
-// arrays of registered records; no current field needs it (rosters and id
-// arrays are SHARE leaves), so no helper exists until one does.
+const list = (of) => ({ kind: 'list', of });
 
 /**
  * Swap tailored procedures back to the pristine community version. The org
@@ -64,20 +63,40 @@ const map = (of) => ({ kind: 'map', of });
  * derived leak path. Provenance (procedureSource.bankId) makes the fix
  * deterministic: shared copies get the untailored community markdown. If the
  * source cannot be resolved, the text is dropped entirely — never leaked.
- * Resolution is a POSITIVE bank match (resolvePristine): a tailored source
- * carrying a bank label this build does not recognize drops to '' rather
- * than shipping community markdown under a foreign label. Registry-owned so
- * the pristine rule has exactly one home; applied as the observation record
- * transform in default share mode.
+ * Resolution goes through pristineProcedureText (plan §5 C1's ONE named
+ * function): it REPLAYS the recorded composition recipe when the source
+ * carries one and falls back to the positive legacy match otherwise. A
+ * tailored source carrying a bank label this build does not recognize drops
+ * to '' rather than shipping community markdown under a foreign label (the
+ * fail-closed fallback lives inside pristineProcedureText; flag-resetting
+ * stays HERE, in the caller). Registry-owned so the pristine rule has
+ * exactly one home; applied as the observation record transform in default
+ * share mode.
  */
 export const pristineObservation = (obs) => {
   if (!obs?.procedureSource?.tailored) return obs;
-  const pristine = resolvePristine(obs.procedureSource);
   return {
     ...obs,
-    testProcedures: pristine ? pristine.markdown : '',
+    testProcedures: pristineProcedureText(obs.procedureSource),
     procedureSource: { ...obs.procedureSource, tailored: false, modified: false }
   };
+};
+
+/**
+ * Expansion-on-export (plan §7 R-3, ratified default): a share export is the
+ * distributed artifact, so a receiving install must never depend on corpus
+ * presence or version. Observations carrying platform references have their
+ * testProcedures EXPANDED through the single choke point — trunk + addendum
+ * text + attribution (an unresolvable ref expands to its explicit
+ * placeholder); the references themselves are consumed by the expansion and
+ * never ride a share export (their field disposition below is OMIT in both
+ * modes). Complete backups are wholesale by design and carry references
+ * verbatim. Observations with no platform entries pass through untouched —
+ * the pre-platform share output stays byte-identical (golden-pinned).
+ */
+const expandObservationForShare = (obs) => {
+  if (!Array.isArray(obs?.platformProcedures) || obs.platformProcedures.length === 0) return obs;
+  return { ...obs, testProcedures: expandProcedureText(obs) };
 };
 
 const QUARTER = struct({
@@ -127,8 +146,32 @@ const OBSERVATION = struct({
         sha: SHARE,
         path: SHARE
       })
-    })
+    }),
+    // Composition recipe recorded at attach (plan §7 R-6): the trunk entry
+    // plus one platform-ref entry per addendum reference. Public pointers
+    // only — bank/corpus identities, policy ids, content hashes — never org
+    // data, so it rides shares in both modes: it is what tells a receiving
+    // install what an expanded procedure was composed FROM.
+    components: list(
+      struct({
+        kind: SHARE,
+        bank: SHARE,
+        bankId: SHARE,
+        bankVersion: SHARE,
+        corpusId: SHARE,
+        corpusVersion: SHARE,
+        policyId: SHARE,
+        contentHash: SHARE
+      })
+    )
   }),
+  // Platform addendum references / copy-on-write forks (plan §7 R-3).
+  // OMIT in BOTH modes: expansion-on-export already folded their text into
+  // testProcedures above, so shipping the refs too would make a receiving
+  // install double-render them. Complete backups (wholesale by design)
+  // carry them verbatim; the recipe in procedureSource.components preserves
+  // the lineage on shares.
+  platformProcedures: OMIT,
   linkedArtifacts: SHARE,
   linkedFindings: SHARE,
   linkedControls: SHARE,
@@ -350,7 +393,11 @@ export const SHARE_SECTIONS = {
     disposition: 'fold',
     record: ASSESSMENT,
     filter: keepAssessment,
-    observationTransform: (obs, ctx) => (ctx.includePrivate ? obs : pristineObservation(obs))
+    // Order matters: the pristine swap restores the trunk first (default
+    // mode only), then expansion-on-export folds addendum references into
+    // the text (BOTH modes — corpus-independence is not a privacy toggle).
+    observationTransform: (obs, ctx) =>
+      expandObservationForShare(ctx.includePrivate ? obs : pristineObservation(obs))
   },
   requirements: { disposition: 'fold', record: REQUIREMENT },
   frameworks: { disposition: 'fold', record: FRAMEWORK },

--- a/src/utils/shareRegistry.test.js
+++ b/src/utils/shareRegistry.test.js
@@ -28,8 +28,9 @@ import {
   STRIP_IF_EXCLUDED_METRIC,
   declaredPaths
 } from './shareRegistry';
-import { bankAttachObservation } from './procedureTailor';
+import { bankAttachObservation, composeAttachObservation } from './procedureTailor';
 import { getBankProcedure } from './procedureBank';
+import { getPlatformProcedures, getPlatformRecord, PLATFORM_CORPUS_ID } from './platformBank';
 import { importPack } from './packImport';
 import { parseMetricsCSV, validateMetricsCatalog, importMetricsCatalog } from './metricsImport';
 import useAssessmentsStore from '../stores/assessmentsStore';
@@ -79,7 +80,14 @@ const OPAQUE_LEAVES = new Set([
   // Legacy v0 tri-state — historical shape, no producer writes it today.
   'assessments[].observations{}.assessmentMethods',
   // User-authored display labels — no privacy class, wholesale by intent.
-  'frameworks[].hierarchyLabels'
+  'frameworks[].hierarchyLabels',
+  // Platform addendum references / copy-on-write forks (plan §7 R-3).
+  // OMIT in both share modes — expansion-on-export folds their text into
+  // testProcedures, so the refs never serialize on the share path at all;
+  // shape is producer-enforced (buildPlatformRef / forkPlatformProcedure,
+  // pinned in platformBank.test.js) and complete backups carry them
+  // wholesale by design.
+  'assessments[].observations{}.platformProcedures'
 ]);
 
 const isLeaf = (spec) => !spec.kind;
@@ -207,6 +215,31 @@ const seedThroughProducers = () => {
     { substituteName: true, adaptStack: true }
   );
   assessments.updateObservation(assessmentId, 'GV.OC-01 Ex1', produced);
+  // The real composed-attach producer (PR-5): trunk + platform addendum
+  // REFERENCES + the recorded recipe, tailored trunk so the pristine-swap ×
+  // expansion composition is exercised on the share path.
+  assessments.addToScope(assessmentId, 'PR.DS-01 Ex1');
+  const composed = composeAttachObservation(
+    getBankProcedure('PR.DS-01'),
+    getPlatformProcedures('PR.DS-01', ['microsoft-365']).slice(0, 2),
+    useOrgProfileStore.getState().profile,
+    { substituteName: true }
+  );
+  assessments.updateObservation(assessmentId, 'PR.DS-01 Ex1', composed);
+  // An unresolvable reference riding a real observation (foreign corpus id):
+  // the share export must expand it to the explicit placeholder.
+  assessments.addToScope(assessmentId, 'DE.CM-09 Ex1');
+  assessments.updateObservation(assessmentId, 'DE.CM-09 Ex1', {
+    testProcedures: 'Trunk with a dead reference.',
+    platformProcedures: [
+      {
+        corpusId: 'foreign-corpus',
+        corpusVersion: 'ffffffffffffffff',
+        policyId: 'gone.policy.1.1v1',
+        contentHash: '0123456789abcdef'
+      }
+    ]
+  });
   assessments.updateObservation(assessmentId, 'GV.OC-01 Ex1', {
     auditorId: 'U-1',
     linkedArtifacts: ['AR-1'],
@@ -606,5 +639,118 @@ describe('share registry enforcement — restore lane', () => {
       interview: false,
       test: false
     });
+  });
+});
+
+describe('PR-5: expansion-on-export + reference dispositions (production share path)', () => {
+  // Earlier describes (the CSV-importer appearance lanes) rebuild store
+  // state; re-seed so these tests read the producer-built assessment.
+  beforeAll(() => {
+    seedThroughProducers();
+  });
+
+  const shareObs = (share, itemId) =>
+    share.data.assessments.find((a) => a.id === assessmentId).observations[itemId];
+
+  test('leak-side: platformProcedures references never serialize on the share path, either mode', () => {
+    expect(JSON.stringify(buildShareableExport(stores()))).not.toContain('platformProcedures');
+    expect(
+      JSON.stringify(buildShareableExport(stores(), { includePrivate: true }))
+    ).not.toContain('platformProcedures');
+  });
+
+  test('complete backups carry the references verbatim (wholesale by design)', () => {
+    const envelope = exportAllDataJSON(stores());
+    const backup = envelope.data.assessments.find((a) => a.id === assessmentId);
+    const refs = backup.observations['PR.DS-01 Ex1'].platformProcedures;
+    expect(refs).toHaveLength(2);
+    refs.forEach((ref) => {
+      expect(Object.keys(ref).sort()).toEqual([
+        'contentHash',
+        'corpusId',
+        'corpusVersion',
+        'policyId'
+      ]);
+    });
+  });
+
+  test('default mode: pristine trunk + expanded addenda + attribution, in one self-contained text', () => {
+    const obs = shareObs(buildShareableExport(stores()), 'PR.DS-01 Ex1');
+    const pristine = getBankProcedure('PR.DS-01').markdown;
+    // trunk swapped back to pristine (tailored org name gone), then expanded
+    expect(obs.testProcedures.startsWith(pristine)).toBe(true);
+    expect(obs.testProcedures).not.toContain('Producer Org');
+    // both referenced addenda expanded from the corpus with attribution
+    const refs = getPlatformProcedures('PR.DS-01', ['microsoft-365']).slice(0, 2);
+    refs.forEach(({ policyId }) => {
+      const record = getPlatformRecord(PLATFORM_CORPUS_ID, policyId);
+      expect(obs.testProcedures).toContain(record.assertion);
+      expect(obs.testProcedures).toContain(record.attribution.attributionText);
+    });
+    // provenance flags reset by the pristine swap, recipe still rides
+    expect(obs.procedureSource.tailored).toBe(false);
+    expect(obs.procedureSource.components).toHaveLength(3);
+    expect(obs.procedureSource.components[0].kind).toBe('trunk');
+  });
+
+  test('include-private mode: user trunk kept, addenda still expanded (corpus-independence is not a privacy toggle)', () => {
+    const obs = shareObs(buildShareableExport(stores(), { includePrivate: true }), 'PR.DS-01 Ex1');
+    expect(obs.testProcedures).toContain('Producer Org'); // tailored trunk rides
+    const refs = getPlatformProcedures('PR.DS-01', ['microsoft-365']).slice(0, 2);
+    refs.forEach(({ policyId }) => {
+      expect(obs.testProcedures).toContain(
+        getPlatformRecord(PLATFORM_CORPUS_ID, policyId).assertion
+      );
+    });
+  });
+
+  test('unresolvable reference expands to the identity-carrying placeholder on the share — never a silent drop', () => {
+    const obs = shareObs(buildShareableExport(stores()), 'DE.CM-09 Ex1');
+    expect(obs.testProcedures).toContain('Trunk with a dead reference.');
+    expect(obs.testProcedures).toContain('Unresolved platform procedure reference');
+    expect(obs.testProcedures).toContain('gone.policy.1.1v1');
+    expect(obs.testProcedures).toContain('ffffffffffffffff');
+    expect(obs.testProcedures).toContain('0123456789abcdef');
+  });
+
+  test('store passthrough: updateObservation persisted the references unmangled (real producer path)', () => {
+    const stored = useAssessmentsStore
+      .getState()
+      .getObservation(assessmentId, 'PR.DS-01 Ex1');
+    expect(stored.platformProcedures).toHaveLength(2);
+    expect(stored.procedureSource.components).toHaveLength(3);
+    // and an untouched observation's default shape has no platform keys
+    const fresh = useAssessmentsStore.getState().getObservation(assessmentId, 'GV.OC-01 Ex1');
+    expect('platformProcedures' in fresh).toBe(false);
+  });
+});
+
+describe('PR-5: copy-on-write forks on the share path', () => {
+  beforeAll(() => {
+    seedThroughProducers();
+    // Fork one PR.DS-01 addendum through the production fork producer and
+    // attach it alongside a pristine reference.
+    const offer = getPlatformProcedures('PR.DS-01', ['microsoft-365'])[0];
+    const { forkPlatformProcedure, buildPlatformRef } =
+      // eslint-disable-next-line global-require
+      require('./platformBank');
+    const fork = forkPlatformProcedure(buildPlatformRef(offer.record), 'FORKED-ADDENDUM user text.');
+    useAssessmentsStore.getState().updateObservation(assessmentId, 'PR.DS-01 Ex1', {
+      platformProcedures: [fork]
+    });
+  });
+
+  test('a forked addendum rides the DEFAULT share as user text with modification indication (pinned current behavior)', () => {
+    // Pins the policy boundary the reviewer flagged for PR-6: hand-edited
+    // addendum text rides default shares exactly like hand-edited trunk
+    // text does today (the pristine swap is tailoring-scoped, not
+    // edit-scoped). If PR-6 decides forks need a pristine reset on default
+    // share, this test is the one that changes — deliberately.
+    const share = buildShareableExport(stores());
+    const obs = share.data.assessments.find((a) => a.id === assessmentId)
+      .observations['PR.DS-01 Ex1'];
+    expect(obs.testProcedures).toContain('FORKED-ADDENDUM user text.');
+    expect(obs.testProcedures).toContain('modified from the referenced original');
+    expect(JSON.stringify(obs)).not.toContain('platformProcedures');
   });
 });


### PR DESCRIPTION
# PR body — feat/pr5-reference-attach (PR-5: reference-based attach + expansion choke point)

Title: `Attach platform procedures by reference with a single expansion choke point`

---

## What this changes

PR-5 of the platform-procedures program (plan §7 R-3/R-6/R-9 + §5 C1). Machinery only — no wizard (PR-6), no badges/notices UI (PR-7). The Reset confirm dialog copy is the only user-facing string change.

**Reference attach.** Observations never copy platform text. They carry `platformProcedures: [{corpusId, corpusVersion, policyId, contentHash}]`, and `procedureSource.components[]` records the composition recipe at attach (`composeAttachObservation`). Measured reverse cardinality made copies untenable: 122 policies land on PR.DS-10 alone (derived lane matches the plan exactly: 122/94/93/73/72; totals with the authored gap-table pairs put DE.CM-01 at 117).

**One expansion choke point.** `expandProcedureText` (new `src/utils/platformBank.js`) is the ONLY place references become text. It serves the detail-panel render, the JSON share transform, and all four CSV/Jira exporters. Attribution is asserted there from provenance on every egress; modification indication derives from the `tailored`/`modified` flags; an unresolvable reference renders an explicit placeholder carrying policyId + corpusVersion + contentHash — never a silent drop, never a crash. Observations without platform entries pass through byte-identical (golden-pinned).

**Copy-on-write.** First user edit forks a reference to a concrete provenance-flagged value (`forkPlatformProcedure`); the guard is a POSITIVE corpus lookup, proven by tests that execute the production render path. Nothing user-authored can become unresolvable.

**Pristine swap replays the recipe.** `pristineProcedureText(procedureSource)` (in `procedureBank.js`) replays `components[]`; legacy sources resolve exactly as before; the fail-closed `''` stays; flag-resetting stays in the caller. `dataExport.js` is touched ONLY via the registry plus this named function — its entire diff is the format-version block (C1's falsifiable test, verified).

**Reset stops being a destroyer.** `resetToCommunityUpdate` replays the recipe: trunk goes pristine, addendum references are restored from the recipe (forks reset to pristine refs). The confirm dialog now says exactly what resets.

**Envelope discriminator.** `EXPORT_FORMAT_VERSION` 4→5: share-export procedure text is self-contained (trunk + expanded addenda + attribution); refs never ride shares; complete backups carry refs verbatim; from format 5 on, absence of license/components/refs is meaningful. Goldens regenerated — diff is exactly the three `formatVersion` lines.

## Egress census (every text egress → through the choke point?)

| Egress | Surface | Expands? |
|---|---|---|
| JSON share (both modes) | `shareRegistry` observationTransform | ✅ (pristine swap first in default mode; refs OMIT both modes) |
| `exportAssessmentCSV` | store CSV | ✅ |
| `exportForJiraCSV` | store CSV (field + Description) | ✅ both |
| `exportAllForJiraCSV` | store CSV | ✅ |
| `exportAllAssessmentsCSV` | store CSV | ✅ |
| Detail-panel read-only render (= browser print path) | `Assessments.js` call-site swap | ✅ |
| Complete backup | wholesale by design | refs verbatim (state snapshot, not text egress) |
| `exportAssessmentsJSON` ("Assessments Only") | own-data JSON | refs verbatim (data egress; keeping C1's dataExport diff = discriminator only) |
| Edit textarea / 80-char table preview / wizard preview | trunk-only UI surfaces | deliberate no (addenda UI = PR-6/7) |
| Report/PDF surfaces | never render procedure text | invariant test added (R-9 rot-stopper) |

## Tests

1055/1055 (57 suites; 983 baseline + 72 new). Highlights: exact reverse-cardinality pins re-derived from the committed map; map↔bank freshness pin; leak-side AND restore-side (foreign-corpus refs restore verbatim and render the placeholder); COW polarity both directions on the production render path; pristine-replay polarity + recipe-vs-source discrimination fixture; Reset destroyer-closed polarity; per-exporter expansion fixtures (Blob-capture harness); reports-never-render invariant; license gate + ND-verbatim at the choke point (synthetic corpora); format-5 accept / format-6 reject.

## Review-round adoptions (amended into ffdbc59)

- **Fork license gate**: `forkPlatformProcedure` now requires a truthy corpus lookup AND `mayTailor` (editing is a derivative) — returns null otherwise. Completes R-3's positive-guard COW and closes the reviewer's latent noDerivatives hole before any UI exists.
- **`platformRefDrift(entry)`**: contentHash is now read, not just stored — drift detection with polarity tests; expansion output pinned drift-SILENT in PR-5 (the drift badge is PR-7 UI, stated deferral). Hash normalization pinned to an exact literal on a frozen record.
- **Notices on forks**: adapted content keeps the upstream notice obligations (CISA disclaimer rides fork expansions when the record resolves).
- **Rot-stoppers** (egressCensus): positive pin that the detail-panel render calls the choke point; residual `obs.testProcedures` count-pin in the store (a new exporter bypassing expansion goes red); composition-writer guard pinning which modules may write the ref/recipe keys.
- **Round-trip pins**: a share-import is NOT permanently detached — the recipe rides shares, so Reset on an imported observation re-references from `components[]` (test-proven); format-4 backups explicitly accepted; a fork restored byte-identical to corpus text stays `modified` (flag-derived, never string-compare); forked addendum text pinned as riding default shares (the PR-6 decision surface, see entry conditions).
- pr-test-analyzer ran 8 LIVE mutants across the 4 named classes — ALL KILLED with surgical one-test-per-mutant attribution. code-reviewer: 6/6 hard constraints PASS, zero defects.

## Merging this PR ratifies

1. **No corpus snapshots** — v1 durability model: expansion-on-export, placeholder-never-drop, COW-forks-are-concrete; withdrawal/rev is regeneration-not-migration (G21 advisor ruling).
2. **Envelope discriminator = formatVersion 5** (older installs refuse newer files with the existing explicit message — same precedent as formats 2–4).
3. **Resolution ignores corpusVersion**: a ref resolves by positive (corpusId, policyId) lookup against the CURRENT corpus; corpusVersion + contentHash ride as drift evidence and placeholder identity. Version-gating would break every ref on every corpus regeneration — snapshots in denial.
4. **Refs OMIT from shares in both modes** (corpus-independence is not a privacy toggle).
5. **Working-artifact CSV/Jira egresses expand** (completeness + attribution) while remaining unscrubbed own-data artifacts (PR-0 posture unchanged); `exportAssessmentsJSON` stays a data egress with refs verbatim.
6. **Reset = recipe replay** — the recipe is maintained at composition-changing writes; PR-6's addendum add/remove UI must re-record `components[]` so replay stays honest.
7. **New Reset dialog copy** (the only user-facing string change).

## Checks

- Full jest green; changed files lint `--max-warnings=0` (Assessments.js allowlisted; its 2 warnings pre-exist on main); `CI=false npm run build` compiles (no warnings on touched modules).
- Zero diff: platform bank, subcategory map, community bank, `scripts/`. No new markdown (lychee surface unchanged). Deny-token scan clean.
