### PR TITLE
Add the wizard Environment step: per-assessment platform selection with reference attach

### DIFF
--- a/src/components/OrgProfileWizard.js
+++ b/src/components/OrgProfileWizard.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { X, Building2, Server, Shield, Gem, ChevronLeft, ChevronRight } from 'lucide-react';
 import toast from 'react-hot-toast';
 import useOrgProfileStore, { EMPTY_PROFILE } from '../stores/orgProfileStore';
+import { INFRA_PRESET_LABELS } from '../utils/infraPresets';
 
 /**
  * Optional org-profile mini-wizard. Five questions, every one skippable,
@@ -13,12 +14,9 @@ import useOrgProfileStore, { EMPTY_PROFILE } from '../stores/orgProfileStore';
 const SIZE_BANDS = ['1–49', '50–249', '250–999', '1,000–4,999', '5,000+'];
 
 // Cloud, email, and chat selections drive DETERMINISTIC procedure tailoring
-// (canned substitutions, no AI) — see utils/stackTailorMaps.js.
-const INFRA_PRESETS = [
-  'AWS', 'Azure', 'Google Cloud', 'On-premises data center', 'SaaS-heavy',
-  'Kubernetes / containers', 'OT / ICS', 'Remote-first endpoints',
-  'Microsoft 365', 'Google Workspace', 'Slack', 'Microsoft Teams'
-];
+// (canned substitutions, no AI) — see utils/stackTailorMaps.js. The preset
+// list lives in utils/infraPresets.js so the assessment wizard's Environment
+// step can read the same source of truth; the persisted token stays the label.
 
 // Naming a specific EDR product here enables an exact SentinelOne→product
 // swap in tailored procedures; the generic 'EDR' chip neutralizes instead.
@@ -147,7 +145,7 @@ const OrgProfileWizard = ({ onClose }) => {
       title: 'Key IT infrastructure?',
       body: (
         <ChipPicker
-          presets={INFRA_PRESETS}
+          presets={INFRA_PRESET_LABELS}
           value={draft.infrastructure}
           onChange={(infrastructure) => patch({ infrastructure })}
           placeholder="Add your own and press Enter…"

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -3,7 +3,7 @@ import {
   Plus, Edit, Save, Trash2, X, CheckCircle, XCircle,
   Download, Upload, ClipboardList, FileSearch, ChevronRight, Copy,
   Loader2, Bot, Sparkles, User, Settings,
-  BookOpen, ExternalLink, RotateCcw
+  BookOpen, ExternalLink, RotateCcw, Server
 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import Markdown from '../components/Markdown';
@@ -29,7 +29,9 @@ import useUIStore from '../stores/uiStore';
 import { formatInlineMarkdown, stripMarkdown } from '../utils/markdownText';
 import { bankCoverage, getBankProcedure, canResetToCommunity, resetToCommunityUpdate, sourceUrlFor } from '../utils/procedureBank';
 import { expandProcedureText } from '../utils/platformBank';
-import { canUseProfileWithProvider, buildTailorPrompt, tailoredProvenance, deriveStackTargets, describeStackPlan, bankAttachObservation, deterministicTailorUpdate } from '../utils/procedureTailor';
+import { canUseProfileWithProvider, buildTailorPrompt, tailoredProvenance, deriveStackTargets, describeStackPlan, bankAttachObservation, wizardAttachObservation, deterministicTailorUpdate } from '../utils/procedureTailor';
+import { buildEnvironmentMatrix, buildAttachPlan, cellKey, toggleCell, setColumn, columnFullySelected, columnTotal, countAttached, attachedCountForItem, availablePlatforms } from '../utils/environmentStep';
+import { platformIdsFromInfrastructure } from '../utils/infraPresets';
 import { getScoringScale, scoreBand, CMMI_LEVELS } from '../utils/scoringScale';
 import { SYSTEM_NAME_MAX_LENGTH } from '../utils/externalLinks';
 import { belongsToAssessment, isUnassigned } from '../utils/assessmentScope';
@@ -116,7 +118,7 @@ const Assessments = () => {
 
   // New assessment wizard state
   const [showNewModal, setShowNewModal] = useState(false);
-  const [wizardStep, setWizardStep] = useState(1); // 1: Basic + Scope, 2: Test Procedures, 3: Users
+  const [wizardStep, setWizardStep] = useState(1); // 1: Basic + Scope, 2: Environment, 3: Test Procedures, 4: Users
   const [newAssessment, setNewAssessment] = useState({
     name: '',
     description: '',
@@ -151,6 +153,33 @@ const Assessments = () => {
   const [generatedProcedures, setGeneratedProcedures] = useState({});
   const [generationProgress, setGenerationProgress] = useState({ done: 0, total: 0 });
   const cancelGenerationRef = useRef(false);
+
+  // Wizard Environment step (plan PR-6): ephemeral chip + cell state. The
+  // chips seed from the saved org profile (pure read, never written back —
+  // ratified); the assessment persists only the DERIVED platform set of
+  // what actually attaches. All rules live in utils/environmentStep.js.
+  const [envPlatforms, setEnvPlatforms] = useState([]);
+  const [envSelections, setEnvSelections] = useState({});
+
+  // Seed the platform chips each time the wizard opens. Open-time snapshot
+  // on purpose: the profile store hydrates synchronously from localStorage
+  // long before the modal can open, and a profile edited mid-wizard applies
+  // on the next open (the reset link re-derives on demand).
+  React.useEffect(() => {
+    if (showNewModal) {
+      setEnvPlatforms(platformIdsFromInfrastructure(orgProfile?.infrastructure));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showNewModal]);
+
+  const envMatrix = useMemo(
+    () => buildEnvironmentMatrix(Array.from(selectedScopeItems), envPlatforms),
+    [selectedScopeItems, envPlatforms]
+  );
+  const envAttachedCount = useMemo(
+    () => countAttached(envMatrix, envSelections),
+    [envMatrix, envSelections]
+  );
 
   // Wizard Users step (issue #290): people in scope for the assessment.
   // Rows are { name, email, role } while editing; on create they become
@@ -649,6 +678,8 @@ Format as a numbered list. Be specific and actionable.`;
     setScopePreset(null);
     setScopeFilterText('');
     setUseBankProcedures(true);
+    setEnvPlatforms([]);
+    setEnvSelections({});
     setShowBankPreview(false);
     setTailorWithProfile(false);
     setAdaptStackRefs(false);
@@ -686,7 +717,14 @@ Format as a numbered list. Be specific and actionable.`;
       }
     }
 
-    const created = createAssessment({ ...newAssessment, users: scopedUsers });
+    // Environment step (plan PR-6): which platform checks each item attaches
+    // (checked cells only — the user is the only exclusion actor) and the
+    // DERIVED platform set the assessment record persists.
+    const attachPlan = buildAttachPlan(
+      Array.from(selectedScopeItems), envSelections, envPlatforms, useBankProcedures
+    );
+
+    const created = createAssessment({ ...newAssessment, users: scopedUsers, platforms: attachPlan.platforms });
 
     // Add selected items to scope
     for (const itemId of selectedScopeItems) {
@@ -700,7 +738,10 @@ Format as a numbered list. Be specific and actionable.`;
         // the case study's "Alma Security" and/or re-aim tool/platform
         // references at the org's stack (canned maps, no AI). The producer
         // stamps tailored provenance so share export can swap to pristine.
-        updateObservation(created.id, itemId, bankAttachObservation(bankEntry, orgProfile, {
+        // Platform checks selected in the Environment step ride as
+        // references through the composed producer; with none selected the
+        // update is byte-identical to the plain community attach.
+        updateObservation(created.id, itemId, wizardAttachObservation(bankEntry, attachPlan.offersByItem[itemId], orgProfile, {
           substituteName: tailorWithProfile,
           adaptStack: adaptStackRefs
         }));
@@ -714,7 +755,7 @@ Format as a numbered list. Be specific and actionable.`;
     setCurrentAssessmentId(created.id);
     setView('scope');
     toast.success(`Assessment "${created.name}" created with ${selectedScopeItems.size} items`);
-  }, [newAssessment, createAssessment, selectedScopeItems, useBankProcedures, tailorWithProfile, adaptStackRefs, orgProfile, generatedProcedures, wizardUsers, addToScope, updateObservation, setCurrentAssessmentId, resetWizard]);
+  }, [newAssessment, createAssessment, selectedScopeItems, useBankProcedures, envSelections, envPlatforms, tailorWithProfile, adaptStackRefs, orgProfile, generatedProcedures, wizardUsers, addToScope, updateObservation, setCurrentAssessmentId, resetWizard]);
 
   const handleSelectAssessment = useCallback((assessment) => {
     setCurrentAssessmentId(assessment.id);
@@ -2148,8 +2189,9 @@ Format as a numbered list. Be specific and actionable.`;
               <div className="flex items-center justify-center gap-2">
                 {[
                   { num: 1, label: 'Scope' },
-                  { num: 2, label: 'Test Procedures' },
-                  { num: 3, label: 'Users' }
+                  { num: 2, label: 'Environment' },
+                  { num: 3, label: 'Test Procedures' },
+                  { num: 4, label: 'Users' }
                 ].map((step, idx) => (
                   <React.Fragment key={step.num}>
                     <div className={`flex items-center gap-2 ${wizardStep === step.num ? 'text-blue-600' : wizardStep > step.num ? 'text-green-600' : 'text-gray-400'}`}>
@@ -2160,7 +2202,7 @@ Format as a numbered list. Be specific and actionable.`;
                       </div>
                       <span className="text-sm font-medium hidden sm:inline">{step.label}</span>
                     </div>
-                    {idx < 2 && <div className={`w-8 h-0.5 ${wizardStep > step.num ? 'bg-green-600' : 'bg-gray-300'}`} />}
+                    {idx < 3 && <div className={`w-8 h-0.5 ${wizardStep > step.num ? 'bg-green-600' : 'bg-gray-300'}`} />}
                   </React.Fragment>
                 ))}
               </div>
@@ -2490,7 +2532,133 @@ Format as a numbered list. Be specific and actionable.`;
               )}
 
               {/* Step 2: Test Procedures — community bank first, AI fills the gaps */}
+              {/* Step 2: Environment (plan PR-6) — per-assessment platform
+                  selection. Chips are ephemeral and seed from the org profile
+                  (read-only); the assessment stores only what attaches. */}
               {wizardStep === 2 && (
+                <div className="space-y-4">
+                  <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-4">
+                    <div className="flex items-start gap-3">
+                      <Server size={20} className="text-blue-600 mt-0.5" />
+                      <div className="flex-1">
+                        <h4 className="font-medium text-blue-900 dark:text-blue-200">Which platforms does this assessment cover? (optional)</h4>
+                        <p className="text-sm text-blue-800 dark:text-blue-300 mt-1">
+                          Pick a platform to see its configuration checks, drawn from CISA's SCuBA
+                          secure configuration baselines. Checks you select attach alongside the
+                          community test procedure for that subcategory. Nothing attaches unless
+                          you select it, and you can skip this step entirely.
+                        </p>
+                        <div className="flex flex-wrap items-center gap-2 mt-3">
+                          {availablePlatforms().map(({ id, label }) => (
+                            <button
+                              key={id}
+                              type="button"
+                              onClick={() => setEnvPlatforms((prev) => (
+                                prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id]
+                              ))}
+                              className={`px-3 py-1.5 text-sm rounded-full border ${envPlatforms.includes(id)
+                                ? 'bg-blue-600 border-blue-600 text-white'
+                                : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'}`}
+                            >
+                              {label}
+                            </button>
+                          ))}
+                          {hasOrgProfile && (
+                            <button
+                              type="button"
+                              onClick={() => setEnvPlatforms(platformIdsFromInfrastructure(orgProfile?.infrastructure))}
+                              className="text-sm text-blue-700 dark:text-blue-400 underline ml-1"
+                            >
+                              Same as my org profile
+                            </button>
+                          )}
+                        </div>
+                        {hasOrgProfile && platformIdsFromInfrastructure(orgProfile?.infrastructure).length > 0 && (
+                          <p className="text-xs text-blue-700 dark:text-blue-400 mt-2">
+                            Pre-selected from your saved org profile. Changes here apply to this
+                            assessment only and never modify the profile.
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  {envPlatforms.length > 0 && !useBankProcedures && (
+                    <p className="text-sm text-amber-700 dark:text-amber-400">
+                      Platform checks attach alongside community test procedures, which are turned
+                      off in the next step. Turn them back on for these selections to apply.
+                    </p>
+                  )}
+
+                  {envPlatforms.length > 0 && envMatrix.rows.length === 0 && (
+                    <p className="text-sm text-gray-600 dark:text-gray-300">
+                      {newAssessment.scopeType === 'controls'
+                        ? 'Platform checks map to CSF subcategories, so control-scope items have no matches.'
+                        : 'None of your scoped items have platform checks for these platforms.'}
+                    </p>
+                  )}
+
+                  {envPlatforms.length > 0 && envMatrix.rows.length > 0 && (
+                    <div className="border dark:border-gray-600 rounded-lg overflow-hidden">
+                      <div className="p-3 bg-gray-50 dark:bg-gray-800 border-b dark:border-gray-600 flex items-center justify-between flex-wrap gap-2">
+                        <span className="text-sm font-medium dark:text-white">
+                          {envAttachedCount} of {envMatrix.totalAvailable} available checks selected
+                        </span>
+                        <div className="flex gap-3">
+                          {envPlatforms.filter((p) => columnTotal(envMatrix, p) > 0).map((platformId) => {
+                            const allOn = columnFullySelected(envMatrix, envSelections, platformId);
+                            const label = availablePlatforms().find((ap) => ap.id === platformId)?.label || platformId;
+                            return (
+                              <button
+                                key={platformId}
+                                type="button"
+                                onClick={() => setEnvSelections(setColumn(envMatrix, envSelections, platformId, !allOn))}
+                                className="text-sm text-blue-700 dark:text-blue-400 underline"
+                              >
+                                {allOn
+                                  ? `Clear ${label}`
+                                  : `Select all ${label} (${columnTotal(envMatrix, platformId)} checks)`}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                      <div className="max-h-72 overflow-y-auto divide-y dark:divide-gray-700">
+                        {envMatrix.rows.map((row) => (
+                          <div key={row.itemId} className="p-2 px-3 flex items-center justify-between gap-3">
+                            <span className="text-sm dark:text-gray-200 min-w-0 truncate" title={row.title}>
+                              <span className="font-medium">{row.itemId}</span>
+                              <span className="text-gray-500 dark:text-gray-400"> — {row.title}</span>
+                            </span>
+                            <div className="flex gap-4 shrink-0">
+                              {envPlatforms.filter((p) => p in row.cells).map((platformId) => (
+                                <label key={platformId} className="flex items-center gap-1.5 text-sm cursor-pointer dark:text-gray-300">
+                                  <input
+                                    type="checkbox"
+                                    className="w-4 h-4 rounded"
+                                    checked={!!envSelections[cellKey(row.itemId, platformId)]}
+                                    onChange={() => setEnvSelections(toggleCell(envSelections, row.itemId, platformId))}
+                                  />
+                                  {availablePlatforms().find((ap) => ap.id === platformId)?.label || platformId}
+                                  <span className="text-gray-500 dark:text-gray-400">({row.cells[platformId]})</span>
+                                </label>
+                              ))}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                      {envMatrix.noOfferCount > 0 && (
+                        <p className="p-2 px-3 text-xs text-gray-500 dark:text-gray-400 border-t dark:border-gray-600">
+                          {envMatrix.noOfferCount} of your scoped items have no platform checks for
+                          these platforms. Their community procedures attach as usual.
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {wizardStep === 3 && (
                 <div className="space-y-4">
                   {/* Card 1: community-contributed procedures (default ON) */}
                   <div className={`border rounded-lg p-4 ${useBankProcedures ? 'bg-green-50 border-green-300 dark:bg-green-900/20 dark:border-green-700' : 'bg-gray-50 border-gray-200 dark:bg-gray-800 dark:border-gray-600'}`}>
@@ -2514,6 +2682,13 @@ Format as a numbered list. Be specific and actionable.`;
                         <p className="text-sm font-medium mt-2 text-green-900 dark:text-green-200">
                           {scopeCoverage.covered.length} of {selectedScopeItems.size} selected items have community procedures
                         </p>
+                        {envPlatforms.length > 0 && (
+                          <p className="text-sm text-green-800 dark:text-green-300 mt-1">
+                            {envAttachedCount} platform {envAttachedCount === 1 ? 'check' : 'checks'} from
+                            the Environment step {envAttachedCount === 1 ? 'attaches' : 'attach'} as
+                            addenda ({envMatrix.totalAvailable} available).
+                          </p>
+                        )}
                         {scopeCoverage.uncovered.length > 0 && (
                           <p className="text-sm text-amber-700 dark:text-amber-400 mt-1">
                             {newAssessment.scopeType === 'controls'
@@ -2547,6 +2722,13 @@ Format as a numbered list. Be specific and actionable.`;
                                   <pre className="whitespace-pre-wrap text-xs text-gray-600 dark:text-gray-300 mt-2 max-h-40 overflow-y-auto">
                                     {previewText.slice(0, 1500)}{previewText.length > 1500 ? '\n…(full procedure attaches on create)' : ''}
                                   </pre>
+                                  {attachedCountForItem(envMatrix, envSelections, id) > 0 && (
+                                    <p className="text-xs text-blue-700 dark:text-blue-400 mt-1">
+                                      + {attachedCountForItem(envMatrix, envSelections, id)} platform
+                                      {attachedCountForItem(envMatrix, envSelections, id) === 1 ? ' check attaches' : ' checks attach'} as
+                                      addenda (not shown in this preview).
+                                    </p>
+                                  )}
                                 </details>
                               );
                             })}
@@ -2736,8 +2918,8 @@ Format as a numbered list. Be specific and actionable.`;
                 </div>
               )}
 
-              {/* Step 3: Users in scope (issue #290) */}
-              {wizardStep === 3 && (
+              {/* Step 4: Users in scope (issue #290) */}
+              {wizardStep === 4 && (
                 <div className="space-y-4">
                   <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
                     <div className="flex items-start gap-3">
@@ -2848,7 +3030,7 @@ Format as a numbered list. Be specific and actionable.`;
               </button>
 
               <div className="flex gap-2">
-                {wizardStep < 3 && (
+                {wizardStep < 4 && (
                   <button
                     className="px-4 py-2 text-gray-500 hover:text-gray-700"
                     onClick={() => setWizardStep(prev => prev + 1)}
@@ -2856,7 +3038,7 @@ Format as a numbered list. Be specific and actionable.`;
                     Skip
                   </button>
                 )}
-                {wizardStep < 3 ? (
+                {wizardStep < 4 ? (
                   <button
                     className="px-4 py-2 bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white rounded disabled:bg-gray-300"
                     onClick={() => {

--- a/src/stores/assessmentYearUsers.test.js
+++ b/src/stores/assessmentYearUsers.test.js
@@ -293,3 +293,35 @@ describe('assessment user roster actions (issue #297)', () => {
     expect(DEMO_ASSESSMENT_USERS).toHaveLength(8);
   });
 });
+
+describe('assessment platforms producers (plan PR-6, v16)', () => {
+  const cleanup = [];
+  afterEach(() => {
+    while (cleanup.length) {
+      useAssessmentsStore.getState().deleteAssessment(cleanup.pop());
+    }
+  });
+
+  test('createAssessment defaults platforms to [] and normalizes what it is given', () => {
+    const bare = useAssessmentsStore.getState().createAssessment({ name: 'Platforms default' });
+    cleanup.push(bare.id);
+    expect(bare.platforms).toEqual([]);
+
+    const seeded = useAssessmentsStore.getState().createAssessment({
+      name: 'Platforms seeded',
+      platforms: ['google-workspace', 'google-workspace', '', 9]
+    });
+    cleanup.push(seeded.id);
+    expect(seeded.platforms).toEqual(['google-workspace']);
+  });
+
+  test('updateAssessment guards platforms at the producer (#288 doctrine)', () => {
+    const created = useAssessmentsStore.getState().createAssessment({ name: 'Platforms guard' });
+    cleanup.push(created.id);
+    useAssessmentsStore.getState().updateAssessment(created.id, {
+      platforms: ['microsoft-365', null, 'microsoft-365']
+    });
+    const stored = useAssessmentsStore.getState().assessments.find(a => a.id === created.id);
+    expect(stored.platforms).toEqual(['microsoft-365']);
+  });
+});

--- a/src/stores/assessmentsStore.js
+++ b/src/stores/assessmentsStore.js
@@ -158,10 +158,32 @@ export const normalizeAssessmentUsers = (value) => {
 };
 
 /**
+ * Normalize the per-assessment platform selection (plan PR-6). Platform ids
+ * are opaque strings against the platform-procedure map ('google-workspace',
+ * 'microsoft-365'); unknown ids are KEPT — a future corpus adds ids, and a
+ * whitelist here would silently eat them on restore. Dedupes, drops
+ * non-string/empty entries, and collapses any non-array to [] — the correct
+ * historical truth for records that predate the environment step.
+ */
+export const normalizeAssessmentPlatforms = (value) => {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string') continue;
+    const id = entry.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+};
+
+/**
  * Current schema version of csf-assessments-storage. Exported so the restore
  * path (dataImport.js) can migrate older exported payloads before applying them.
  */
-export const ASSESSMENTS_SCHEMA_VERSION = 15;
+export const ASSESSMENTS_SCHEMA_VERSION = 16;
 
 /**
  * Full persisted-state migration chain for csf-assessments-storage.
@@ -357,6 +379,19 @@ export const migrateAssessmentsState = (persistedState, version) => {
     const assessments = (state.assessments || []).map(a =>
       a.id === COMPREHENSIVE_ASSESSMENT_ID && normalizeAssessmentUsers(a.users).length === 0
         ? { ...a, users: DEMO_ASSESSMENT_USERS }
+        : a
+    );
+    state = { ...state, assessments };
+  }
+
+  // v16 (plan PR-6): stamp the per-assessment platform selection. Existing
+  // assessments predate the wizard Environment step, so platforms: [] is the
+  // correct historical truth (ratified). Idempotent: a record already
+  // carrying a platforms array keeps it (normalized).
+  if (version < 16) {
+    const assessments = (state.assessments || []).map(a =>
+      a && typeof a === 'object'
+        ? { ...a, platforms: normalizeAssessmentPlatforms(a.platforms) }
         : a
     );
     state = { ...state, assessments };
@@ -628,6 +663,10 @@ const useAssessmentsStore = create(
           // role auditor | control owner | stakeholder. No PII embedded —
           // names/emails live in the user directory (userStore).
           users: normalizeAssessmentUsers(assessmentData.users),
+          // Per-assessment platform selection (plan PR-6): the DERIVED set of
+          // platforms with at least one attached platform check — never raw
+          // chip state, so an assessment with zero addenda declares nothing.
+          platforms: normalizeAssessmentPlatforms(assessmentData.platforms),
           scopeIds: assessmentData.scopeIds || [], // Array of requirement IDs or control IDs
           frameworkFilter: assessmentData.frameworkFilter || null, // Optional framework filter
           status: 'Not Started', // Not Started, In Progress, Complete
@@ -657,6 +696,9 @@ const useAssessmentsStore = create(
         }
         if (updates && updates.users !== undefined) {
           safeUpdates = { ...safeUpdates, users: normalizeAssessmentUsers(updates.users) };
+        }
+        if (updates && updates.platforms !== undefined) {
+          safeUpdates = { ...safeUpdates, platforms: normalizeAssessmentPlatforms(updates.platforms) };
         }
         const updatedAssessments = get().assessments.map(a =>
           a.id === assessmentId

--- a/src/stores/assessmentsStore.migrate.test.js
+++ b/src/stores/assessmentsStore.migrate.test.js
@@ -1,4 +1,4 @@
-import { migrateAssessmentsState, DEMO_ASSESSMENT_USERS } from './assessmentsStore';
+import { migrateAssessmentsState, normalizeAssessmentPlatforms, DEMO_ASSESSMENT_USERS } from './assessmentsStore';
 import { getBankProcedure, BANK_VERSION } from '../utils/procedureBank';
 
 /**
@@ -69,7 +69,8 @@ describe('migrateAssessmentsState', () => {
         scoringScale: 10,
         externalTracking: { enabled: false, systems: { findings: '', artifacts: '', controls: '' } },
         year: 2026,
-        users: [{ userId: 1, role: 'auditor' }]
+        users: [{ userId: 1, role: 'auditor' }],
+        platforms: []
       }],
       currentAssessmentId: 'ASM-x'
     };
@@ -551,5 +552,61 @@ describe('migrateAssessmentsState', () => {
       const twice = migrateAssessmentsState(JSON.parse(JSON.stringify(once)), 15);
       expect(twice.assessments[0].users).toEqual(once.assessments[0].users);
     });
+  });
+
+  describe('v16: per-assessment platforms stamp (plan PR-6)', () => {
+    test('a v15 record gains platforms: [] — the correct historical truth', () => {
+      const state = { assessments: [{ id: 'ASM-old', observations: {} }] };
+      const result = migrateAssessmentsState(state, 15);
+      expect(result.assessments[0].platforms).toEqual([]);
+    });
+
+    test('polarity: a record already carrying platforms keeps them (normalized)', () => {
+      const state = {
+        assessments: [{
+          id: 'ASM-env',
+          observations: {},
+          platforms: ['google-workspace', 'google-workspace', '', 7, 'microsoft-365']
+        }]
+      };
+      const result = migrateAssessmentsState(state, 15);
+      expect(result.assessments[0].platforms).toEqual(['google-workspace', 'microsoft-365']);
+    });
+
+    test('a v0 client falls through all the way to the v16 stamp', () => {
+      const result = migrateAssessmentsState(
+        { assessments: [{ id: 'ASM-ancient', observations: {} }], currentAssessmentId: null }, 0
+      );
+      result.assessments.forEach((a) => {
+        expect(Array.isArray(a.platforms)).toBe(true);
+      });
+    });
+
+    test('is idempotent', () => {
+      const once = migrateAssessmentsState(
+        { assessments: [{ id: 'ASM-x', observations: {}, platforms: ['google-workspace'] }] }, 15
+      );
+      const twice = migrateAssessmentsState(JSON.parse(JSON.stringify(once)), 16);
+      expect(twice.assessments[0].platforms).toEqual(['google-workspace']);
+    });
+  });
+});
+
+describe('normalizeAssessmentPlatforms', () => {
+  test('keeps unknown string ids (future corpora must survive restore)', () => {
+    expect(normalizeAssessmentPlatforms(['okta-corpus-2027'])).toEqual(['okta-corpus-2027']);
+  });
+
+  test('dedupes, trims, drops non-strings and empties', () => {
+    expect(normalizeAssessmentPlatforms([
+      ' google-workspace ', 'google-workspace', '', null, 42, {}, 'microsoft-365'
+    ])).toEqual(['google-workspace', 'microsoft-365']);
+  });
+
+  test('non-array collapses to []', () => {
+    expect(normalizeAssessmentPlatforms(undefined)).toEqual([]);
+    expect(normalizeAssessmentPlatforms(null)).toEqual([]);
+    expect(normalizeAssessmentPlatforms('google-workspace')).toEqual([]);
+    expect(normalizeAssessmentPlatforms({ 0: 'google-workspace' })).toEqual([]);
   });
 });

--- a/src/utils/__snapshots__/dataExportGolden.test.js.snap
+++ b/src/utils/__snapshots__/dataExportGolden.test.js.snap
@@ -453,7 +453,7 @@ Object {
   },
   "storeVersions": Object {
     "artifacts": 9,
-    "assessments": 15,
+    "assessments": 16,
     "findings": 6,
     "frameworks": 6,
     "metrics": 1,
@@ -774,7 +774,7 @@ Alma's position as a continuous authentication SaaS company creates a unique dyn
   },
   "storeVersions": Object {
     "artifacts": 9,
-    "assessments": 15,
+    "assessments": 16,
     "findings": 6,
     "frameworks": 6,
     "metrics": 1,
@@ -1198,7 +1198,7 @@ Object {
   },
   "storeVersions": Object {
     "artifacts": 9,
-    "assessments": 15,
+    "assessments": 16,
     "findings": 6,
     "frameworks": 6,
     "metrics": 1,

--- a/src/utils/dataImport.js
+++ b/src/utils/dataImport.js
@@ -27,6 +27,7 @@ import {
   ASSESSMENTS_SCHEMA_VERSION,
   normalizeAssessmentYear,
   normalizeAssessmentUsers,
+  normalizeAssessmentPlatforms,
   assessmentYearFromCreatedDate
 } from '../stores/assessmentsStore';
 import {
@@ -189,6 +190,12 @@ export const importCompleteDatabase = (parsed, stores, { backupFirst = true } = 
   // or foreign-tool file stamped at the current version could otherwise smuggle
   // PII fields inside assessment.users straight past every producer guard —
   // and users has no share-export rebuild backstop the way externalTracking does.
+  // platforms joins the same pass (plan PR-6, v16): a current-version-stamped
+  // foreign file skips the migration chain entirely, so the platform selection
+  // is normalized here regardless — missing/junk collapses to [], the correct
+  // historical truth. Only the assessment-level string array is touched;
+  // observation platformProcedures refs ride verbatim (PR-5 placeholder-
+  // never-drop semantics own unresolvable refs at expansion, never at import).
   if (Array.isArray(data.assessments)) {
     data.assessments = data.assessments.map((a) => {
       if (!a || typeof a !== 'object') return a;
@@ -196,7 +203,8 @@ export const importCompleteDatabase = (parsed, stores, { backupFirst = true } = 
         ...a,
         externalTracking: normalizeExternalTracking(a.externalTracking),
         year: normalizeAssessmentYear(a.year, assessmentYearFromCreatedDate(a.createdDate)),
-        users: normalizeAssessmentUsers(a.users)
+        users: normalizeAssessmentUsers(a.users),
+        platforms: normalizeAssessmentPlatforms(a.platforms)
       };
       if (a.observations && typeof a.observations === 'object') {
         next.observations = Object.fromEntries(

--- a/src/utils/dataImport.test.js
+++ b/src/utils/dataImport.test.js
@@ -63,16 +63,17 @@ describe('export → restore round-trip', () => {
       expect.arrayContaining(['users', 'controls', 'assessments', 'requirements', 'frameworks', 'artifacts', 'findings'])
     );
     expect(setters.setUsers).toHaveBeenCalledWith(SAMPLE.users);
-    // Assessments additionally get the externalTracking shape (issue #288)
-    // and the year/users fields (issues #291/#290) guaranteed on restore by
-    // the unconditional normalize — everything else is byte-identical to the
-    // exported section.
+    // Assessments additionally get the externalTracking shape (issue #288),
+    // the year/users fields (issues #291/#290), and the platforms field
+    // (plan PR-6, v16) guaranteed on restore by the unconditional normalize —
+    // everything else is byte-identical to the exported section.
     expect(setters.setAssessments).toHaveBeenCalledWith(
       SAMPLE.assessments.map(a => ({
         ...a,
         externalTracking: { enabled: false, systems: { findings: '', artifacts: '', controls: '' } },
         year: new Date().getFullYear(),
-        users: []
+        users: [],
+        platforms: []
       }))
     );
     expect(setters.setFindings).toHaveBeenCalledWith(SAMPLE.findings);
@@ -678,5 +679,77 @@ describe('PR-5: share-import round trip is NOT permanently detached (recipe ride
   test('a format-4 backup is still accepted (heal-in-place, not stranded at the gate)', () => {
     const result = validateDatabaseExport({ formatVersion: 4, data: { users: [] } });
     expect(result.ok).toBe(true);
+  });
+});
+
+describe('platforms restore-path normalization (plan PR-6, v16)', () => {
+  const baseAssessment = (extra) => ({
+    id: 'ASM-platforms',
+    name: 'Platforms restore fixture',
+    scopeType: 'requirements',
+    scoringScale: 10,
+    scopeIds: [],
+    observations: {},
+    ...extra
+  });
+
+  const restoreWith = (storeVersion, assessment) => {
+    const { stores, setters } = makeStores();
+    const parsed = {
+      formatVersion: EXPORT_FORMAT_VERSION,
+      storeVersions: { assessments: storeVersion },
+      data: { assessments: [assessment] }
+    };
+    importCompleteDatabase(parsed, stores, { backupFirst: false });
+    return setters.setAssessments.mock.calls[0][0].find((a) => a.id === 'ASM-platforms');
+  };
+
+  test('a v15 backup gains platforms: [] on restore (migration chain path)', () => {
+    const restored = restoreWith(15, baseAssessment());
+    expect(restored.platforms).toEqual([]);
+  });
+
+  test('UNCONDITIONAL: a current-version-stamped file with junk platforms is normalized (bulk setters bypass migrate)', () => {
+    // Stamped at the CURRENT schema version, so the migration chain is
+    // skipped entirely — only the unconditional pass can catch this. A
+    // mutant that drops the restore-path normalize fails here (v16-skipping
+    // restore, analyzer class).
+    const restored = restoreWith(
+      ASSESSMENTS_SCHEMA_VERSION,
+      baseAssessment({ platforms: ['google-workspace', 'google-workspace', 7, '', null] })
+    );
+    expect(restored.platforms).toEqual(['google-workspace']);
+  });
+
+  test('UNCONDITIONAL: a current-version-stamped file missing platforms restores with []', () => {
+    const restored = restoreWith(ASSESSMENTS_SCHEMA_VERSION, baseAssessment());
+    expect(restored.platforms).toEqual([]);
+  });
+
+  test('polarity: valid platforms ride a current-version restore verbatim', () => {
+    const restored = restoreWith(
+      ASSESSMENTS_SCHEMA_VERSION,
+      baseAssessment({ platforms: ['google-workspace', 'microsoft-365'] })
+    );
+    expect(restored.platforms).toEqual(['google-workspace', 'microsoft-365']);
+  });
+
+  test('observation platformProcedures refs ride restore verbatim — normalize never touches them', () => {
+    const REF = {
+      corpusId: 'scuba',
+      corpusVersion: 'v-old',
+      policyId: 'gws.commoncontrols.1.1v1',
+      contentHash: 'deadbeefdeadbeef'
+    };
+    const restored = restoreWith(
+      ASSESSMENTS_SCHEMA_VERSION,
+      baseAssessment({
+        platforms: ['google-workspace'],
+        observations: {
+          'PR.AA-05': { testProcedures: 'trunk text', platformProcedures: [REF] }
+        }
+      })
+    );
+    expect(restored.observations['PR.AA-05'].platformProcedures).toEqual([REF]);
   });
 });

--- a/src/utils/environmentStep.js
+++ b/src/utils/environmentStep.js
@@ -1,0 +1,161 @@
+/**
+ * Wizard Environment step logic (plan PR-6). The page component is a
+ * dispatcher; every rule lives here so it is lint-gated and probe-able.
+ *
+ * Semantics, all ratified:
+ *  - Platform chips are EPHEMERAL viewport state, seeded from the saved org
+ *    profile (a pure read — nothing writes back). The assessment persists
+ *    only the DERIVED set of platforms with at least one attached check.
+ *  - Offers stay unranked (committed-map order); rows sort in CSF canonical
+ *    function order — a location, not a ranking.
+ *  - Nothing attaches by default and the machine never trims: a checked
+ *    subcategory×platform cell attaches ALL of that cell's offers, an
+ *    unchecked cell attaches none and keeps its count visible.
+ */
+import subcategoryMap from '../data/platformSubcategoryMap.json';
+import { getPlatformProcedures, platformLabel } from './platformBank';
+import { getBankProcedure, subcategoryFromItemId } from './procedureBank';
+
+/* Requirement-scope item ids look like "PR.DS-10 Ex1"; the platform map keys
+ * on the bare subcategory id. Same normalization the bank lookup applies. */
+const itemOffers = (itemId, platforms) =>
+  getPlatformProcedures(subcategoryFromItemId(itemId), platforms);
+
+/**
+ * Platforms the committed map actually covers, as {id, label} chips in
+ * stable alphabetical id order. Derived from data so a future corpus's
+ * platforms appear without a code change here.
+ */
+let availablePlatformsCache = null;
+export const availablePlatforms = () => {
+  if (!availablePlatformsCache) {
+    const ids = new Set();
+    Object.values(subcategoryMap.policies).forEach((entry) => ids.add(entry.platform));
+    availablePlatformsCache = Array.from(ids).sort().map((id) => ({ id, label: platformLabel(id) }));
+  }
+  return availablePlatformsCache;
+};
+
+/* CSF 2.0 function order — canonical presentation order, not a ranking. */
+const FUNCTION_ORDER = ['GV', 'ID', 'PR', 'DE', 'RS', 'RC'];
+const functionRank = (itemId) => {
+  const fn = String(itemId).slice(0, 2);
+  const idx = FUNCTION_ORDER.indexOf(fn);
+  return idx === -1 ? FUNCTION_ORDER.length : idx;
+};
+export const compareCsfOrder = (a, b) =>
+  functionRank(a) - functionRank(b) || String(a).localeCompare(String(b));
+
+/** Stable key for one subcategory×platform selection cell. */
+export const cellKey = (itemId, platformId) => `${itemId}|${platformId}`;
+
+/**
+ * Build the Environment step's review matrix: one row per scoped item that
+ * has a community bank entry (addenda ride the community trunk) AND at least
+ * one offer for the chosen platforms. Rows sort in CSF canonical order.
+ * `noOfferCount` counts the scoped items that get no row — the footer keeps
+ * them visible so non-coverage is stated, never implied away.
+ */
+export const buildEnvironmentMatrix = (scopeItemIds, platformIds) => {
+  const ids = Array.isArray(scopeItemIds) ? scopeItemIds : [];
+  const platforms = Array.isArray(platformIds) ? platformIds : [];
+  const totals = {};
+  platforms.forEach((p) => { totals[p] = 0; });
+  const rows = [];
+  let noOfferCount = 0;
+  ids.forEach((itemId) => {
+    const bankEntry = getBankProcedure(itemId);
+    const cells = {};
+    let rowTotal = 0;
+    if (bankEntry) {
+      platforms.forEach((platformId) => {
+        const count = itemOffers(itemId, [platformId]).length;
+        if (count > 0) {
+          cells[platformId] = count;
+          totals[platformId] += count;
+          rowTotal += count;
+        }
+      });
+    }
+    if (rowTotal === 0) {
+      noOfferCount += 1;
+      return;
+    }
+    rows.push({ itemId, title: bankEntry.title, cells });
+  });
+  rows.sort((a, b) => compareCsfOrder(a.itemId, b.itemId));
+  const totalAvailable = Object.values(totals).reduce((n, c) => n + c, 0);
+  return { rows, totals, totalAvailable, noOfferCount };
+};
+
+/** Count of checks the current selection attaches, for the honest header. */
+export const countAttached = (matrix, selections) =>
+  matrix.rows.reduce((sum, row) =>
+    sum + Object.entries(row.cells).reduce((rowSum, [platformId, count]) =>
+      rowSum + (selections[cellKey(row.itemId, platformId)] ? count : 0), 0), 0);
+
+/** Checks the current selection attaches for ONE item, for preview lines. */
+export const attachedCountForItem = (matrix, selections, itemId) => {
+  const row = matrix.rows.find((r) => r.itemId === itemId);
+  if (!row) return 0;
+  return Object.entries(row.cells).reduce((sum, [platformId, count]) =>
+    sum + (selections[cellKey(itemId, platformId)] ? count : 0), 0);
+};
+
+/** Checks a whole platform column offers, for the labeled select-all. */
+export const columnTotal = (matrix, platformId) => matrix.totals[platformId] || 0;
+
+/** True when every cell of the platform's column is selected. */
+export const columnFullySelected = (matrix, selections, platformId) =>
+  matrix.rows.every((row) =>
+    !(platformId in row.cells) || selections[cellKey(row.itemId, platformId)]);
+
+/** New selections object with the platform's whole column set on/off. */
+export const setColumn = (matrix, selections, platformId, on) => {
+  const next = { ...selections };
+  matrix.rows.forEach((row) => {
+    if (!(platformId in row.cells)) return;
+    if (on) next[cellKey(row.itemId, platformId)] = true;
+    else delete next[cellKey(row.itemId, platformId)];
+  });
+  return next;
+};
+
+/** New selections object with one cell toggled. */
+export const toggleCell = (selections, itemId, platformId) => {
+  const key = cellKey(itemId, platformId);
+  const next = { ...selections };
+  if (next[key]) delete next[key];
+  else next[key] = true;
+  return next;
+};
+
+/**
+ * The create-time attach plan. For every scoped item, the offers its checked
+ * cells attach (ALL offers of each checked platform — user cells are the only
+ * exclusion actor), plus the DERIVED platform set the assessment persists:
+ * exactly the platforms that contribute at least one attached offer. Items
+ * without a community trunk (or with the bank disabled) attach nothing —
+ * addenda ride the community procedure.
+ */
+export const buildAttachPlan = (scopeItemIds, selections, platformIds, useBank) => {
+  const ids = Array.isArray(scopeItemIds) ? scopeItemIds : [];
+  const platforms = Array.isArray(platformIds) ? platformIds : [];
+  const offersByItem = {};
+  const attachedPlatforms = new Set();
+  if (useBank) {
+    ids.forEach((itemId) => {
+      if (!getBankProcedure(itemId)) return;
+      const checked = platforms.filter((p) => selections[cellKey(itemId, p)]);
+      if (checked.length === 0) return;
+      const offers = itemOffers(itemId, checked);
+      if (offers.length === 0) return;
+      offersByItem[itemId] = offers;
+      offers.forEach((offer) => attachedPlatforms.add(offer.record.platform));
+    });
+  }
+  return {
+    offersByItem,
+    platforms: Array.from(attachedPlatforms).sort()
+  };
+};

--- a/src/utils/environmentStep.test.js
+++ b/src/utils/environmentStep.test.js
@@ -1,0 +1,194 @@
+/**
+ * Environment step logic (plan PR-6). The rules under test are ratified
+ * doctrine: user cells are the ONLY exclusion actor (no machine trimming,
+ * the retired cap must not resurrect here), offers stay unranked, rows sort
+ * in CSF canonical order, and the assessment persists the DERIVED platform
+ * set — never raw chip state.
+ */
+import {
+  availablePlatforms,
+  buildEnvironmentMatrix,
+  buildAttachPlan,
+  cellKey,
+  toggleCell,
+  setColumn,
+  columnFullySelected,
+  columnTotal,
+  countAttached,
+  attachedCountForItem,
+  compareCsfOrder
+} from './environmentStep';
+import { getPlatformProcedures } from './platformBank';
+
+const BOTH = ['google-workspace', 'microsoft-365'];
+// The measured attractor: 122 offers across both platforms (session pin).
+const ATTRACTOR = 'PR.DS-10';
+
+describe('availablePlatforms', () => {
+  test('derives the two SCuBA platforms from the committed map, labeled', () => {
+    expect(availablePlatforms()).toEqual([
+      { id: 'google-workspace', label: 'Google Workspace' },
+      { id: 'microsoft-365', label: 'Microsoft 365' }
+    ]);
+  });
+});
+
+describe('buildEnvironmentMatrix', () => {
+  test('rows require a community bank entry AND at least one offer; counts exactly match getPlatformProcedures', () => {
+    const matrix = buildEnvironmentMatrix([ATTRACTOR, 'GV.OC-01'], BOTH);
+    const row = matrix.rows.find((r) => r.itemId === ATTRACTOR);
+    expect(row).toBeTruthy();
+    BOTH.forEach((p) => {
+      expect(row.cells[p]).toBe(getPlatformProcedures(ATTRACTOR, [p]).length);
+    });
+    expect(row.cells['google-workspace'] + row.cells['microsoft-365']).toBe(122);
+  });
+
+  test('scoped items without offers are counted, never silently vanished', () => {
+    // GV.OC-01 has a community procedure but no platform offers.
+    const matrix = buildEnvironmentMatrix([ATTRACTOR, 'GV.OC-01'], BOTH);
+    expect(matrix.rows.map((r) => r.itemId)).toEqual([ATTRACTOR]);
+    expect(matrix.noOfferCount).toBe(1);
+  });
+
+  test('rows sort in CSF canonical function order, not input or alphabetical order', () => {
+    // Input deliberately reversed: DE first, PR last. All three are known
+    // offer-bearing subcategories (session-start measurement).
+    const matrix = buildEnvironmentMatrix(['DE.CM-01', ATTRACTOR, 'PR.AA-05'], BOTH);
+    const ids = matrix.rows.map((r) => r.itemId);
+    // PR before DE is canonical CSF function order and the opposite of both
+    // the input order and alphabetical order ('DE' < 'PR').
+    expect(ids).toEqual(['PR.AA-05', ATTRACTOR, 'DE.CM-01']);
+    expect(ids).toEqual([...ids].sort(compareCsfOrder));
+    // Unknown function prefixes rank after every canonical CSF function.
+    expect(compareCsfOrder('ZZ.XX-01', 'RC.RP-01')).toBeGreaterThan(0);
+    expect(compareCsfOrder('GV.OC-01', 'ZZ.XX-01')).toBeLessThan(0);
+  });
+
+  test('totals and totalAvailable sum the cells exactly', () => {
+    const matrix = buildEnvironmentMatrix([ATTRACTOR, 'DE.CM-01'], BOTH);
+    const cellSum = matrix.rows.reduce(
+      (n, r) => n + Object.values(r.cells).reduce((m, c) => m + c, 0), 0
+    );
+    expect(matrix.totalAvailable).toBe(cellSum);
+    expect(matrix.totalAvailable).toBe(
+      Object.values(matrix.totals).reduce((n, c) => n + c, 0)
+    );
+  });
+
+  test('REGRESSION: implementation-example scope ids ("PR.DS-10 Ex1") resolve to subcategory offers', () => {
+    // Real wizard scope ids carry the Ex suffix; the platform map keys on the
+    // bare subcategory. Caught live in the Interceptor click-through when the
+    // bare-id unit fixtures all passed while the real wizard matrix was empty.
+    const matrix = buildEnvironmentMatrix([`${ATTRACTOR} Ex1`], BOTH);
+    expect(matrix.rows).toHaveLength(1);
+    expect(matrix.rows[0].itemId).toBe(`${ATTRACTOR} Ex1`);
+    expect(matrix.rows[0].cells['google-workspace'] + matrix.rows[0].cells['microsoft-365']).toBe(122);
+  });
+
+  test('empty platforms or empty scope produce an empty matrix, no throw', () => {
+    expect(buildEnvironmentMatrix([], BOTH).rows).toEqual([]);
+    expect(buildEnvironmentMatrix([ATTRACTOR], []).rows).toEqual([]);
+    expect(buildEnvironmentMatrix(null, null).rows).toEqual([]);
+  });
+});
+
+describe('selection helpers', () => {
+  const matrix = buildEnvironmentMatrix([ATTRACTOR, 'DE.CM-01', 'PR.AA-05'], BOTH);
+
+  test('toggleCell is a pure on/off with no side effects on other cells', () => {
+    const on = toggleCell({}, ATTRACTOR, 'google-workspace');
+    expect(on[cellKey(ATTRACTOR, 'google-workspace')]).toBe(true);
+    expect(Object.keys(on)).toHaveLength(1);
+    const off = toggleCell(on, ATTRACTOR, 'google-workspace');
+    expect(off[cellKey(ATTRACTOR, 'google-workspace')]).toBeUndefined();
+  });
+
+  test('setColumn selects and clears exactly the platform column', () => {
+    const on = setColumn(matrix, {}, 'google-workspace', true);
+    expect(columnFullySelected(matrix, on, 'google-workspace')).toBe(true);
+    expect(columnFullySelected(matrix, on, 'microsoft-365')).toBe(false);
+    expect(countAttached(matrix, on)).toBe(columnTotal(matrix, 'google-workspace'));
+    const off = setColumn(matrix, on, 'google-workspace', false);
+    expect(countAttached(matrix, off)).toBe(0);
+  });
+
+  test('countAttached and attachedCountForItem agree with the cell arithmetic', () => {
+    const selections = toggleCell({}, ATTRACTOR, 'microsoft-365');
+    const row = matrix.rows.find((r) => r.itemId === ATTRACTOR);
+    expect(countAttached(matrix, selections)).toBe(row.cells['microsoft-365']);
+    expect(attachedCountForItem(matrix, selections, ATTRACTOR)).toBe(row.cells['microsoft-365']);
+    expect(attachedCountForItem(matrix, selections, 'DE.CM-01')).toBe(0);
+  });
+});
+
+describe('buildAttachPlan', () => {
+  test('a checked cell attaches ALL of that cell offers — the attractor keeps every one of its 122 (no silent cap)', () => {
+    const selections = {
+      [cellKey(ATTRACTOR, 'google-workspace')]: true,
+      [cellKey(ATTRACTOR, 'microsoft-365')]: true
+    };
+    const plan = buildAttachPlan([ATTRACTOR], selections, BOTH, true);
+    expect(plan.offersByItem[ATTRACTOR]).toHaveLength(122);
+    // Byte-level identity with the production offer source, order included:
+    expect(plan.offersByItem[ATTRACTOR]).toEqual(getPlatformProcedures(ATTRACTOR, BOTH));
+  });
+
+  test('an unchecked platform is excluded by USER cell state only', () => {
+    const selections = { [cellKey(ATTRACTOR, 'google-workspace')]: true };
+    const plan = buildAttachPlan([ATTRACTOR], selections, BOTH, true);
+    expect(plan.offersByItem[ATTRACTOR]).toEqual(
+      getPlatformProcedures(ATTRACTOR, ['google-workspace'])
+    );
+    plan.offersByItem[ATTRACTOR].forEach((o) => {
+      expect(o.record.platform).toBe('google-workspace');
+    });
+  });
+
+  test('persisted platforms are DERIVED from attached offers, never chip state', () => {
+    // Both chips on, but the user only checked one GWS cell: the assessment
+    // must declare only google-workspace. Zero checks declare nothing.
+    const selections = { [cellKey(ATTRACTOR, 'google-workspace')]: true };
+    expect(buildAttachPlan([ATTRACTOR], selections, BOTH, true).platforms).toEqual(['google-workspace']);
+    expect(buildAttachPlan([ATTRACTOR], {}, BOTH, true).platforms).toEqual([]);
+  });
+
+  test('REGRESSION: attach plan resolves Ex-suffixed scope ids and keys offers by the raw item id', () => {
+    const itemId = `${ATTRACTOR} Ex1`;
+    const selections = {
+      [cellKey(itemId, 'google-workspace')]: true,
+      [cellKey(itemId, 'microsoft-365')]: true
+    };
+    const plan = buildAttachPlan([itemId], selections, BOTH, true);
+    expect(plan.offersByItem[itemId]).toEqual(getPlatformProcedures(ATTRACTOR, BOTH));
+    expect(plan.platforms).toEqual(['google-workspace', 'microsoft-365']);
+  });
+
+  test('a checked cell for a DE-CHIPPED platform is a ghost — never attaches (analyzer adoption)', () => {
+    // User checks M365 cells, then toggles the M365 chip off: the stale
+    // selection keys stay in state, but the plan must intersect with the
+    // CURRENT platform list. A refactor iterating Object.keys(selections)
+    // would resurrect ghost attaches and fail here.
+    const selections = { [cellKey(ATTRACTOR, 'microsoft-365')]: true };
+    const plan = buildAttachPlan([ATTRACTOR], selections, ['google-workspace'], true);
+    expect(plan.offersByItem).toEqual({});
+    expect(plan.platforms).toEqual([]);
+  });
+
+  test('bank disabled or item uncovered attaches nothing regardless of cells', () => {
+    const selections = { [cellKey(ATTRACTOR, 'google-workspace')]: true };
+    const noBank = buildAttachPlan([ATTRACTOR], selections, BOTH, false);
+    expect(noBank.offersByItem).toEqual({});
+    expect(noBank.platforms).toEqual([]);
+  });
+
+  test('unranked passthrough: offers keep committed-map order (no sorting or scoring anywhere)', () => {
+    const selections = setColumn(
+      buildEnvironmentMatrix(['DE.CM-01'], BOTH), {}, 'google-workspace', true
+    );
+    const plan = buildAttachPlan(['DE.CM-01'], selections, BOTH, true);
+    expect(plan.offersByItem['DE.CM-01'].map((o) => o.policyId)).toEqual(
+      getPlatformProcedures('DE.CM-01', ['google-workspace']).map((o) => o.policyId)
+    );
+  });
+});

--- a/src/utils/infraPresets.js
+++ b/src/utils/infraPresets.js
@@ -1,0 +1,53 @@
+/**
+ * IT-infrastructure presets, promoted out of OrgProfileWizard (plan §5).
+ *
+ * The LABEL is the persisted token: orgProfileStore stores these strings
+ * verbatim in profile.infrastructure, and deriveStackTargets substring-matches
+ * against them — so promotion ADDS ids alongside the labels without changing
+ * what persists (no orgProfileStore version bump, no stack-tailoring change).
+ *
+ * `platformId`, where present, names the platform-procedure map id the label
+ * corresponds to. It powers the wizard Environment step's SEEDING only — a
+ * pure read of the saved profile that pre-checks platform chips. Nothing here
+ * writes back to the org profile (ratified: the profile is global and
+ * optional; the environment selection is per-assessment).
+ */
+export const INFRA_PRESETS = [
+  { id: 'aws', label: 'AWS' },
+  { id: 'azure', label: 'Azure' },
+  { id: 'google-cloud', label: 'Google Cloud' },
+  { id: 'on-prem', label: 'On-premises data center' },
+  { id: 'saas-heavy', label: 'SaaS-heavy' },
+  { id: 'kubernetes', label: 'Kubernetes / containers' },
+  { id: 'ot-ics', label: 'OT / ICS' },
+  { id: 'remote-endpoints', label: 'Remote-first endpoints' },
+  { id: 'microsoft-365', label: 'Microsoft 365', platformId: 'microsoft-365' },
+  { id: 'google-workspace', label: 'Google Workspace', platformId: 'google-workspace' },
+  { id: 'slack', label: 'Slack' },
+  { id: 'microsoft-teams', label: 'Microsoft Teams' }
+];
+
+/** The persisted-token list the org-profile chip picker renders. */
+export const INFRA_PRESET_LABELS = INFRA_PRESETS.map((p) => p.label);
+
+/* Platform-signal matchers for seeding. Substring semantics mirror
+ * deriveStackTargets (profile chips may be free text, e.g. "Office 365 E5"),
+ * kept deliberately conservative: identity-only signals like "Entra ID" do
+ * not imply the M365 platform selection. */
+const PLATFORM_SIGNALS = [
+  { platformId: 'google-workspace', needles: ['google workspace'] },
+  { platformId: 'microsoft-365', needles: ['microsoft 365', 'm365', 'office 365', 'o365'] }
+];
+
+/**
+ * Map a saved org profile's infrastructure chips to platform-procedure map
+ * ids, for pre-checking the Environment step's platform chips. Pure read;
+ * unmatched chips contribute nothing.
+ */
+export const platformIdsFromInfrastructure = (infrastructure) => {
+  const chips = (Array.isArray(infrastructure) ? infrastructure : [])
+    .map((c) => String(c).toLowerCase());
+  return PLATFORM_SIGNALS
+    .filter(({ needles }) => chips.some((c) => needles.some((n) => c.includes(n))))
+    .map(({ platformId }) => platformId);
+};

--- a/src/utils/infraPresets.test.js
+++ b/src/utils/infraPresets.test.js
@@ -1,0 +1,74 @@
+/**
+ * Infra presets promotion (plan PR-6, §5 constraint): the LABEL is the
+ * persisted token. Promotion adds ids alongside labels — the label list must
+ * stay byte-equal to what OrgProfileWizard inlined before, or every saved
+ * profile's chips and deriveStackTargets' substring matching silently break.
+ */
+import { INFRA_PRESETS, INFRA_PRESET_LABELS, platformIdsFromInfrastructure } from './infraPresets';
+import { deriveStackTargets } from './procedureTailor';
+
+// The exact inline array OrgProfileWizard shipped before the promotion.
+const LEGACY_INLINE_LABELS = [
+  'AWS', 'Azure', 'Google Cloud', 'On-premises data center', 'SaaS-heavy',
+  'Kubernetes / containers', 'OT / ICS', 'Remote-first endpoints',
+  'Microsoft 365', 'Google Workspace', 'Slack', 'Microsoft Teams'
+];
+
+describe('INFRA_PRESETS promotion', () => {
+  test('labels byte-equal the legacy inline array, same order (persisted token unchanged)', () => {
+    expect(INFRA_PRESET_LABELS).toEqual(LEGACY_INLINE_LABELS);
+  });
+
+  test('every preset has a non-empty id and label; platformId only on the two map platforms', () => {
+    INFRA_PRESETS.forEach((p) => {
+      expect(typeof p.id).toBe('string');
+      expect(p.id.length).toBeGreaterThan(0);
+      expect(typeof p.label).toBe('string');
+      expect(p.label.length).toBeGreaterThan(0);
+    });
+    const withPlatform = INFRA_PRESETS.filter((p) => p.platformId);
+    expect(withPlatform.map((p) => p.platformId).sort()).toEqual([
+      'google-workspace',
+      'microsoft-365'
+    ]);
+  });
+
+  test('promoted labels keep deriveStackTargets behavior (chips match as before)', () => {
+    // The stack-tailoring email signal keys off the same persisted labels.
+    const targets = deriveStackTargets({ infrastructure: ['Google Workspace', 'Google Cloud'] });
+    expect(targets.email).toBe('google');
+    expect(targets.cloud).toBe('gcp');
+  });
+});
+
+describe('platformIdsFromInfrastructure (Environment step seeding)', () => {
+  test('maps the preset labels to map platform ids', () => {
+    expect(platformIdsFromInfrastructure(['Google Workspace'])).toEqual(['google-workspace']);
+    expect(platformIdsFromInfrastructure(['Microsoft 365'])).toEqual(['microsoft-365']);
+    expect(platformIdsFromInfrastructure(['Microsoft 365', 'Google Workspace']).sort()).toEqual([
+      'google-workspace',
+      'microsoft-365'
+    ]);
+  });
+
+  test('matches free-text variants case-insensitively (chips may be typed)', () => {
+    expect(platformIdsFromInfrastructure(['Office 365 E5'])).toEqual(['microsoft-365']);
+    expect(platformIdsFromInfrastructure(['o365'])).toEqual(['microsoft-365']);
+    expect(platformIdsFromInfrastructure(['M365 tenant'])).toEqual(['microsoft-365']);
+    expect(platformIdsFromInfrastructure(['GOOGLE WORKSPACE for Education'])).toEqual(['google-workspace']);
+  });
+
+  test('non-signals contribute nothing: identity products, clouds, chat, junk input', () => {
+    expect(platformIdsFromInfrastructure(['Entra ID', 'AWS', 'Slack', 'Google Cloud'])).toEqual([]);
+    expect(platformIdsFromInfrastructure([])).toEqual([]);
+    expect(platformIdsFromInfrastructure(null)).toEqual([]);
+    expect(platformIdsFromInfrastructure(undefined)).toEqual([]);
+  });
+
+  test('pure read: never mutates the input array', () => {
+    const input = ['Google Workspace', 'AWS'];
+    const frozen = JSON.parse(JSON.stringify(input));
+    platformIdsFromInfrastructure(input);
+    expect(input).toEqual(frozen);
+  });
+});

--- a/src/utils/procedureTailor.js
+++ b/src/utils/procedureTailor.js
@@ -274,6 +274,21 @@ export const composeAttachObservation = (bankEntry, platformOffers, profile, opt
 };
 
 /**
+ * The wizard's single attach producer (plan PR-6). Offers present → the
+ * composed attach (trunk + platform references + recipe). Zero offers → the
+ * plain community attach, BYTE-IDENTICAL to what the wizard produced before
+ * the Environment step existed: an assessment that attaches no platform
+ * checks gains no new keys, not even a trunk-only recipe — the recipe
+ * appears when a composition exists to record (advisor ruling, G24).
+ */
+export const wizardAttachObservation = (bankEntry, platformOffers, profile, options = {}) => {
+  const offers = Array.isArray(platformOffers) ? platformOffers : [];
+  return offers.length > 0
+    ? composeAttachObservation(bankEntry, offers, profile, options)
+    : bankAttachObservation(bankEntry, profile, options);
+};
+
+/**
  * Pure producer for the per-item "Adapt to my environment" action.
  * Returns null when nothing would change; otherwise the observation
  * update (tailored provenance always stamped) plus the stack-swap count

--- a/src/utils/shareRegistry.js
+++ b/src/utils/shareRegistry.js
@@ -204,6 +204,12 @@ const ASSESSMENT = struct({
   externalTracking: { default: REBUILD_EXTERNAL_TRACKING, includePrivate: SHARE },
   year: SHARE,
   users: SHARE, // roster of { userId, role } pairs — opaque ids, no PII
+  // Per-assessment platform selection (plan PR-6). SHARE is honest, not a
+  // leak: the field is DERIVED from attached platform checks (never raw chip
+  // state), and a share that carries any addendum already names its platform
+  // in the expanded header — so the field only exists where the share body
+  // discloses the same fact. An assessment with zero addenda has [].
+  platforms: SHARE,
   scopeIds: SHARE,
   frameworkFilter: SHARE,
   status: SHARE,

--- a/src/utils/wizardAttach.test.js
+++ b/src/utils/wizardAttach.test.js
@@ -1,0 +1,136 @@
+/**
+ * wizardAttachObservation — the wizard's single attach producer (plan PR-6)
+ * — plus the source-scan pins that keep the page a dispatcher.
+ *
+ * Branch semantics (advisor ruling, G24): offers → the PR-5 composed attach,
+ * byte-exact; zero offers → the plain community attach, deepEqual to what
+ * the wizard produced before the Environment step existed. An assessment
+ * that attaches no platform checks gains NO new keys — not even a
+ * trunk-only recipe.
+ */
+import fs from 'fs';
+import path from 'path';
+import {
+  bankAttachObservation,
+  composeAttachObservation,
+  wizardAttachObservation
+} from './procedureTailor';
+import { getBankProcedure } from './procedureBank';
+import { getPlatformProcedures } from './platformBank';
+
+const trunkEntry = getBankProcedure('PR.AA-05');
+const offers = getPlatformProcedures('PR.AA-05', ['google-workspace']);
+
+// attachedAt is a wall-clock stamp; two producer calls can straddle a
+// millisecond boundary, so every producer-identity comparison neutralizes it.
+const neutralize = (o) => JSON.stringify({
+  ...o,
+  procedureSource: { ...o.procedureSource, attachedAt: 'T' }
+});
+
+describe('wizardAttachObservation branch polarity', () => {
+  test('offers present: output === composeAttachObservation, byte-exact (attach timestamp neutralized)', () => {
+    const viaWizard = wizardAttachObservation(trunkEntry, offers, null, {});
+    const direct = composeAttachObservation(trunkEntry, offers, null, {});
+    // attachedAt is a wall-clock stamp; the two calls are milliseconds apart.
+    // Everything else must be byte-exact.
+    expect(typeof viaWizard.procedureSource.attachedAt).toBe('string');
+    expect(neutralize(viaWizard)).toBe(neutralize(direct));
+    expect(viaWizard.platformProcedures).toHaveLength(offers.length);
+  });
+
+  test('zero offers: output deepEqual to bankAttachObservation — no platformProcedures, no components key', () => {
+    const viaWizard = wizardAttachObservation(trunkEntry, [], null, {});
+    const legacy = bankAttachObservation(trunkEntry, null, {});
+    expect(neutralize(viaWizard)).toBe(neutralize(legacy));
+    expect('platformProcedures' in viaWizard).toBe(false);
+    expect('components' in viaWizard.procedureSource).toBe(false);
+  });
+
+  test('undefined offers behave as zero (items outside the attach plan)', () => {
+    const viaWizard = wizardAttachObservation(trunkEntry, undefined, null, {});
+    expect(neutralize(viaWizard)).toBe(neutralize(bankAttachObservation(trunkEntry, null, {})));
+  });
+
+  test('tailoring options thread through both branches', () => {
+    const profile = { orgName: 'Wizard Test Org' };
+    const opts = { substituteName: true };
+    expect(wizardAttachObservation(trunkEntry, offers, profile, opts).testProcedures).toBe(
+      composeAttachObservation(trunkEntry, offers, profile, opts).testProcedures
+    );
+    expect(wizardAttachObservation(trunkEntry, [], profile, opts).testProcedures).toBe(
+      bankAttachObservation(trunkEntry, profile, opts).testProcedures
+    );
+  });
+
+  test('hand-built refs cannot substitute for compose output (decorrelation)', () => {
+    // A mutant page that splices its own ref objects produces refs that
+    // diverge from compose's canonical shape the moment any field drifts.
+    const viaWizard = wizardAttachObservation(trunkEntry, offers.slice(0, 2), null, {});
+    const handBuilt = offers.slice(0, 2).map((o) => ({
+      corpusId: o.corpusId,
+      policyId: o.policyId
+      // missing corpusVersion + contentHash — the drift a hand-builder ships
+    }));
+    expect(viaWizard.platformProcedures).not.toEqual(handBuilt);
+    viaWizard.platformProcedures.forEach((ref) => {
+      expect(Object.keys(ref).sort()).toEqual([
+        'contentHash', 'corpusId', 'corpusVersion', 'policyId'
+      ]);
+    });
+  });
+});
+
+describe('page-dispatcher source pins (plan PR-6)', () => {
+  const SRC = path.join(process.cwd(), 'src');
+  const stripComments = (code) =>
+    code.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+  const page = stripComments(
+    fs.readFileSync(path.join(SRC, 'pages/Assessments.js'), 'utf8')
+  );
+
+  test('exactly one attach-producer call in the create path: wizardAttachObservation', () => {
+    expect((page.match(/wizardAttachObservation\(/g) || []).length).toBe(1);
+    // compose is never called from the page directly (the wrapper owns the branch)
+    expect((page.match(/composeAttachObservation\(/g) || []).length).toBe(0);
+    // bankAttachObservation remains ONLY as the step-3 preview producer
+    expect((page.match(/bankAttachObservation\(/g) || []).length).toBe(1);
+  });
+
+  test('no wizard module writes the org profile (ratified no-write-back)', () => {
+    // The org profile's only write APIs are saveProfile / setCloudConsent /
+    // clearProfile / setProfileState. The assessment wizard page and the
+    // Environment helpers must never call any of them; seeding is a pure read.
+    const WRITE_TOKENS = /saveProfile\s*\(|setCloudConsent\s*\(|clearProfile\s*\(|setProfileState\s*\(/;
+    expect(WRITE_TOKENS.test(page)).toBe(false);
+    ['utils/environmentStep.js', 'utils/infraPresets.js'].forEach((rel) => {
+      const code = stripComments(fs.readFileSync(path.join(SRC, rel), 'utf8'));
+      expect(WRITE_TOKENS.test(code)).toBe(false);
+      // Belt and braces: the helpers never even import the profile store.
+      expect(code).not.toMatch(/orgProfileStore/);
+    });
+  });
+});
+
+describe('org profile store state is byte-untouched by Environment step logic', () => {
+  test('running seed + matrix + plan against a hydrated store leaves its state identical', () => {
+    /* eslint-disable global-require */
+    const useOrgProfileStore = require('../stores/orgProfileStore').default;
+    const { platformIdsFromInfrastructure } = require('./infraPresets');
+    const { buildEnvironmentMatrix, buildAttachPlan, cellKey } = require('./environmentStep');
+    /* eslint-enable global-require */
+    useOrgProfileStore.getState().saveProfile({
+      orgName: 'Untouched Org',
+      infrastructure: ['Google Workspace', 'AWS']
+    });
+    const before = JSON.stringify(useOrgProfileStore.getState());
+    const seeded = platformIdsFromInfrastructure(
+      useOrgProfileStore.getState().profile.infrastructure
+    );
+    expect(seeded).toEqual(['google-workspace']);
+    buildEnvironmentMatrix(['PR.AA-05'], seeded);
+    buildAttachPlan(['PR.AA-05'], { [cellKey('PR.AA-05', 'google-workspace')]: true }, seeded, true);
+    const after = JSON.stringify(useOrgProfileStore.getState());
+    expect(after).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary

First user-visible PR of the platform-procedures program. The New Assessment wizard gains a step 2, **Environment**: declare which platforms the assessment covers and attach CISA SCuBA configuration checks as references through the PR-5 compose/expansion machinery. With this PR the whole reference pipeline shipped in #314 carries real user data: the detail panel renders expanded addenda with attribution, and every CSV/Jira/share egress carries them through the single choke point.

## What changed

- **`src/utils/infraPresets.js`** (new): the org-profile infrastructure presets, promoted out of `OrgProfileWizard` with ids added alongside labels. The **label stays the persisted token**, so saved profiles and `deriveStackTargets` substring matching are untouched (no orgProfileStore version bump). `platformIdsFromInfrastructure` maps profile chips to platform ids for seeding.
- **`src/utils/environmentStep.js`** (new): all Environment-step rules. `buildEnvironmentMatrix` (row eligibility: community trunk + at least one offer; CSF canonical order; exact per-cell counts), selection helpers, and `buildAttachPlan` (checked cells attach ALL their offers; the persisted platform set is DERIVED from what attached).
- **`src/utils/procedureTailor.js`**: `wizardAttachObservation`, the wizard's single attach producer. Offers present: the PR-5 composed attach, byte-exact. Zero offers: the plain community attach, deep-equal to the pre-PR-6 producer, so untouched assessments gain no new keys.
- **`src/pages/Assessments.js`**: the step UI (chips seeded from the org profile, "Same as my org profile" reset, selection matrix, labeled select-all, honest totals) plus call-site swaps. Rules live in the utils; the page stays a dispatcher.
- **`src/stores/assessmentsStore.js`**: schema v16. `platforms` on every assessment (empty for records that predate the step — the correct historical truth), normalized at `createAssessment`, `updateAssessment`, and the migration chain.
- **`src/utils/dataImport.js`**: `platforms` joins the unconditional restore-path normalize (the #288 precedent block) — a current-version-stamped foreign file bypasses the migration chain, so the pass runs regardless. Observation `platformProcedures` refs ride restore verbatim; unresolvable refs remain the expansion placeholder's job, never import's.
- **`src/utils/shareRegistry.js`**: `platforms: SHARE`, with the honesty argument in place: the field is derived from attached checks, and any share carrying an addendum already names its platform in the expanded header. An assessment with zero addenda shares `[]`.

## Design decisions (ratify by merging)

1. **Org profile seeds, never written back.** The profile is global and optional; the environment selection is per-assessment. The wizard reads the profile to pre-check chips and offers a reset; no wizard flow writes the profile (source-scan-pinned, byte-untouched-store test, and verified live).
2. **The user is the only exclusion actor.** Nothing attaches by default. A checked subcategory-by-platform cell attaches every one of its offers — the PR.DS-10 attractor keeps all 122 when checked (pinned). No cap, no threshold, no grain filter: measurement showed grain precision does not rescue the attractors (67 of PR.DS-10's 122 are exact-grain or authored), so grain stays display-only.
3. **Offers stay unranked.** Rows sort in CSF canonical function order; offers keep committed-map order end to end (pinned).
4. **`platforms` is derived, not declared.** The assessment stores the platforms that actually contributed an attached check — chip state is ephemeral UI. Skipping the step leaves behavior byte-identical to today.
5. **Zero-offer attach is byte-identical to the pre-PR-6 producer.** No trunk-only recipe is sprayed onto assessments that never touched the step; the recipe appears when a composition exists to record.
6. **Wizard preview stays trunk-only**, with an honest "+N platform checks attach as addenda" line (rendered at 0 too). Full addendum preview is PR-7 alongside badges.
7. **Known gap, dated:** no post-create addendum add/remove/edit surface yet — that is the PR-7 detail-panel region (entry conditions 5–6 stay dormant; no fork UI shipped). Until then the only escape from an over-attached assessment is delete-and-recreate; a checked attractor cell is a deliberate, disclosed 122-block commitment. PR-7's picker can heal in place because every wizard-derived addendum is a reference (no text field) with the derivation recorded in `procedureSource.components[]` — wizard content and user-authored content are positively distinguishable (`isPlatformFork`).

## Verification

- 1100 tests green (60 suites; 1055 baseline + 45 new). Golden snapshots diff exactly three `assessments: 15 -> 16` storeVersion lines.
- Store v16 polarity both directions (migrate gains `[]`, existing platforms preserved; restore-path junk normalized on a current-version-stamped file, valid platforms verbatim, refs untouched).
- Write-back anti-tests: source scan (no profile write APIs in wizard code), store-state byte-equality through the production save path, and a live byte-comparison of `csf-org-profile-storage` across a full wizard session.
- Live click-through in real Chrome: profile seeding, reset, matrix selection (67 of 493 checks), create, `platforms: ["google-workspace"]` derived, 64 refs + 65-component recipe on PR.DS-10, detail-panel expansion with attribution and license line, CSV export carrying 67 addendum blocks with attribution.
- Five live analyzer mutant classes killed: hand-built-ref writer, write-back-to-profile, v16-skipping restore, recipe-dropping attach, offer-truncating selection.
- Changed files lint clean under both eslint invocations (CI `--env` set and bare); `CI=false npm run build` compiles; deny-token scan zero hits; no packFormat; no new markdown.
