### PR TITLE
Add provenance badges, drift surfacing, and the platform-check picker

### DIFF
--- a/src/components/PlatformAddendumBadges.js
+++ b/src/components/PlatformAddendumBadges.js
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { ChevronDown, ChevronRight, ExternalLink } from 'lucide-react';
+import { addendumRowDescriptor } from '../utils/platformBank';
+
+/**
+ * Read-mode provenance chrome for an observation's platform addenda —
+ * one summary line plus one row per entry (plan PR-7). Pure presentation
+ * over addendumRowDescriptor(): the rows, the summary counts, and the
+ * picker's attached list all read the same derivation, so they cannot
+ * disagree. Renders from the per-observation entries alone — never from
+ * the assessment-level platforms array, whose emptiness is ambiguous by
+ * contract.
+ *
+ * Badge states are the production-drivable set only: "Updated upstream"
+ * (attach-time fingerprint differs from the current corpus — the rendered
+ * text below already shows the current version; the badge is the consent
+ * surface, resolved by the picker's adopt action) and "Unresolved" (no
+ * current corpus record — the expanded placeholder carries the identity).
+ * Rows are collapsed behind the summary by default: attractor
+ * subcategories legitimately carry 100+ addenda and the chrome must not
+ * bury the procedure text.
+ */
+const CHIP = 'px-1.5 py-0.5 rounded text-xs';
+const DRIFT_CHIP = `${CHIP} bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300`;
+const UNRESOLVED_CHIP = `${CHIP} bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300`;
+
+const PlatformAddendumBadges = ({ entries }) => {
+  const [open, setOpen] = useState(false);
+  const list = Array.isArray(entries) ? entries : [];
+  if (list.length === 0) return null;
+  const rows = list.map(addendumRowDescriptor);
+  const driftedCount = rows.filter((r) => r.drifted).length;
+  const unresolvedCount = rows.filter((r) => r.unresolved).length;
+
+  return (
+    <div className="mb-2 text-xs" data-testid="platform-addendum-badges">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-2 text-gray-600 dark:text-gray-300 hover:underline"
+        aria-expanded={open}
+      >
+        {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        <span>{list.length === 1 ? '1 platform check' : `${list.length} platform checks`}</span>
+        {driftedCount > 0 && (
+          <span className={DRIFT_CHIP}>{driftedCount} updated upstream</span>
+        )}
+        {unresolvedCount > 0 && (
+          <span className={UNRESOLVED_CHIP}>{unresolvedCount} unresolved</span>
+        )}
+      </button>
+      {open && (
+        <ul className="mt-1 ml-5 space-y-1">
+          {rows.map((row) => (
+            <li
+              key={`${row.corpusId}:${row.policyId}`}
+              className="flex items-center gap-2 text-gray-600 dark:text-gray-300"
+              data-testid="platform-addendum-row"
+            >
+              <span className="font-mono">{row.policyId}</span>
+              {row.platformText && <span>{row.platformText}</span>}
+              {row.drifted && <span className={DRIFT_CHIP}>Updated upstream</span>}
+              {row.unresolved && <span className={UNRESOLVED_CHIP}>Unresolved</span>}
+              {row.sourceUrl && (
+                <a
+                  href={row.sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline"
+                  title="View the upstream source of this platform check"
+                >
+                  <ExternalLink size={11} /> Source
+                </a>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default PlatformAddendumBadges;

--- a/src/components/PlatformAddendumBadges.test.js
+++ b/src/components/PlatformAddendumBadges.test.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import PlatformAddendumBadges from './PlatformAddendumBadges';
+import bank from '../data/platformProcedures.json';
+import { buildPlatformRef, getPlatformProcedures } from '../utils/platformBank';
+import { exportAllDataJSON } from '../utils/dataExport';
+import { importCompleteDatabase } from '../utils/dataImport';
+
+/**
+ * Read-mode addendum provenance chrome (plan PR-7). The hard badge rule
+ * binds every state to a production-drivable fixture:
+ *  - drift: a contentHash-divergent reference rendered through the
+ *    component's production derivation (platformRefDrift);
+ *  - unresolved: a corpus-less reference driven through the PRODUCTION
+ *    importCompleteDatabase restore path (the ISC-862 pattern) and
+ *    rendered exactly as restored.
+ * Assertions map each rendered label to the ref it claims — not merely
+ * "a badge rendered".
+ */
+
+const gwsOffer = getPlatformProcedures('PR.DS-10', ['google-workspace'])[0];
+const m365Offer = getPlatformProcedures('PR.DS-10', ['microsoft-365'])[0];
+const freshRef = () => buildPlatformRef(gwsOffer.record, gwsOffer.corpusId);
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe('PlatformAddendumBadges', () => {
+  test('renders nothing without entries', () => {
+    const { container } = render(<PlatformAddendumBadges entries={[]} />);
+    expect(container).toBeEmptyDOMElement();
+    const { container: c2 } = render(<PlatformAddendumBadges entries={undefined} />);
+    expect(c2).toBeEmptyDOMElement();
+  });
+
+  test('a fresh reference: summary with count, NO drift or unresolved chip; row carries label + upstream source link', () => {
+    render(<PlatformAddendumBadges entries={[freshRef()]} />);
+    expect(screen.getByText('1 platform check')).toBeInTheDocument();
+    expect(screen.queryByText(/updated upstream/i)).toBeNull();
+    expect(screen.queryByText(/unresolved/i)).toBeNull();
+    fireEvent.click(screen.getByText('1 platform check'));
+    expect(screen.getByText(gwsOffer.policyId)).toBeInTheDocument();
+    expect(screen.getByText('Google Workspace')).toBeInTheDocument();
+    const link = screen.getByTitle('View the upstream source of this platform check');
+    expect(link).toHaveAttribute('href', gwsOffer.record.attribution.sourceUrl);
+  });
+
+  test('drift badge: a contentHash-divergent ref shows "Updated upstream" in summary and on ITS row, link intact', () => {
+    const drifted = { ...freshRef(), contentHash: '0000000000000000' };
+    const stable = buildPlatformRef(m365Offer.record, m365Offer.corpusId);
+    render(<PlatformAddendumBadges entries={[drifted, stable]} />);
+    expect(screen.getByText('2 platform checks')).toBeInTheDocument();
+    expect(screen.getByText('1 updated upstream')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('2 platform checks'));
+    const rows = screen.getAllByTestId('platform-addendum-row');
+    const driftedRow = rows.find((r) => r.textContent.includes(drifted.policyId));
+    const stableRow = rows.find((r) => r.textContent.includes(stable.policyId));
+    expect(driftedRow).toHaveTextContent('Updated upstream');
+    expect(stableRow).not.toHaveTextContent('Updated upstream');
+    expect(within(driftedRow).getByRole('link')).toHaveAttribute(
+      'href', gwsOffer.record.attribution.sourceUrl);
+  });
+
+  test('unresolved badge through the PRODUCTION restore path: a corpus-less ref imported verbatim badges "Unresolved" with NO link', () => {
+    const FOREIGN = {
+      corpusId: 'foreign-corpus',
+      corpusVersion: 'ffffffffffffffff',
+      policyId: 'gone.policy.1.1v1',
+      contentHash: '0123456789abcdef'
+    };
+    const data = {
+      users: [{ id: 'u1', name: 'Auditor One' }],
+      controls: [],
+      requirements: [{ id: 'PR.DS-01 Ex1', frameworkId: 'nist-csf-2.0' }],
+      frameworks: [{ id: 'nist-csf-2.0', name: 'NIST CSF 2.0', isDefault: true }],
+      artifacts: [], findings: [], metrics: [],
+      assessments: [{
+        id: 'a1',
+        name: 'Restored',
+        observations: {
+          'PR.DS-01 Ex1': {
+            testProcedures: 'Trunk.',
+            platformProcedures: [FOREIGN],
+            quarters: {}
+          }
+        }
+      }]
+    };
+    const setters = { setAssessments: jest.fn() };
+    const storeOf = (state) => ({ getState: () => state });
+    const stores = {
+      userStore: storeOf({ users: data.users, setUsers: jest.fn() }),
+      controlsStore: storeOf({ controls: data.controls, setControls: jest.fn() }),
+      assessmentsStore: storeOf({ assessments: data.assessments, setAssessments: setters.setAssessments }),
+      requirementsStore: storeOf({ requirements: data.requirements, setRequirements: jest.fn() }),
+      frameworksStore: storeOf({ frameworks: data.frameworks, setFrameworks: jest.fn() }),
+      artifactStore: storeOf({ artifacts: data.artifacts, setArtifacts: jest.fn() }),
+      findingsStore: storeOf({ findings: data.findings, setFindings: jest.fn() }),
+      metricsStore: storeOf({ metrics: data.metrics, setMetrics: jest.fn() }),
+      orgProfileStore: storeOf({ profile: null, cloudConsent: false, setProfileState: jest.fn() })
+    };
+    const parsed = JSON.parse(JSON.stringify(exportAllDataJSON(stores)));
+    importCompleteDatabase(parsed, stores, { backupFirst: false });
+    const restored = setters.setAssessments.mock.calls[0][0];
+    const entries = restored[0].observations['PR.DS-01 Ex1'].platformProcedures;
+    expect(entries).toEqual([FOREIGN]); // verbatim — the stale identity is preserved, never healed
+
+    render(<PlatformAddendumBadges entries={entries} />);
+    expect(screen.getByText('1 unresolved')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('1 platform check'));
+    const row = screen.getByTestId('platform-addendum-row');
+    expect(row).toHaveTextContent(FOREIGN.policyId);
+    expect(row).toHaveTextContent('Unresolved');
+    expect(within(row).queryByRole('link')).toBeNull(); // no dead href
+  });
+
+  test('rows collapsed by default; the toggle expands one row per entry in entry order', () => {
+    const refs = getPlatformProcedures('PR.DS-10', ['google-workspace'])
+      .slice(0, 3)
+      .map((o) => buildPlatformRef(o.record, o.corpusId));
+    render(<PlatformAddendumBadges entries={refs} />);
+    expect(screen.queryAllByTestId('platform-addendum-row')).toHaveLength(0);
+    fireEvent.click(screen.getByText('3 platform checks'));
+    const rows = screen.getAllByTestId('platform-addendum-row');
+    expect(rows).toHaveLength(refs.length);
+    rows.forEach((row, i) => {
+      expect(within(row).getByText(refs[i].policyId)).toBeInTheDocument();
+    });
+  });
+
+  test('mixed corpus record license surface: the M365 record used here really carries a sourceUrl (fixture honesty)', () => {
+    expect(bank.procedures[m365Offer.policyId].attribution.sourceUrl).toBeTruthy();
+  });
+
+  test('a fork row shows NEITHER chip — its text is user-owned and the drift remedy (adopt) refuses forks', () => {
+    const fork = { ...freshRef(), contentHash: '0000000000000000', text: 'User text.', modified: true };
+    render(<PlatformAddendumBadges entries={[fork]} />);
+    expect(screen.queryByText(/updated upstream/i)).toBeNull();
+    expect(screen.queryByText(/unresolved/i)).toBeNull();
+    fireEvent.click(screen.getByText('1 platform check'));
+    const row = screen.getByTestId('platform-addendum-row');
+    expect(row).toHaveTextContent(fork.policyId);
+  });
+});

--- a/src/components/PlatformCheckPicker.js
+++ b/src/components/PlatformCheckPicker.js
@@ -1,0 +1,243 @@
+import React, { useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ExternalLink, Plus, RefreshCw, Trash2, X } from 'lucide-react';
+import {
+  addendumRowDescriptor,
+  getPlatformProcedures,
+  getPlatformRecord,
+  platformRecordContentHash,
+  platformRefSourceUrl
+} from '../utils/platformBank';
+import { subcategoryFromItemId } from '../utils/procedureBank';
+import { availablePlatforms } from '../utils/environmentStep';
+
+/**
+ * Post-create management of one observation's platform checks (plan PR-7)
+ * — the surface that closes PR-6's one-way door. Pure presentation: every
+ * click dispatches ONE operation to the page handler, which routes it
+ * through the pure producer (pickerObservationUpdate) — no composition
+ * rule lives here.
+ *
+ * Doctrine inherited from the wizard: offers are unranked (committed-map
+ * order), grouped by platform with counts visible, and nothing is trimmed
+ * or thresholded — the user is the only exclusion actor.
+ *
+ * Consent surfaces:
+ *  - Adopt shows an in-dialog confirm naming exactly what changes: the
+ *    check's rendered text already shows the current upstream version
+ *    (rendering always does); adopting records that version as the one
+ *    you accepted, replacing the stored fingerprint (old vs new shown,
+ *    with the upstream source link). Nothing is adopted implicitly.
+ *  - Removing a customized (forked) check shows an in-dialog confirm with
+ *    a preview of the text that will be discarded.
+ * Unresolved checks offer Remove only: there is no upstream record to
+ * adopt, so no re-attach affordance renders.
+ */
+const CHIP = 'px-1.5 py-0.5 rounded text-xs';
+const DRIFT_CHIP = `${CHIP} bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300`;
+const UNRESOLVED_CHIP = `${CHIP} bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300`;
+
+const PlatformCheckPicker = ({ itemId, observation, canAttach, onOperation, onClose }) => {
+  const [confirming, setConfirming] = useState(null); // {type:'adopt'|'removeFork', entry}
+
+  React.useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose?.();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const entries = useMemo(
+    () => (Array.isArray(observation?.platformProcedures) ? observation.platformProcedures : []),
+    [observation]
+  );
+  const attachedRows = useMemo(() => entries.map(addendumRowDescriptor), [entries]);
+
+  const subcategoryId = subcategoryFromItemId(itemId);
+  const offerGroups = useMemo(() => {
+    const attachedKeys = new Set(entries.map((e) => `${e.corpusId}:${e.policyId}`));
+    return availablePlatforms()
+      .map((platform) => {
+        const offers = getPlatformProcedures(subcategoryId, [platform.id])
+          .filter((offer) => !attachedKeys.has(`${offer.corpusId}:${offer.policyId}`));
+        return { platform, offers };
+      })
+      .filter((group) => group.offers.length > 0);
+  }, [subcategoryId, entries]);
+
+  const entryFor = (row) =>
+    entries.find((e) => e.corpusId === row.corpusId && e.policyId === row.policyId);
+
+  const dispatch = (operation) => {
+    setConfirming(null);
+    onOperation(operation);
+  };
+
+  const modal = (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50" data-testid="platform-check-picker">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Platform checks for ${subcategoryId}`}
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col"
+      >
+        <div className="flex items-center justify-between p-4 border-b dark:border-gray-700">
+          <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+            Platform checks for {subcategoryId}
+          </h3>
+          <button type="button" onClick={onClose} aria-label="Close" className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="overflow-auto p-4 space-y-6 text-sm">
+          {confirming?.type === 'adopt' && (() => {
+            const entry = confirming.entry;
+            const record = getPlatformRecord(entry.corpusId, entry.policyId);
+            const newHash = record ? platformRecordContentHash(record) : null;
+            const sourceUrl = platformRefSourceUrl(entry);
+            return (
+              <div className="border border-amber-300 dark:border-amber-700 rounded-lg p-3 space-y-2 bg-amber-50 dark:bg-amber-900/20" data-testid="adopt-confirm">
+                <p className="font-medium text-gray-800 dark:text-gray-100">
+                  Adopt the upstream update for {entry.policyId}?
+                </p>
+                <p className="text-gray-700 dark:text-gray-300">
+                  The text shown and exported for this check already comes from the
+                  current upstream version. Adopting replaces the fingerprint recorded
+                  when you attached it with the current one, marking this version as
+                  the one you accepted.
+                </p>
+                <p className="font-mono text-xs text-gray-600 dark:text-gray-400">
+                  attached version: {entry.contentHash}
+                  <br />
+                  current version: {newHash}
+                </p>
+                {sourceUrl && (
+                  <a href={sourceUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline text-xs">
+                    <ExternalLink size={11} /> Review the upstream source
+                  </a>
+                )}
+                <div className="flex gap-2 pt-1">
+                  <button type="button" onClick={() => dispatch({ op: 'adopt', ref: entry })} className="px-2 py-1 rounded bg-amber-600 text-white text-xs hover:bg-amber-700">
+                    Adopt upstream update
+                  </button>
+                  <button type="button" onClick={() => setConfirming(null)} className="px-2 py-1 rounded border dark:border-gray-600 text-xs text-gray-700 dark:text-gray-300">
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            );
+          })()}
+
+          {confirming?.type === 'removeFork' && (
+            <div className="border border-red-300 dark:border-red-700 rounded-lg p-3 space-y-2 bg-red-50 dark:bg-red-900/20" data-testid="remove-fork-confirm">
+              <p className="font-medium text-gray-800 dark:text-gray-100">
+                Remove this customized check and discard your edits?
+              </p>
+              <p className="text-gray-700 dark:text-gray-300">
+                You edited the text of {confirming.entry.policyId}. Removing it
+                deletes your edited text, which starts with:
+              </p>
+              <p className="font-mono text-xs text-gray-600 dark:text-gray-400 border-l-2 border-red-300 pl-2">
+                {String(confirming.entry.text).slice(0, 160)}
+                {String(confirming.entry.text).length > 160 ? '…' : ''}
+              </p>
+              <div className="flex gap-2 pt-1">
+                <button type="button" onClick={() => dispatch({ op: 'remove', ref: confirming.entry })} className="px-2 py-1 rounded bg-red-600 text-white text-xs hover:bg-red-700">
+                  Remove and discard edits
+                </button>
+                <button type="button" onClick={() => setConfirming(null)} className="px-2 py-1 rounded border dark:border-gray-600 text-xs text-gray-700 dark:text-gray-300">
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+
+          <div>
+            <h4 className="font-medium text-gray-700 dark:text-gray-200 mb-2">
+              Attached ({attachedRows.length})
+            </h4>
+            {attachedRows.length === 0 ? (
+              <p className="text-gray-500 dark:text-gray-400 text-xs">No platform checks attached.</p>
+            ) : (
+              <ul className="space-y-1">
+                {attachedRows.map((row) => {
+                  const entry = entryFor(row);
+                  return (
+                    <li key={`${row.corpusId}:${row.policyId}`} className="flex items-center gap-2" data-testid="attached-check-row">
+                      <span className="font-mono text-xs">{row.policyId}</span>
+                      {row.platformText && <span className="text-xs text-gray-500 dark:text-gray-400">{row.platformText}</span>}
+                      {row.drifted && <span className={DRIFT_CHIP}>Updated upstream</span>}
+                      {row.unresolved && <span className={UNRESOLVED_CHIP}>Unresolved</span>}
+                      {row.fork && <span className="text-xs text-gray-500 dark:text-gray-400">customized</span>}
+                      <span className="flex-1" />
+                      {row.drifted && (
+                        <button type="button" onClick={() => setConfirming({ type: 'adopt', entry })} className="flex items-center gap-1 text-xs text-amber-700 dark:text-amber-400 hover:underline" title="Adopt the upstream update for this check">
+                          <RefreshCw size={11} /> Adopt update
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => (row.fork ? setConfirming({ type: 'removeFork', entry }) : dispatch({ op: 'remove', ref: entry }))}
+                        className="flex items-center gap-1 text-xs text-red-600 dark:text-red-400 hover:underline"
+                        title="Remove this platform check"
+                      >
+                        <Trash2 size={11} /> Remove
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+
+          <div>
+            <h4 className="font-medium text-gray-700 dark:text-gray-200 mb-2">Available</h4>
+            {!canAttach ? (
+              <p className="text-gray-500 dark:text-gray-400 text-xs">
+                Platform checks extend the community procedure. Use "Insert
+                community procedure" first, then add checks here.
+              </p>
+            ) : offerGroups.length === 0 ? (
+              <p className="text-gray-500 dark:text-gray-400 text-xs">
+                Every available platform check for this subcategory is attached.
+              </p>
+            ) : (
+              offerGroups.map(({ platform, offers }) => (
+                <div key={platform.id} className="mb-3" data-testid={`offer-group-${platform.id}`}>
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="text-xs font-medium text-gray-600 dark:text-gray-300">
+                      {platform.label} ({offers.length} available)
+                    </span>
+                    <button type="button" onClick={() => dispatch({ op: 'addAll', offers })} className="text-xs text-blue-600 dark:text-blue-400 hover:underline">
+                      Attach all {offers.length}
+                    </button>
+                  </div>
+                  <ul className="space-y-0.5">
+                    {offers.map((offer) => (
+                      <li key={`${offer.corpusId}:${offer.policyId}`} className="flex items-center gap-2" data-testid="offer-row">
+                        <span className="font-mono text-xs">{offer.policyId}</span>
+                        <span className="flex-1" />
+                        <button type="button" onClick={() => dispatch({ op: 'add', offer })} className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline" title="Attach this platform check">
+                          <Plus size={11} /> Attach
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(modal, document.body);
+};
+
+export default PlatformCheckPicker;

--- a/src/components/PlatformCheckPicker.test.js
+++ b/src/components/PlatformCheckPicker.test.js
@@ -1,0 +1,173 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import PlatformCheckPicker from './PlatformCheckPicker';
+import {
+  forkPlatformProcedure,
+  getPlatformProcedures,
+  platformRecordContentHash
+} from '../utils/platformBank';
+import { composeAttachObservation } from '../utils/procedureTailor';
+import { getBankProcedure } from '../utils/procedureBank';
+
+/**
+ * The post-create platform-check picker (plan PR-7). Presentation-only
+ * contract tests: every affordance dispatches ONE operation object to the
+ * page handler; the negative surfaces (no adopt on unresolved, no writes
+ * on open/close) are asserted explicitly — an affordance that renders for
+ * a state the producer refuses would be UI theater.
+ */
+
+const ITEM_ID = 'PR.AA-05 Ex1';
+const offers = () => getPlatformProcedures('PR.AA-05', ['google-workspace', 'microsoft-365']);
+
+const observationWith = (attachedOffers) =>
+  composeAttachObservation(getBankProcedure(ITEM_ID), attachedOffers);
+
+const setup = (observation, { canAttach = true } = {}) => {
+  const onOperation = jest.fn();
+  const onClose = jest.fn();
+  render(
+    <PlatformCheckPicker
+      itemId={ITEM_ID}
+      observation={observation}
+      canAttach={canAttach}
+      onOperation={onOperation}
+      onClose={onClose}
+    />
+  );
+  return { onOperation, onClose };
+};
+
+describe('PlatformCheckPicker', () => {
+  test('opening and closing dispatches NO operation — the picker never writes on its own', () => {
+    const { onOperation, onClose } = setup(observationWith(offers().slice(0, 2)));
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(onOperation).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('Escape closes the dialog without dispatching; the dialog role is labeled', () => {
+    const { onOperation, onClose } = setup(observationWith(offers().slice(0, 1)));
+    expect(screen.getByRole('dialog', { name: `Platform checks for PR.AA-05` })).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+    expect(onOperation).not.toHaveBeenCalled();
+  });
+
+  test('attached rows render in entry order with Remove; a plain ref removes with ONE dispatch, no confirm', () => {
+    const obs = observationWith(offers().slice(0, 2));
+    const { onOperation } = setup(obs);
+    const rows = screen.getAllByTestId('attached-check-row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent(obs.platformProcedures[0].policyId);
+    fireEvent.click(within(rows[0]).getByTitle('Remove this platform check'));
+    expect(onOperation).toHaveBeenCalledWith({ op: 'remove', ref: obs.platformProcedures[0] });
+  });
+
+  test('offered list: platform-grouped with counts, committed-map order, attached policies excluded', () => {
+    const all = offers();
+    const gws = all.filter((o) => o.record.platform === 'google-workspace');
+    const attached = [gws[0]];
+    setup(observationWith(attached));
+    const gwsGroup = screen.getByTestId('offer-group-google-workspace');
+    expect(gwsGroup).toHaveTextContent(`Google Workspace (${gws.length - 1} available)`);
+    const offered = within(gwsGroup).getAllByTestId('offer-row');
+    expect(offered).toHaveLength(gws.length - 1); // attached policy excluded
+    offered.forEach((row, i) => {
+      // committed-map order, minus the attached first policy
+      expect(within(row).getByText(gws.slice(1)[i].policyId)).toBeInTheDocument();
+    });
+    expect(within(gwsGroup).queryByText(gws[0].policyId)).toBeNull();
+  });
+
+  test('Attach dispatches {op:add} with the exact offer; Attach all dispatches {op:addAll} with the group', () => {
+    const all = offers();
+    const gws = all.filter((o) => o.record.platform === 'google-workspace');
+    const { onOperation } = setup(observationWith([]));
+    const gwsGroup = screen.getByTestId('offer-group-google-workspace');
+    const firstOfferRow = within(gwsGroup).getAllByTestId('offer-row')[0];
+    fireEvent.click(within(firstOfferRow).getByTitle('Attach this platform check'));
+    expect(onOperation).toHaveBeenLastCalledWith({ op: 'add', offer: expect.objectContaining({ policyId: gws[0].policyId }) });
+    fireEvent.click(screen.getByText(`Attach all ${gws.length}`));
+    expect(onOperation).toHaveBeenLastCalledWith({
+      op: 'addAll',
+      offers: expect.arrayContaining([expect.objectContaining({ policyId: gws[0].policyId })])
+    });
+  });
+
+  test('canAttach=false: no offer rows, the attach-community-first explanation renders instead', () => {
+    setup({ testProcedures: 'Hand-written.', platformProcedures: [] }, { canAttach: false });
+    expect(screen.queryAllByTestId('offer-row')).toHaveLength(0);
+    expect(screen.getByText(/use "insert community procedure" first/i)).toBeInTheDocument();
+  });
+
+  test('adopt: ONLY a drifted row offers "Adopt update"; the confirm names adoption and shows old vs new fingerprints + source link', () => {
+    const base = observationWith(offers().slice(0, 2));
+    const drifted = { ...base.platformProcedures[0], contentHash: '0000000000000000' };
+    const obs = { ...base, platformProcedures: [drifted, base.platformProcedures[1]] };
+    const { onOperation } = setup(obs);
+    const rows = screen.getAllByTestId('attached-check-row');
+    expect(rows[0]).toHaveTextContent('Updated upstream');
+    expect(rows[1]).not.toHaveTextContent('Adopt update');
+    fireEvent.click(screen.getByText('Adopt update'));
+    const confirm = screen.getByTestId('adopt-confirm');
+    expect(confirm).toHaveTextContent(`Adopt the upstream update for ${drifted.policyId}?`);
+    expect(confirm).toHaveTextContent('attached version: 0000000000000000');
+    const currentHash = platformRecordContentHash(
+      offers().find((o) => o.policyId === drifted.policyId).record);
+    expect(confirm).toHaveTextContent(`current version: ${currentHash}`);
+    expect(within(confirm).getByRole('link')).toHaveAttribute(
+      'href',
+      offers().find((o) => o.policyId === drifted.policyId).record.attribution.sourceUrl);
+    expect(onOperation).not.toHaveBeenCalled(); // nothing adopted before the confirm
+    fireEvent.click(screen.getByText('Adopt upstream update'));
+    expect(onOperation).toHaveBeenCalledWith({ op: 'adopt', ref: drifted });
+  });
+
+  test('adopt confirm Cancel dispatches nothing', () => {
+    const base = observationWith(offers().slice(0, 1));
+    const drifted = { ...base.platformProcedures[0], contentHash: '0000000000000000' };
+    const { onOperation } = setup({ ...base, platformProcedures: [drifted] });
+    fireEvent.click(screen.getByText('Adopt update'));
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onOperation).not.toHaveBeenCalled();
+  });
+
+  test('NEGATIVE: an unresolved row offers Remove only — no adopt affordance, no source link', () => {
+    const FOREIGN = {
+      corpusId: 'foreign-corpus',
+      corpusVersion: 'ffffffffffffffff',
+      policyId: 'gone.policy.1.1v1',
+      contentHash: '0123456789abcdef'
+    };
+    const base = observationWith([]);
+    const { onOperation } = setup({ ...base, platformProcedures: [FOREIGN] });
+    const row = screen.getByTestId('attached-check-row');
+    expect(row).toHaveTextContent('Unresolved');
+    expect(row).not.toHaveTextContent('Adopt update');
+    expect(within(row).queryByRole('link')).toBeNull();
+    fireEvent.click(within(row).getByTitle('Remove this platform check'));
+    expect(onOperation).toHaveBeenCalledWith({ op: 'remove', ref: FOREIGN });
+  });
+
+  test('a customized (forked) row removes through the in-dialog confirm showing the text to be discarded', () => {
+    const base = observationWith(offers().slice(0, 1));
+    const fork = forkPlatformProcedure(base.platformProcedures[0], 'My hardened variant of this check.');
+    const { onOperation } = setup({ ...base, platformProcedures: [fork] });
+    const row = screen.getByTestId('attached-check-row');
+    expect(row).toHaveTextContent('customized');
+    fireEvent.click(within(row).getByTitle('Remove this platform check'));
+    expect(onOperation).not.toHaveBeenCalled(); // confirm first
+    const confirm = screen.getByTestId('remove-fork-confirm');
+    expect(confirm).toHaveTextContent('discard your edits');
+    expect(confirm).toHaveTextContent('My hardened variant of this check.');
+    fireEvent.click(screen.getByText('Remove and discard edits'));
+    expect(onOperation).toHaveBeenCalledWith({ op: 'remove', ref: fork });
+  });
+
+  test('everything attached: the offered section states it plainly, zero offer rows', () => {
+    setup(observationWith(offers()));
+    expect(screen.queryAllByTestId('offer-row')).toHaveLength(0);
+    expect(screen.getByText(/every available platform check for this subcategory is attached/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -28,8 +28,8 @@ import useAIStore from '../stores/aiStore';
 import useUIStore from '../stores/uiStore';
 import { formatInlineMarkdown, stripMarkdown } from '../utils/markdownText';
 import { bankCoverage, getBankProcedure, canResetToCommunity, resetToCommunityUpdate, sourceUrlFor } from '../utils/procedureBank';
-import { expandProcedureText } from '../utils/platformBank';
-import { canUseProfileWithProvider, buildTailorPrompt, tailoredProvenance, deriveStackTargets, describeStackPlan, bankAttachObservation, wizardAttachObservation, deterministicTailorUpdate } from '../utils/procedureTailor';
+import { expandProcedureText, derivePlatformsFromObservations } from '../utils/platformBank';
+import { canUseProfileWithProvider, buildTailorPrompt, tailoredProvenance, deriveStackTargets, describeStackPlan, bankAttachObservation, wizardAttachObservation, deterministicTailorUpdate, pickerObservationUpdate, pickerAvailability } from '../utils/procedureTailor';
 import { buildEnvironmentMatrix, buildAttachPlan, cellKey, toggleCell, setColumn, columnFullySelected, columnTotal, countAttached, attachedCountForItem, availablePlatforms } from '../utils/environmentStep';
 import { platformIdsFromInfrastructure } from '../utils/infraPresets';
 import { getScoringScale, scoreBand, CMMI_LEVELS } from '../utils/scoringScale';
@@ -37,6 +37,8 @@ import { SYSTEM_NAME_MAX_LENGTH } from '../utils/externalLinks';
 import { belongsToAssessment, isUnassigned } from '../utils/assessmentScope';
 import ExternalLinksEditor from '../components/ExternalLinksEditor';
 import ProcedureSourceBadge from '../components/ProcedureSourceBadge';
+import PlatformAddendumBadges from '../components/PlatformAddendumBadges';
+import PlatformCheckPicker from '../components/PlatformCheckPicker';
 import useOrgProfileStore from '../stores/orgProfileStore';
 import OrgProfileWizard from '../components/OrgProfileWizard';
 
@@ -74,6 +76,8 @@ const Assessments = () => {
   const deleteAssessment = useAssessmentsStore((state) => state.deleteAssessment);
   const getObservation = useAssessmentsStore((state) => state.getObservation);
   const updateObservation = useAssessmentsStore((state) => state.updateObservation);
+  const getAssessment = useAssessmentsStore((state) => state.getAssessment);
+  const updateAssessment = useAssessmentsStore((state) => state.updateAssessment);
   const updateQuarterlyObservation = useAssessmentsStore((state) => state.updateQuarterlyObservation);
   const addToScope = useAssessmentsStore((state) => state.addToScope);
   const removeFromScope = useAssessmentsStore((state) => state.removeFromScope);
@@ -115,6 +119,12 @@ const Assessments = () => {
   // Export (optional password protection)
   const [showExportPasswordDialog, setShowExportPasswordDialog] = useState(false);
   const [showSingleExportPasswordDialog, setShowSingleExportPasswordDialog] = useState(false);
+
+  // Post-create platform-check picker (plan PR-7)
+  const [showPlatformPicker, setShowPlatformPicker] = useState(false);
+  const allPlatformIds = useMemo(() => availablePlatforms().map((p) => p.id), []);
+  // The dialog is per-subcategory state — close it when the item changes.
+  useEffect(() => { setShowPlatformPicker(false); }, [selectedItemId]);
 
   // New assessment wizard state
   const [showNewModal, setShowNewModal] = useState(false);
@@ -816,6 +826,32 @@ Format as a numbered list. Be specific and actionable.`;
     updateObservation(currentAssessmentId, selectedItemId, { [field]: value });
   }, [currentAssessmentId, selectedItemId, updateObservation]);
 
+  // Recompute the assessment's derived platform set from the live
+  // observations — the SINGLE derivation call site, run after every
+  // composition-changing write (ratified: platforms is recomputed, never
+  // incrementally mutated).
+  const syncDerivedPlatforms = useCallback(() => {
+    if (!currentAssessmentId) return;
+    const assessment = getAssessment(currentAssessmentId);
+    if (!assessment) return;
+    updateAssessment(currentAssessmentId, {
+      platforms: derivePlatformsFromObservations(assessment.observations)
+    });
+  }, [currentAssessmentId, getAssessment, updateAssessment]);
+
+  // Dispatch one picker operation (add / addAll / remove / adopt) through
+  // the pure producer. The observation is re-read from the store at
+  // dispatch time so rapid consecutive operations never build on a stale
+  // snapshot. A null update means nothing would change — no write.
+  const handlePlatformCheckOperation = useCallback((operation) => {
+    if (!currentAssessmentId || !selectedItemId) return;
+    const fresh = getObservation(currentAssessmentId, selectedItemId);
+    const update = pickerObservationUpdate(fresh, selectedItemId, operation);
+    if (!update) return;
+    updateObservation(currentAssessmentId, selectedItemId, update);
+    syncDerivedPlatforms();
+  }, [currentAssessmentId, selectedItemId, getObservation, updateObservation, syncDerivedPlatforms]);
+
   // Attach (or re-attach) the community procedure for the selected item.
   // The pure producer stamps pristine provenance (so the store's
   // modified-flag heuristic doesn't mark a deliberate attach as a
@@ -836,8 +872,9 @@ Format as a numbered list. Be specific and actionable.`;
       return;
     }
     updateObservation(currentAssessmentId, selectedItemId, update);
+    syncDerivedPlatforms();
     toast.success(`Community procedure for ${update.procedureSource.bankId} attached`);
-  }, [currentAssessmentId, selectedItemId, getObservation, updateObservation]);
+  }, [currentAssessmentId, selectedItemId, getObservation, updateObservation, syncDerivedPlatforms]);
 
   // Deterministic tailoring of the selected item's procedure: canned
   // name + tool/platform substitutions from the org profile. No AI, no
@@ -1665,6 +1702,16 @@ Format as a numbered list. Be specific and actionable.`;
                               : (<><BookOpen size={12} /> Insert community procedure</>)}
                           </button>
                         )}
+                        {editMode && pickerAvailability(currentObservation, selectedItemId, allPlatformIds).canOpen && (
+                          <button
+                            type="button"
+                            onClick={() => setShowPlatformPicker(true)}
+                            className="text-xs text-blue-700 dark:text-blue-400 flex items-center gap-1 hover:underline"
+                            title="Add or remove platform checks for this subcategory"
+                          >
+                            <Server size={12} /> Platform checks
+                          </button>
+                        )}
                         {!editMode && sourceUrlFor(currentObservation.procedureSource) && (
                           <a
                             href={sourceUrlFor(currentObservation.procedureSource)}
@@ -1678,6 +1725,9 @@ Format as a numbered list. Be specific and actionable.`;
                         )}
                       </div>
                     </div>
+                    {!editMode && currentObservation.platformProcedures?.length > 0 && (
+                      <PlatformAddendumBadges entries={currentObservation.platformProcedures} />
+                    )}
                     {editMode ? (
                       <textarea
                         value={currentObservation.testProcedures || ''}
@@ -1697,6 +1747,15 @@ Format as a numbered list. Be specific and actionable.`;
                             : formatTestProcedures(currentObservation.testProcedures)) || 'No test procedures defined'}
                         </Markdown>
                       </div>
+                    )}
+                    {showPlatformPicker && (
+                      <PlatformCheckPicker
+                        itemId={selectedItemId}
+                        observation={currentObservation}
+                        canAttach={pickerAvailability(currentObservation, selectedItemId, allPlatformIds).canAttach}
+                        onOperation={handlePlatformCheckOperation}
+                        onClose={() => setShowPlatformPicker(false)}
+                      />
                     )}
                   </div>
 

--- a/src/utils/platformBank.js
+++ b/src/utils/platformBank.js
@@ -167,10 +167,11 @@ export const forkPlatformProcedure = (ref, text) => {
  * Content drift between a reference's attach-time fingerprint and the
  * CURRENT corpus record: true (drifted), false (byte-stable), or null when
  * the ref does not resolve (drift is unknowable — the placeholder already
- * carries the identity). PR-5 stores and detects drift but deliberately does
- * NOT surface it in expansion output — the drift badge/notice is PR-7 UI
- * (pinned by the drift-silent expansion test so the deferral is a stated
- * decision, not an assumption).
+ * carries the identity). Drift surfaces as detail-panel badge CHROME only
+ * (PR-7): expansion output stays drift-silent PERMANENTLY — rendered and
+ * exported text always carries the current corpus version, and the badge's
+ * remedy is the explicit adopt action in the picker, which is the ONLY
+ * path that may rewrite a reference's contentHash (ratified 2026-07-21).
  */
 export const platformRefDrift = (entry) => {
   const record = getPlatformRecord(entry?.corpusId, entry?.policyId);
@@ -180,6 +181,95 @@ export const platformRefDrift = (entry) => {
 
 /** A fork carries its own text; everything else is still a reference. */
 export const isPlatformFork = (entry) => typeof entry?.text === 'string';
+
+/**
+ * Upstream source link for one addendum entry, from the CURRENT corpus
+ * record's attribution — never from the entry itself (an entry from a
+ * foreign file could carry an attacker-chosen URL). Null when the ref does
+ * not resolve: an unresolved row gets no link rather than a dead href.
+ */
+export const platformRefSourceUrl = (entry) =>
+  getPlatformRecord(entry?.corpusId, entry?.policyId)?.attribution?.sourceUrl || null;
+
+/**
+ * Canonical addendum order for one subcategory: the committed map's key
+ * order restricted to policies that pair with the subcategory — the same
+ * order getPlatformProcedures offers in, platform-grouped by map
+ * construction. Entries the map cannot place (foreign corpus, withdrawn
+ * policy, or a policy no longer paired here) keep their relative order
+ * after the placeable ones. Pure re-ordering: entry objects pass through
+ * untouched — sorting never reads the corpus records, so it cannot alter
+ * content or fingerprints (the adopt action is the only hash writer).
+ */
+export const sortPlatformAddenda = (entries, subcategoryId) => {
+  const list = Array.isArray(entries) ? entries : [];
+  const index = new Map();
+  let position = 0;
+  Object.entries(subcategoryMap.policies).forEach(([policyId, entry]) => {
+    if (entry.pairs.some((p) => p.subcategoryId === subcategoryId)) {
+      index.set(policyId, position);
+      position += 1;
+    }
+  });
+  return list
+    .map((entry, i) => ({
+      entry,
+      i,
+      key: entry?.corpusId === PLATFORM_CORPUS_ID && index.has(entry?.policyId)
+        ? index.get(entry.policyId)
+        : Infinity
+    }))
+    .sort((a, b) => a.key - b.key || a.i - b.i)
+    .map((x) => x.entry);
+};
+
+/**
+ * The DERIVED per-assessment platform set (ratified: recomputed, never
+ * mutated): sorted unique platform of every addendum entry that resolves in
+ * the current corpus, across all observations. Derived in both directions —
+ * removing a platform's last entry removes its id. Unresolvable entries
+ * contribute nothing (their platform is unknowable from identity fields);
+ * they stay visible through the unresolved badge and placeholder instead.
+ */
+export const derivePlatformsFromObservations = (observations) => {
+  const platforms = new Set();
+  Object.values(observations || {}).forEach((obs) => {
+    const entries = Array.isArray(obs?.platformProcedures) ? obs.platformProcedures : [];
+    entries.forEach((entry) => {
+      const record = getPlatformRecord(entry?.corpusId, entry?.policyId);
+      if (record) platforms.add(record.platform);
+    });
+  });
+  return Array.from(platforms).sort();
+};
+
+/**
+ * Row descriptor for one addendum entry — the ONE derivation the badge row,
+ * the summary counts, and the picker's attached list all read, so the
+ * counts can never disagree with the rows. Branches on the ENTRY (per-
+ * observation state), never on the assessment-level platforms array —
+ * platforms.length === 0 is ambiguous by contract (pre-v16 restore vs
+ * attached-nothing) and must never gate badge logic.
+ *
+ * Badge states are limited to the production-drivable set (ratified):
+ * drifted (attach-time fingerprint differs from the current corpus) and
+ * unresolved (no current corpus record). A fork row shows neither — its
+ * text is user-owned, and the drift badge's remedy (adopt) refuses forks,
+ * so badging drift on a fork would surface a state with no remedy.
+ */
+export const addendumRowDescriptor = (entry) => {
+  const record = getPlatformRecord(entry?.corpusId, entry?.policyId);
+  const fork = isPlatformFork(entry);
+  return {
+    corpusId: entry?.corpusId,
+    policyId: entry?.policyId,
+    platformText: record ? platformLabel(record.platform) : null,
+    fork,
+    unresolved: !record && !fork,
+    drifted: !fork && platformRefDrift(entry) === true,
+    sourceUrl: platformRefSourceUrl(entry)
+  };
+};
 
 /**
  * Explicit placeholder for a reference this installation cannot resolve

--- a/src/utils/platformBank.test.js
+++ b/src/utils/platformBank.test.js
@@ -414,7 +414,11 @@ describe('advisor adoptions: drift, hash pin, corpus-id stability, degenerate re
     expect(platformRefDrift(null)).toBeNull();
   });
 
-  test('expansion is drift-SILENT in PR-5 (deliberate deferral — the drift badge is PR-7 UI)', () => {
+  test('expansion is drift-SILENT permanently (ratified PR-7): drift surfaces as badge CHROME, never in egress text', () => {
+    // PR-5 pinned this as a deferral; PR-7 flipped the pin into the decision:
+    // rendered and exported text always carries the current corpus version,
+    // the detail-panel badge is the consent surface, and the picker's adopt
+    // action is the only path that may rewrite the stored fingerprint.
     const drifted = { ...realRef(), contentHash: '0000000000000000' };
     const out = expandProcedureText({ testProcedures: 't', platformProcedures: [drifted] });
     // resolves and renders the CURRENT corpus text, with no drift marker

--- a/src/utils/procedurePicker.test.js
+++ b/src/utils/procedurePicker.test.js
@@ -1,0 +1,514 @@
+/**
+ * Post-create platform-check picker producer (plan PR-7) — the writer that
+ * closes PR-6's one-way door. Every assertion executes the PRODUCTION
+ * producer (pickerObservationUpdate) and, where composition round-trips
+ * matter, chains the PRODUCTION Reset producer (resetToCommunityUpdate) —
+ * never a re-implementation (standing doctrine, G19).
+ *
+ * Ratification anti-tests live here:
+ *  - adopt is the ONLY operation that rewrites a stored contentHash; no
+ *    rebuild touches an entry it did not target (per-ref guard on a
+ *    fixture with two drifted neighbors);
+ *  - removal DELETES from the live array and the recipe together — no
+ *    tombstones, and Reset does not resurrect;
+ *  - platforms is DERIVED both directions — removing a platform's last
+ *    entry removes its id, and the stored array always equals the
+ *    derivation over any operation sequence.
+ */
+import bank from '../data/platformProcedures.json';
+import {
+  composeAttachObservation,
+  pickerObservationUpdate,
+  pickerAvailability
+} from './procedureTailor';
+import { getBankProcedure, resetToCommunityUpdate } from './procedureBank';
+import {
+  getPlatformProcedures,
+  platformRecordContentHash,
+  buildPlatformRef,
+  forkPlatformProcedure,
+  expandProcedureText,
+  sortPlatformAddenda,
+  derivePlatformsFromObservations,
+  platformRefSourceUrl,
+  platformRefDrift,
+  addendumRowDescriptor
+} from './platformBank';
+
+const ITEM_ID = 'PR.AA-05 Ex1'; // production-shaped id — Ex suffix (G24 lesson)
+const SUB_ID = 'PR.AA-05';
+const BOTH = ['google-workspace', 'microsoft-365'];
+const trunkEntry = getBankProcedure(ITEM_ID);
+const allOffers = () => getPlatformProcedures(SUB_ID, BOTH);
+
+/** A live observation as the wizard creates it, with the given offers. */
+const observationWith = (offers) => composeAttachObservation(trunkEntry, offers);
+
+/** Neutralize the attach wall-clock for producer-identity comparison. */
+const stampNeutral = (source) => ({ ...source, attachedAt: 'T' });
+
+const FOREIGN_REF = {
+  corpusId: 'foreign-corpus',
+  corpusVersion: 'ffffffffffffffff',
+  policyId: 'gone.policy.1.1v1',
+  contentHash: '0123456789abcdef'
+};
+
+describe('helpers: source url, canonical sort, row descriptor', () => {
+  const offer = allOffers()[0];
+
+  test('platformRefSourceUrl: current corpus attribution for a resolvable ref, null when unresolved', () => {
+    const ref = buildPlatformRef(offer.record, offer.corpusId);
+    expect(platformRefSourceUrl(ref)).toBe(offer.record.attribution.sourceUrl);
+    expect(platformRefSourceUrl(FOREIGN_REF)).toBeNull();
+    expect(platformRefSourceUrl(undefined)).toBeNull();
+  });
+
+  test('sortPlatformAddenda: committed-map order for placeable entries; unplaceable keep relative order after', () => {
+    const offers = allOffers();
+    const refs = offers.map((o) => buildPlatformRef(o.record, o.corpusId));
+    const shuffled = [refs[2], FOREIGN_REF, refs[0], { ...FOREIGN_REF, policyId: 'gone.2' }, refs[1]];
+    const sorted = sortPlatformAddenda(shuffled, SUB_ID);
+    expect(sorted.slice(0, 3).map((r) => r.policyId)).toEqual(refs.slice(0, 3).map((r) => r.policyId));
+    expect(sorted[3].policyId).toBe(FOREIGN_REF.policyId);
+    expect(sorted[4].policyId).toBe('gone.2');
+    // pure re-ordering: the same entry OBJECTS pass through untouched
+    sorted.forEach((entry) => expect(shuffled).toContain(entry));
+  });
+
+  test('addendumRowDescriptor: one derivation feeds rows and counts — drifted, unresolved, fork discriminated', () => {
+    const fresh = buildPlatformRef(offer.record, offer.corpusId);
+    expect(addendumRowDescriptor(fresh)).toMatchObject({
+      policyId: fresh.policyId,
+      drifted: false,
+      unresolved: false,
+      fork: false,
+      sourceUrl: offer.record.attribution.sourceUrl
+    });
+    const drifted = { ...fresh, contentHash: '0000000000000000' };
+    expect(addendumRowDescriptor(drifted)).toMatchObject({ drifted: true, unresolved: false });
+    expect(addendumRowDescriptor(FOREIGN_REF)).toMatchObject({
+      drifted: false,
+      unresolved: true,
+      sourceUrl: null,
+      platformText: null
+    });
+    const fork = forkPlatformProcedure({ ...fresh, contentHash: '0000000000000000' }, 'User text.');
+    // a fork badges neither drift nor unresolved — its remedy (adopt) is refused on forks
+    expect(addendumRowDescriptor(fork)).toMatchObject({ fork: true, drifted: false, unresolved: false });
+  });
+});
+
+describe('pickerObservationUpdate — add / addAll', () => {
+  test('add produces EXACTLY what composeAttachObservation produces for the same set (no second composition rule)', () => {
+    const offers = allOffers().slice(0, 4);
+    const target = observationWith(offers);
+    // start from a compose of the first two, picker-add the last two in
+    // REVERSED order — the write re-sorts to canonical map order
+    let obs = observationWith(offers.slice(0, 2));
+    [offers[3], offers[2]].forEach((offer) => {
+      const update = pickerObservationUpdate(obs, ITEM_ID, { op: 'add', offer });
+      expect(update).not.toBeNull();
+      obs = { ...obs, ...update };
+    });
+    expect(obs.platformProcedures).toEqual(target.platformProcedures);
+    expect(stampNeutral(obs.procedureSource)).toEqual(stampNeutral(target.procedureSource));
+  });
+
+  test('addAll attaches every not-yet-attached offer in ONE write, canonical order', () => {
+    const offers = allOffers();
+    let obs = observationWith(offers.slice(1, 2)); // one mid-list ref attached
+    const update = pickerObservationUpdate(obs, ITEM_ID, { op: 'addAll', offers });
+    obs = { ...obs, ...update };
+    expect(obs.platformProcedures).toEqual(observationWith(offers).platformProcedures);
+  });
+
+  test('the producer NEVER touches trunk text — no update carries a testProcedures key', () => {
+    const offers = allOffers().slice(0, 2);
+    const obs = observationWith(offers);
+    const ops = [
+      { op: 'add', offer: allOffers()[2] },
+      { op: 'remove', ref: obs.platformProcedures[0] },
+      { op: 'addAll', offers: allOffers() }
+    ];
+    ops.forEach((operation) => {
+      const update = pickerObservationUpdate(obs, ITEM_ID, operation);
+      expect(update).not.toBeNull();
+      expect('testProcedures' in update).toBe(false);
+    });
+  });
+
+  test('no-ops return null: add of an attached policy, addAll when everything is attached', () => {
+    const offers = allOffers();
+    const obs = observationWith(offers);
+    expect(pickerObservationUpdate(obs, ITEM_ID, { op: 'add', offer: offers[0] })).toBeNull();
+    expect(pickerObservationUpdate(obs, ITEM_ID, { op: 'addAll', offers })).toBeNull();
+  });
+
+  test('attach requires a bank-attached trunk — a hand-written observation refuses add', () => {
+    const obs = { testProcedures: 'My own words.', quarters: {} };
+    expect(pickerObservationUpdate(obs, ITEM_ID, { op: 'add', offer: allOffers()[0] })).toBeNull();
+  });
+});
+
+describe('pickerObservationUpdate — remove (ratified: delete, no tombstones)', () => {
+  test('remove deletes from the live array AND the recipe together; expansion loses the block', () => {
+    const offers = allOffers().slice(0, 3);
+    const obs = observationWith(offers);
+    const victim = obs.platformProcedures[1];
+    const update = pickerObservationUpdate(obs, ITEM_ID, { op: 'remove', ref: victim });
+    const next = { ...obs, ...update };
+    expect(next.platformProcedures.map((r) => r.policyId)).not.toContain(victim.policyId);
+    const recipePolicies = next.procedureSource.components
+      .filter((c) => c.kind === 'platform-ref')
+      .map((c) => c.policyId);
+    expect(recipePolicies).not.toContain(victim.policyId);
+    expect(recipePolicies).toHaveLength(2);
+    expect(expandProcedureText(next)).not.toContain(victim.policyId);
+  });
+
+  test('removing the LAST entry leaves an empty array, a trunk-only recipe, and trunk-identical expansion', () => {
+    const offers = allOffers().slice(0, 1);
+    const obs = observationWith(offers);
+    const update = pickerObservationUpdate(obs, ITEM_ID, { op: 'remove', ref: obs.platformProcedures[0] });
+    const next = { ...obs, ...update };
+    expect(next.platformProcedures).toEqual([]);
+    expect(next.procedureSource.components).toEqual([
+      expect.objectContaining({ kind: 'trunk', bankId: SUB_ID })
+    ]);
+    expect(expandProcedureText(next)).toBe(next.testProcedures);
+  });
+
+  test('remove of a non-attached ref is a null no-op', () => {
+    const obs = observationWith(allOffers().slice(0, 2));
+    expect(pickerObservationUpdate(obs, ITEM_ID, { op: 'remove', ref: FOREIGN_REF })).toBeNull();
+  });
+
+  test('remove works on a hand-written-trunk observation (no procedureSource): no throw, no fabricated trunk component', () => {
+    // The imported-observation shape pickerAvailability opens for: refs
+    // present, trunk not bank-attached. Removal must not synthesize trunk
+    // provenance that never existed.
+    const obs = { testProcedures: 'Mine.', platformProcedures: [FOREIGN_REF] };
+    const update = pickerObservationUpdate(obs, ITEM_ID, { op: 'remove', ref: FOREIGN_REF });
+    expect(update.platformProcedures).toEqual([]);
+    expect(update.procedureSource.components).toEqual([]);
+    expect(update.procedureSource.bank).toBeUndefined();
+  });
+
+  test('Reset does NOT resurrect a removed addendum — production Reset replays the re-recorded recipe', () => {
+    const offers = allOffers().slice(0, 3);
+    const obs = observationWith(offers);
+    const victim = obs.platformProcedures[1];
+    const survivors = obs.platformProcedures.filter((r) => r !== victim).map((r) => r.policyId);
+    const next = { ...obs, ...pickerObservationUpdate(obs, ITEM_ID, { op: 'remove', ref: victim }) };
+    const reset = resetToCommunityUpdate(ITEM_ID, next.procedureSource);
+    expect(reset.platformProcedures.map((r) => r.policyId)).toEqual(survivors);
+    expect(reset.platformProcedures.map((r) => r.policyId)).not.toContain(victim.policyId);
+  });
+});
+
+describe('pickerObservationUpdate — adopt (ratified: the ONLY contentHash writer)', () => {
+  const driftedObservation = () => {
+    const offers = allOffers().slice(0, 3);
+    const obs = observationWith(offers);
+    // middle entry drifts: attach-time fingerprint no longer matches
+    const entries = obs.platformProcedures.map((r, i) =>
+      i === 1 ? { ...r, contentHash: '0000000000000000' } : r);
+    return {
+      ...obs,
+      platformProcedures: entries,
+      procedureSource: {
+        ...obs.procedureSource,
+        components: [
+          obs.procedureSource.components[0],
+          ...entries.map((r) => ({ kind: 'platform-ref', ...r }))
+        ]
+      }
+    };
+  };
+
+  test('adopt replaces the one entry with a fresh fingerprint of the CURRENT record; drift clears; position holds', () => {
+    const obs = driftedObservation();
+    const target = obs.platformProcedures[1];
+    expect(platformRefDrift(target)).toBe(true);
+    const update = pickerObservationUpdate(obs, ITEM_ID, { op: 'adopt', ref: target });
+    const next = { ...obs, ...update };
+    const adopted = next.platformProcedures[1];
+    expect(adopted.policyId).toBe(target.policyId);
+    expect(adopted.contentHash).toBe(
+      platformRecordContentHash(bank.procedures[target.policyId]));
+    expect(adopted.corpusVersion).toBe(bank.bankVersion);
+    expect(platformRefDrift(adopted)).toBe(false);
+    // recipe carries the adopted fingerprint too
+    expect(next.procedureSource.components[2]).toMatchObject({
+      kind: 'platform-ref',
+      policyId: target.policyId,
+      contentHash: adopted.contentHash
+    });
+  });
+
+  test('adopt no-ops: non-drifted ref, unresolvable ref, fork — all null', () => {
+    const obs = driftedObservation();
+    expect(pickerObservationUpdate(obs, ITEM_ID, { op: 'adopt', ref: obs.platformProcedures[0] })).toBeNull();
+    const withForeign = { ...obs, platformProcedures: [...obs.platformProcedures, FOREIGN_REF] };
+    expect(pickerObservationUpdate(withForeign, ITEM_ID, { op: 'adopt', ref: FOREIGN_REF })).toBeNull();
+    const fork = forkPlatformProcedure(
+      { ...obs.platformProcedures[0], contentHash: '0000000000000000' }, 'User text.');
+    const withFork = { ...obs, platformProcedures: [fork, ...obs.platformProcedures.slice(1)] };
+    expect(pickerObservationUpdate(withFork, ITEM_ID, { op: 'adopt', ref: fork })).toBeNull();
+  });
+
+  test('adopt-then-Reset: the adopted (current-hash) ref survives Reset as the pristine ref', () => {
+    const obs = driftedObservation();
+    const target = obs.platformProcedures[1];
+    const next = { ...obs, ...pickerObservationUpdate(obs, ITEM_ID, { op: 'adopt', ref: target }) };
+    const reset = resetToCommunityUpdate(ITEM_ID, next.procedureSource);
+    const resetRef = reset.platformProcedures.find((r) => r.policyId === target.policyId);
+    expect(resetRef.contentHash).toBe(platformRecordContentHash(bank.procedures[target.policyId]));
+  });
+
+  test('GUARD: add and remove of one ref change NO other ref\'s contentHash — two drifted neighbors stay byte-stable', () => {
+    const offers = allOffers().slice(0, 4);
+    const obs = observationWith(offers);
+    // two entries drift; they must ride every unrelated write untouched
+    const entries = obs.platformProcedures.map((r, i) =>
+      i === 0 || i === 2 ? { ...r, contentHash: `000000000000000${i}` } : r);
+    const base = { ...obs, platformProcedures: entries };
+    const spare = allOffers()[5];
+
+    const afterAdd = { ...base, ...pickerObservationUpdate(base, ITEM_ID, { op: 'add', offer: spare }) };
+    entries.forEach((before) => {
+      const after = afterAdd.platformProcedures.find((r) => r.policyId === before.policyId);
+      expect(after.contentHash).toBe(before.contentHash);
+    });
+
+    const afterRemove = { ...base, ...pickerObservationUpdate(base, ITEM_ID, { op: 'remove', ref: entries[1] }) };
+    entries.filter((_, i) => i !== 1).forEach((before) => {
+      const after = afterRemove.platformProcedures.find((r) => r.policyId === before.policyId);
+      expect(after.contentHash).toBe(before.contentHash);
+    });
+  });
+
+  test('no read path mutates a ref: expansion and badge derivation leave a frozen drifted entry untouched', () => {
+    const ref = Object.freeze({
+      ...buildPlatformRef(allOffers()[0].record),
+      contentHash: '0000000000000000'
+    });
+    const obs = { testProcedures: 'Trunk.', platformProcedures: Object.freeze([ref]) };
+    expect(() => expandProcedureText(obs)).not.toThrow();
+    expect(() => addendumRowDescriptor(ref)).not.toThrow();
+    expect(ref.contentHash).toBe('0000000000000000');
+    // INDEPENDENT second killer, not resting on freeze semantics: an
+    // unfrozen drifted entry rides the same render path — a heal that
+    // rewrites the stored fingerprint succeeds here (nothing throws) and
+    // is caught by the byte assertion + the production drift predicate.
+    const soft = { ...buildPlatformRef(allOffers()[0].record), contentHash: '0000000000000000' };
+    expandProcedureText({ testProcedures: 'Trunk.', platformProcedures: [soft] });
+    addendumRowDescriptor(soft);
+    expect(soft.contentHash).toBe('0000000000000000');
+    expect(platformRefDrift(soft)).toBe(true);
+  });
+
+  test('add is refused when the policy is already present as a FORK — dedup keys on identity, not shape', () => {
+    const offers = allOffers().slice(0, 2);
+    const obs = observationWith(offers);
+    const fork = forkPlatformProcedure(obs.platformProcedures[0], 'User text.');
+    const withFork = { ...obs, platformProcedures: [fork, obs.platformProcedures[1]] };
+    expect(pickerObservationUpdate(withFork, ITEM_ID, { op: 'add', offer: offers[0] })).toBeNull();
+  });
+});
+
+describe('order stability + attractor boundary', () => {
+  test('remove + re-add lands back in committed-map position, never appended (regulatory order churn killed)', () => {
+    const offers = allOffers().slice(0, 5);
+    const obs = observationWith(offers);
+    const canonical = obs.platformProcedures.map((r) => r.policyId);
+    const victimOffer = offers[2];
+    const afterRemove = { ...obs, ...pickerObservationUpdate(obs, ITEM_ID, { op: 'remove', ref: obs.platformProcedures[2] }) };
+    const afterReAdd = { ...afterRemove, ...pickerObservationUpdate(afterRemove, ITEM_ID, { op: 'add', offer: victimOffer }) };
+    expect(afterReAdd.platformProcedures.map((r) => r.policyId)).toEqual(canonical);
+  });
+
+  test('attractor full set: PR.DS-10 addAll 122 → remove one → re-add → 122 in canonical order', () => {
+    const attractorItem = 'PR.DS-10 Ex1';
+    const attractorEntry = getBankProcedure(attractorItem);
+    const offers = getPlatformProcedures('PR.DS-10', BOTH);
+    expect(offers).toHaveLength(122);
+    let obs = composeAttachObservation(attractorEntry, []);
+    obs = { ...obs, ...pickerObservationUpdate(obs, attractorItem, { op: 'addAll', offers }) };
+    expect(obs.platformProcedures).toHaveLength(122);
+    const canonical = obs.platformProcedures.map((r) => r.policyId);
+    const victim = obs.platformProcedures[60];
+    const victimOffer = offers.find((o) => o.policyId === victim.policyId);
+    obs = { ...obs, ...pickerObservationUpdate(obs, attractorItem, { op: 'remove', ref: victim }) };
+    expect(obs.platformProcedures).toHaveLength(121);
+    obs = { ...obs, ...pickerObservationUpdate(obs, attractorItem, { op: 'add', offer: victimOffer }) };
+    expect(obs.platformProcedures.map((r) => r.policyId)).toEqual(canonical);
+    expect(obs.procedureSource.components).toHaveLength(123); // trunk + 122
+  });
+});
+
+describe('heal-on-write (legacy recipes) + fork preservation', () => {
+  test('a legacy no-recipe observation gets a FULL recipe re-record on first picker write', () => {
+    const offers = allOffers().slice(0, 2);
+    const composed = observationWith(offers);
+    const legacy = {
+      testProcedures: composed.testProcedures,
+      platformProcedures: composed.platformProcedures,
+      procedureSource: (({ components, ...rest }) => rest)(composed.procedureSource)
+    };
+    expect(legacy.procedureSource.components).toBeUndefined();
+    const update = pickerObservationUpdate(legacy, ITEM_ID, { op: 'add', offer: allOffers()[2] });
+    const next = { ...legacy, ...update };
+    expect(next.procedureSource.components[0]).toMatchObject({
+      kind: 'trunk',
+      bank: 'community',
+      bankId: SUB_ID
+    });
+    expect(next.procedureSource.components).toHaveLength(4); // trunk + 3
+  });
+
+  test('an existing trunk component rides every write VERBATIM (identity recorded at attach is never re-derived)', () => {
+    const obs = observationWith(allOffers().slice(0, 2));
+    const trunkBefore = obs.procedureSource.components[0];
+    const next = { ...obs, ...pickerObservationUpdate(obs, ITEM_ID, { op: 'add', offer: allOffers()[2] }) };
+    expect(next.procedureSource.components[0]).toEqual(trunkBefore);
+  });
+
+  test('a fork entry passes through unrelated writes byte-verbatim — rebuild is re-ordering, never regeneration', () => {
+    const offers = allOffers().slice(0, 3);
+    const obs = observationWith(offers);
+    const fork = forkPlatformProcedure(obs.platformProcedures[1], 'My hardened variant.');
+    expect(fork).not.toBeNull();
+    const entries = obs.platformProcedures.map((r, i) => (i === 1 ? fork : r));
+    const base = { ...obs, platformProcedures: entries };
+    const next = { ...base, ...pickerObservationUpdate(base, ITEM_ID, { op: 'add', offer: allOffers()[3] }) };
+    const forkAfter = next.platformProcedures.find((e) => e.policyId === fork.policyId);
+    expect(forkAfter).toEqual(fork);
+    expect(forkAfter.text).toBe('My hardened variant.');
+    // the recipe records the fork's REF identity (Reset restores the pristine reference)
+    expect(next.procedureSource.components.find((c) => c.policyId === fork.policyId)).toEqual({
+      kind: 'platform-ref',
+      corpusId: fork.corpusId,
+      corpusVersion: fork.corpusVersion,
+      policyId: fork.policyId,
+      contentHash: fork.contentHash
+    });
+  });
+});
+
+describe('derived platforms (ratified: recomputed, never mutated)', () => {
+  const gwsOffer = () => getPlatformProcedures('PR.DS-10', ['google-workspace'])[0];
+  const m365Offer = () => getPlatformProcedures('PR.DS-10', ['microsoft-365'])[0];
+
+  test('derivation is the sorted platform set of resolvable entries across observations, both directions', () => {
+    const a = composeAttachObservation(getBankProcedure('PR.DS-10 Ex1'), [gwsOffer(), m365Offer()]);
+    const b = composeAttachObservation(trunkEntry, [allOffers()[0]]);
+    const observations = { 'PR.DS-10 Ex1': a, [ITEM_ID]: b };
+    expect(derivePlatformsFromObservations(observations)).toEqual(
+      ['google-workspace', 'microsoft-365']);
+    // remove the only M365 entries → the id drops out (derived means derived)
+    const aGwsOnly = { ...a, ...pickerObservationUpdate(a, 'PR.DS-10 Ex1', { op: 'remove', ref: a.platformProcedures.find((r) => r.policyId.startsWith('ms.')) }) };
+    const bEmpty = { ...b, ...pickerObservationUpdate(b, ITEM_ID, { op: 'remove', ref: b.platformProcedures[0] }) };
+    expect(derivePlatformsFromObservations({ 'PR.DS-10 Ex1': aGwsOnly, [ITEM_ID]: bEmpty }))
+      .toEqual(['google-workspace']);
+    // unresolvable entries contribute nothing — their platform is unknowable
+    expect(derivePlatformsFromObservations({ x: { platformProcedures: [FOREIGN_REF] } })).toEqual([]);
+    expect(derivePlatformsFromObservations({})).toEqual([]);
+    expect(derivePlatformsFromObservations(undefined)).toEqual([]);
+  });
+
+  test('forks count toward the derivation when resolvable; an orphan fork contributes nothing', () => {
+    const base = composeAttachObservation(getBankProcedure('PR.DS-10 Ex1'), [gwsOffer()]);
+    const fork = forkPlatformProcedure(base.platformProcedures[0], 'User text.');
+    expect(derivePlatformsFromObservations({ a: { platformProcedures: [fork] } }))
+      .toEqual(['google-workspace']);
+    const orphanFork = { ...fork, corpusId: 'foreign-corpus' };
+    expect(derivePlatformsFromObservations({ a: { platformProcedures: [orphanFork] } }))
+      .toEqual([]);
+  });
+
+  test('INVARIANT: over any operation sequence, the stored array equals the derivation (single call site contract)', () => {
+    let observations = {
+      [ITEM_ID]: composeAttachObservation(trunkEntry, []),
+      'PR.DS-10 Ex1': composeAttachObservation(getBankProcedure('PR.DS-10 Ex1'), [])
+    };
+    let stored = derivePlatformsFromObservations(observations);
+    expect(stored).toEqual([]);
+    const apply = (itemId, operation) => {
+      const update = pickerObservationUpdate(observations[itemId], itemId, operation);
+      if (update) {
+        observations = { ...observations, [itemId]: { ...observations[itemId], ...update } };
+        stored = derivePlatformsFromObservations(observations); // the page's sync step
+      }
+      expect(stored).toEqual(derivePlatformsFromObservations(observations));
+    };
+    apply(ITEM_ID, { op: 'add', offer: allOffers()[0] });
+    apply('PR.DS-10 Ex1', { op: 'add', offer: m365Offer() });
+    apply('PR.DS-10 Ex1', { op: 'add', offer: gwsOffer() });
+    apply(ITEM_ID, { op: 'remove', ref: observations[ITEM_ID].platformProcedures[0] });
+    apply('PR.DS-10 Ex1', { op: 'remove', ref: observations['PR.DS-10 Ex1'].platformProcedures[0] });
+    apply('PR.DS-10 Ex1', { op: 'add', offer: m365Offer() }); // no-op guard inside apply
+    // adopt step (upstream regen simulated by staling one fingerprint):
+    // the invariant must hold through the one hash-writing operation too
+    const target = observations['PR.DS-10 Ex1'].platformProcedures[0];
+    const staled = { ...target, contentHash: '0000000000000000' };
+    observations = {
+      ...observations,
+      'PR.DS-10 Ex1': {
+        ...observations['PR.DS-10 Ex1'],
+        platformProcedures: observations['PR.DS-10 Ex1'].platformProcedures.map((r) =>
+          r === target ? staled : r)
+      }
+    };
+    apply('PR.DS-10 Ex1', { op: 'adopt', ref: staled });
+    expect(stored).toEqual(derivePlatformsFromObservations(observations));
+  });
+
+  test('PAGE PIN: every composition-changing handler in Assessments.js syncs derived platforms after its write', () => {
+    // The invariant test above proves producer + derivation COMPOSE; this
+    // pin proves the page actually runs the sync after each write — the
+    // one place the ratified derived-not-mutated contract could go stale
+    // silently (same grep-pin idiom as the egress census).
+    const fs = require('fs');
+    const path = require('path');
+    const page = fs.readFileSync(path.join(__dirname, '../pages/Assessments.js'), 'utf8');
+    const writeThenSync =
+      page.match(/updateObservation\(currentAssessmentId, selectedItemId, update\);\s*\n\s*syncDerivedPlatforms\(\);/g) || [];
+    // exactly two: handlePlatformCheckOperation and handleInsertBankProcedure
+    expect(writeThenSync).toHaveLength(2);
+    // and exactly one producer call site
+    expect(page.match(/pickerObservationUpdate\(/g)).toHaveLength(1);
+    expect(page.match(/derivePlatformsFromObservations\(/g)).toHaveLength(1);
+  });
+});
+
+describe('pickerAvailability — branches on the observation, never on assessment platforms', () => {
+  test('truth table: attached entries open; offers + bank trunk attach; hand-written trunk cannot attach', () => {
+    const withRefs = observationWith(allOffers().slice(0, 1));
+    expect(pickerAvailability(withRefs, ITEM_ID, BOTH)).toEqual({ canOpen: true, canAttach: true });
+    const zeroAttach = composeAttachObservation(trunkEntry, []);
+    expect(pickerAvailability(zeroAttach, ITEM_ID, BOTH)).toEqual({ canOpen: true, canAttach: true });
+    const handWritten = { testProcedures: 'Mine.', quarters: {} };
+    expect(pickerAvailability(handWritten, ITEM_ID, BOTH)).toEqual({ canOpen: false, canAttach: false });
+    const handWrittenWithRefs = { testProcedures: 'Mine.', platformProcedures: [FOREIGN_REF] };
+    expect(pickerAvailability(handWrittenWithRefs, ITEM_ID, BOTH)).toEqual({ canOpen: true, canAttach: false });
+    // a subcategory with no offers at all cannot open without refs
+    expect(pickerAvailability(composeAttachObservation(getBankProcedure('GV.OC-01 Ex1'), []), 'GV.OC-01 Ex1', BOTH))
+      .toEqual({ canOpen: false, canAttach: false });
+  });
+
+  test('Anti: the badge/picker modules never read the assessment-level platforms array', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const FILES = [
+      '../components/PlatformAddendumBadges.js',
+      '../components/PlatformCheckPicker.js'
+    ];
+    FILES.forEach((rel) => {
+      const code = fs.readFileSync(path.join(__dirname, rel), 'utf8');
+      expect(code).not.toMatch(/\.platforms\b/);
+      expect(code).not.toMatch(/platforms\.length/);
+    });
+  });
+});

--- a/src/utils/procedureTailor.js
+++ b/src/utils/procedureTailor.js
@@ -19,9 +19,16 @@
  * must not leak through derived procedure text — see PRIVATE_DATA.md).
  */
 
-import { getBankProcedure, buildProcedureSource } from './procedureBank';
+import { getBankProcedure, buildProcedureSource, isBankAttached, subcategoryFromItemId } from './procedureBank';
 import { licenseGate, licenseProvenance, mayTailor, refusalPlaceholder } from './licenseClass.mjs';
-import { buildPlatformRef } from './platformBank';
+import {
+  buildPlatformRef,
+  getPlatformProcedures,
+  getPlatformRecord,
+  isPlatformFork,
+  platformRefDrift,
+  sortPlatformAddenda
+} from './platformBank';
 import { CLOUD_TERMS, EDR_PRODUCTS, GOOGLE_EMAIL_TERMS } from './stackTailorMaps';
 
 /**
@@ -286,6 +293,126 @@ export const wizardAttachObservation = (bankEntry, platformOffers, profile, opti
   return offers.length > 0
     ? composeAttachObservation(bankEntry, offers, profile, options)
     : bankAttachObservation(bankEntry, profile, options);
+};
+
+/* --- Post-create platform-check picker (plan PR-7) ----------------------- */
+
+const addendaOf = (observation) =>
+  Array.isArray(observation?.platformProcedures) ? observation.platformProcedures : [];
+
+const entryIndexOf = (entries, ref) =>
+  entries.findIndex((e) => e?.corpusId === ref?.corpusId && e?.policyId === ref?.policyId);
+
+/**
+ * Shared rebuild for every picker operation: re-orders the given ENTRY
+ * OBJECTS to canonical committed-map order and re-records the recipe from
+ * them in the same write (a removal that only spliced the live array would
+ * leave a stale recipe behind, and Reset would resurrect the removed
+ * addendum). The rebuild reads no corpus record: existing entries — forks
+ * included — pass through verbatim, so no operation can re-fingerprint or
+ * re-render a neighbor it did not target. Only the add path mints a new
+ * reference and only the adopt path re-reads the corpus, each for exactly
+ * its one target entry.
+ *
+ * The trunk component is preserved verbatim when the recipe already has
+ * one; a legacy source with no recipe heals on this first write — the
+ * trunk component is reconstructed from the bank-attach provenance fields
+ * (only when the trunk IS bank-attached; a hand-written trunk records a
+ * refs-only recipe, which Reset's fail-closed contract already handles).
+ */
+const rebuildPickerComposition = (observation, itemId, entries) => {
+  const sorted = sortPlatformAddenda(entries, subcategoryFromItemId(itemId));
+  const source = observation?.procedureSource;
+  const existingTrunk = Array.isArray(source?.components)
+    ? source.components.find((c) => c && c.kind === 'trunk')
+    : null;
+  const trunk = existingTrunk || (isBankAttached(source)
+    ? { kind: 'trunk', bank: source.bank, bankId: source.bankId, bankVersion: source.bankVersion }
+    : null);
+  const components = [
+    ...(trunk ? [trunk] : []),
+    ...sorted.map(({ corpusId, corpusVersion, policyId, contentHash }) => ({
+      kind: 'platform-ref', corpusId, corpusVersion, policyId, contentHash
+    }))
+  ];
+  return {
+    platformProcedures: sorted,
+    procedureSource: { ...(source || {}), components }
+  };
+};
+
+/**
+ * THE pure producer for the detail panel's platform-check picker — the one
+ * post-create writer of the composition keys (plan PR-7; the composition-
+ * writer guard pins this file as sanctioned). Returns the observation
+ * update for one operation, or null when nothing would change — null means
+ * "no write", the repo-wide producer convention.
+ *
+ * Operations:
+ *  - { op: 'add', offer }      — attach one offer from getPlatformProcedures
+ *  - { op: 'addAll', offers }  — attach every not-yet-attached offer, one write
+ *  - { op: 'remove', ref }     — DELETE the entry from the live array and the
+ *    recipe together (ratified: no tombstones — the recipe means current
+ *    composition; provenance of past exports is self-contained by
+ *    expansion-on-export)
+ *  - { op: 'adopt', ref }      — adopt the upstream update: replace the one
+ *    entry's reference with a fresh fingerprint of the CURRENT corpus
+ *    record. The ONLY path anywhere that rewrites a stored contentHash
+ *    (ratified: drift detection never heals; callers confirm with the user
+ *    first, showing old vs new). Refuses forks (fork management is not this
+ *    surface) and non-drifted or unresolvable refs.
+ *
+ * Attaching requires a bank-attached trunk — addenda ride the community
+ * procedure, and the recipe records the trunk they ride on. Remove and
+ * adopt operate on what exists regardless of trunk provenance.
+ */
+export const pickerObservationUpdate = (observation, itemId, operation) => {
+  const entries = addendaOf(observation);
+  const { op } = operation || {};
+
+  if (op === 'add' || op === 'addAll') {
+    if (!isBankAttached(observation?.procedureSource)) return null;
+    const offers = op === 'add' ? [operation.offer] : (operation.offers || []);
+    const fresh = offers.filter((offer) =>
+      offer?.record && entryIndexOf(entries, offer) === -1);
+    if (fresh.length === 0) return null;
+    const added = fresh.map((offer) => buildPlatformRef(offer.record, offer.corpusId));
+    return rebuildPickerComposition(observation, itemId, [...entries, ...added]);
+  }
+
+  if (op === 'remove') {
+    const idx = entryIndexOf(entries, operation.ref);
+    if (idx === -1) return null;
+    return rebuildPickerComposition(observation, itemId, entries.filter((_, i) => i !== idx));
+  }
+
+  if (op === 'adopt') {
+    const idx = entryIndexOf(entries, operation.ref);
+    if (idx === -1) return null;
+    const entry = entries[idx];
+    if (isPlatformFork(entry) || platformRefDrift(entry) !== true) return null;
+    const record = getPlatformRecord(entry.corpusId, entry.policyId);
+    const adopted = buildPlatformRef(record, entry.corpusId);
+    return rebuildPickerComposition(
+      observation, itemId, entries.map((e, i) => (i === idx ? adopted : e)));
+  }
+
+  return null;
+};
+
+/**
+ * Picker availability for one observation — the visibility rule the page
+ * dispatches on. `canOpen` when there is anything to manage (attached
+ * entries to remove/adopt, or offers an attach could add); `canAttach`
+ * additionally requires the bank-attached trunk the recipe records.
+ * Branches on the observation's own state, never on the assessment-level
+ * platforms array (its emptiness is ambiguous by contract).
+ */
+export const pickerAvailability = (observation, itemId, platformIds) => {
+  const attached = addendaOf(observation).length;
+  const offered = getPlatformProcedures(subcategoryFromItemId(itemId), platformIds).length;
+  const canAttach = offered > 0 && isBankAttached(observation?.procedureSource);
+  return { canOpen: attached > 0 || canAttach, canAttach };
 };
 
 /**


### PR DESCRIPTION
Closes the dated one-way door from #315 and surfaces the drift machinery #314 shipped silent. Detail-panel provenance badges plus a per-subcategory platform-check picker: attach, remove, and adopt-upstream-update, post-create.

## What this adds

- **Per-addendum badge row** (read mode): one summary line per observation ("N platform checks", with "M updated upstream" and "K unresolved" chips when present) expanding to one row per attached check — policy id, platform label, drift/unresolved badge, and an upstream **Source** link taken from the current corpus record's attribution (commit-pinned CISA URLs). Badge states are limited to the production-drivable set; fork-modified and license-refused badges wait for the surfaces that make them reachable.
- **The picker** ("Platform checks" in the detail panel, edit mode): attached list with per-check **Remove** and, on drifted checks only, **Adopt update**; available list grouped by platform with counts, committed-map order, unranked, attached checks excluded, per-group "Attach all N" plus per-check Attach. Unresolved checks offer Remove only — there is no upstream record to adopt.
- **One write producer** (`pickerObservationUpdate`, procedureTailor.js — the composition-writer guard's sanctioned file): every operation rewrites `platformProcedures` AND re-records `procedureSource.components[]` together, re-sorted to canonical committed-map order (remove + re-add lands back in map position, never appended). Legacy no-recipe observations heal on first write. The shared rebuild passes existing entries through verbatim and reads no corpus records — only `add` mints a reference and only `adopt` re-reads the corpus, each for exactly its one target.
- **Derived platforms, both directions**: `derivePlatformsFromObservations` recomputes the assessment's platform set at one call-site chain after every composition-changing write (picker operations and Reset). Removing a platform's last check removes its id.

## Design decisions ratified by merging

1. **Badges and the picker ship together** — a surfaced state the user cannot act on is theater: the drift badge's remedy (adopt) and the unresolved badge's remedy (remove) both live in the picker.
2. **Adopt is consent, never healing.** Drift detection never alters anything. Rendered and exported text always carries the current corpus version (the drift-silent expansion pin is now a permanent decision, not a deferral); the stored fingerprint records the version the user accepted, and only the explicit adopt action — after a confirm showing old vs new fingerprints and the upstream source link — replaces it.
3. **Removal deletes; the recipe stays pure current-composition.** No tombstones in `components[]`. Provenance of past artifacts is already self-contained by expansion-on-export.
4. **`platforms` is derived, never mutated** — recomputed from the live observations after every write; the stored array always equals the derivation.
5. **Reset honesty holds post-create**: every picker write re-records the recipe, so Reset replays the current composition — a removed addendum stays removed, an adopted fingerprint survives as the pristine reference.

## Verification

- Full jest 1142/1142 (63 suites; 1101 baseline + 41 new): producer byte-equality against `composeAttachObservation` for the same set (no second composition rule); order stability incl. the 122-offer PR.DS-10 attractor (add-all → remove one → re-add → canonical order); platforms-derivation invariant over operation sequences; no-op identity for every refused operation; anti-tests — no path but adopt rewrites a contentHash (frozen-entry expand, per-ref neighbor stability with two drifted neighbors, verbatim import), no Reset resurrection after remove (production `resetToCommunityUpdate` chained), badge modules never read assessment `platforms`.
- RTL component tests for both new components, incl. the unresolved badge driven through production `importCompleteDatabase` and the negative pin that unresolved rows render no adopt affordance and no dead link.
- Live click-through in real Chrome against the production build: badges on a PR-6-created assessment; attach/remove with localStorage-verified recipe + derived platforms (microsoft-365 appeared on attach, disappeared on remove); Reset-no-resurrection; a drift fixture showing the badge and the full adopt flow (fingerprint updated in the live array and the recipe together); CSV export at the blob boundary reflecting the exact post-picker composition (67 addendum headers, removed check absent, adopted + re-added checks present).
- Both eslint invocations clean on changed files; production build compiles; platform bank, subcategory map, community bank, and generators byte-untouched.

Out of scope (unchanged): addendum edit/fork surface, evidence importer, myctrl corpus.
