### PR TITLE
Gate the step-3 attach-count sentence on the community-procedures toggle

### DIFF
--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -30,7 +30,7 @@ import { formatInlineMarkdown, stripMarkdown } from '../utils/markdownText';
 import { bankCoverage, getBankProcedure, canResetToCommunity, resetToCommunityUpdate, sourceUrlFor } from '../utils/procedureBank';
 import { expandProcedureText, derivePlatformsFromObservations } from '../utils/platformBank';
 import { canUseProfileWithProvider, buildTailorPrompt, tailoredProvenance, deriveStackTargets, describeStackPlan, bankAttachObservation, wizardAttachObservation, deterministicTailorUpdate, pickerObservationUpdate, pickerAvailability } from '../utils/procedureTailor';
-import { buildEnvironmentMatrix, buildAttachPlan, cellKey, toggleCell, setColumn, columnFullySelected, columnTotal, countAttached, attachedCountForItem, availablePlatforms } from '../utils/environmentStep';
+import { buildEnvironmentMatrix, buildAttachPlan, cellKey, toggleCell, setColumn, columnFullySelected, columnTotal, countAttached, attachedCountForItem, availablePlatforms, environmentAttachCopy } from '../utils/environmentStep';
 import { platformIdsFromInfrastructure } from '../utils/infraPresets';
 import { getScoringScale, scoreBand, CMMI_LEVELS } from '../utils/scoringScale';
 import { SYSTEM_NAME_MAX_LENGTH } from '../utils/externalLinks';
@@ -189,6 +189,10 @@ const Assessments = () => {
   const envAttachedCount = useMemo(
     () => countAttached(envMatrix, envSelections),
     [envMatrix, envSelections]
+  );
+  const envAttachCopy = useMemo(
+    () => environmentAttachCopy(useBankProcedures, envAttachedCount, envMatrix.totalAvailable),
+    [useBankProcedures, envAttachedCount, envMatrix.totalAvailable]
   );
 
   // Wizard Users step (issue #290): people in scope for the assessment.
@@ -2709,7 +2713,7 @@ Format as a numbered list. Be specific and actionable.`;
                       {envMatrix.noOfferCount > 0 && (
                         <p className="p-2 px-3 text-xs text-gray-500 dark:text-gray-400 border-t dark:border-gray-600">
                           {envMatrix.noOfferCount} of your scoped items have no platform checks for
-                          these platforms. Their community procedures attach as usual.
+                          these platforms.{useBankProcedures ? ' Their community procedures attach as usual.' : ''}
                         </p>
                       )}
                     </div>
@@ -2741,11 +2745,11 @@ Format as a numbered list. Be specific and actionable.`;
                         <p className="text-sm font-medium mt-2 text-green-900 dark:text-green-200">
                           {scopeCoverage.covered.length} of {selectedScopeItems.size} selected items have community procedures
                         </p>
-                        {envPlatforms.length > 0 && (
-                          <p className="text-sm text-green-800 dark:text-green-300 mt-1">
-                            {envAttachedCount} platform {envAttachedCount === 1 ? 'check' : 'checks'} from
-                            the Environment step {envAttachedCount === 1 ? 'attaches' : 'attach'} as
-                            addenda ({envMatrix.totalAvailable} available).
+                        {envPlatforms.length > 0 && envAttachCopy && (
+                          <p className={envAttachCopy.active
+                            ? 'text-sm text-green-800 dark:text-green-300 mt-1'
+                            : 'text-sm text-amber-700 dark:text-amber-400 mt-1'}>
+                            {envAttachCopy.text}
                           </p>
                         )}
                         {scopeCoverage.uncovered.length > 0 && (

--- a/src/utils/environmentStep.js
+++ b/src/utils/environmentStep.js
@@ -131,6 +131,29 @@ export const toggleCell = (selections, itemId, platformId) => {
 };
 
 /**
+ * Step-3 attach-count sentence for the community-procedures card. Pure so
+ * the page stays a dispatcher and so the off state can never claim an
+ * attach that buildAttachPlan will not perform: addenda ride the community
+ * trunk, and the bank toggle gates attachment. Returns null when there is
+ * nothing to say (bank off, nothing selected).
+ */
+export const environmentAttachCopy = (useBank, attachedCount, totalAvailable) => {
+  const noun = attachedCount === 1 ? 'check' : 'checks';
+  if (!useBank) {
+    if (attachedCount === 0) return null;
+    return {
+      active: false,
+      text: `${attachedCount} platform ${noun} selected in the Environment step will not attach while community test procedures are off. Turn them back on to apply your selections.`
+    };
+  }
+  const verb = attachedCount === 1 ? 'attaches' : 'attach';
+  return {
+    active: true,
+    text: `${attachedCount} platform ${noun} from the Environment step ${verb} as addenda (${totalAvailable} available).`
+  };
+};
+
+/**
  * The create-time attach plan. For every scoped item, the offers its checked
  * cells attach (ALL offers of each checked platform — user cells are the only
  * exclusion actor), plus the DERIVED platform set the assessment persists:

--- a/src/utils/environmentStep.test.js
+++ b/src/utils/environmentStep.test.js
@@ -16,7 +16,8 @@ import {
   columnTotal,
   countAttached,
   attachedCountForItem,
-  compareCsfOrder
+  compareCsfOrder,
+  environmentAttachCopy
 } from './environmentStep';
 import { getPlatformProcedures } from './platformBank';
 
@@ -190,5 +191,42 @@ describe('buildAttachPlan', () => {
     expect(plan.offersByItem['DE.CM-01'].map((o) => o.policyId)).toEqual(
       getPlatformProcedures('DE.CM-01', ['google-workspace']).map((o) => o.policyId)
     );
+  });
+});
+
+describe('environmentAttachCopy', () => {
+  test('bank on, plural: byte-matches the shipped step-3 sentence', () => {
+    expect(environmentAttachCopy(true, 493, 493)).toEqual({
+      active: true,
+      text: '493 platform checks from the Environment step attach as addenda (493 available).'
+    });
+  });
+
+  test('bank on, singular: attaches/check agreement preserved', () => {
+    expect(environmentAttachCopy(true, 1, 12)).toEqual({
+      active: true,
+      text: '1 platform check from the Environment step attaches as addenda (12 available).'
+    });
+  });
+
+  test('bank on, zero attached: still an honest active sentence', () => {
+    expect(environmentAttachCopy(true, 0, 493).text).toBe(
+      '0 platform checks from the Environment step attach as addenda (493 available).'
+    );
+  });
+
+  test('bank OFF with selections: inactive warning, never an attach claim', () => {
+    const copy = environmentAttachCopy(false, 493, 493);
+    expect(copy.active).toBe(false);
+    expect(copy.text).toContain('will not attach');
+    expect(copy.text).not.toContain('attach as addenda');
+  });
+
+  test('bank OFF, singular selection keeps noun agreement', () => {
+    expect(environmentAttachCopy(false, 1, 12).text).toContain('1 platform check selected');
+  });
+
+  test('bank OFF with nothing selected renders nothing', () => {
+    expect(environmentAttachCopy(false, 0, 493)).toBeNull();
   });
 });


### PR DESCRIPTION
# PR body: fix/env-attach-copy-gate

Title: `Gate the step-3 attach-count sentence on the community-procedures toggle`

---

## What

The wizard's step-3 line "N platform checks from the Environment step attach as addenda (T available)" rendered from Environment-step selections alone. With the community-procedures checkbox off it still claimed the checks would attach, while `buildAttachPlan` attaches zero in that state (addenda ride the community trunk by design).

The sentence now comes from a pure helper, `environmentAttachCopy` in `src/utils/environmentStep.js`, so the rule is lint-gated and unit-tested rather than living in page JSX:

- Bank on: the shipped sentence, byte-for-byte, singular and plural forms preserved.
- Bank off with selections: an amber warning that the selections will not attach.
- Bank off with nothing selected: renders nothing.

## Why not just hide the line

Hiding it would silently discard the user's Environment-step work with no explanation. The amber state names the consequence and the remedy, consistent with the step-2 warning that already exists for the reverse order of operations.

## Ratification items

1. Off-state wording: "N platform checks selected in the Environment step will not attach while community test procedures are off. Turn them back on to apply your selections."
2. The zero-selected off state renders nothing rather than a warning about nothing.

## Verification

- 6 new unit tests in `environmentStep.test.js` (on-state byte-identity plural and singular, off-state warning, off-state null, zero-count honesty).
- Full suite green at the stack tip; changed files lint at `--max-warnings=0`; `CI=false` build compiles.
- Post-merge click-through: step 2 select platforms, step 3 uncheck community procedures, confirm the amber line replaces the green attach claim.
