### PR TITLE
Match CSF function colors to the NIST CSF 2.0 wheel; use SC shield in header

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -133,8 +133,8 @@ const AppContent = () => {
             <div className="flex items-center gap-3">
               <div className="terminal-logo-disc">
                 <img
-                  src="/SC_SimplyCyberAcademy.png"
-                  alt="Simply Cyber Academy Logo"
+                  src="/SC_Logo.png"
+                  alt="Simply Cyber shield"
                 />
               </div>
               <div className="h-6 w-px bg-gray-300 dark:bg-gray-600" />

--- a/src/components/BadgeSystem.js
+++ b/src/components/BadgeSystem.js
@@ -6,7 +6,7 @@ import React from 'react';
  *
  * Badge Types and Colors:
  * - Framework: Blue (#dbeafe / #2563eb)
- * - CSF Function: Matches function (DETECT=red, PROTECT=green, etc.)
+ * - CSF Function: Matches the NIST CSF 2.0 wheel (GOVERN=yellow, PROTECT=purple, DETECT=orange, etc.)
  * - Subcategory: Amber/Orange (#ffedd5 / #f59e0b)
  * - Artifact: Green (#dcfce7 / #16a34a)
  * - Finding: Red/Orange (#fee2e2 / #ef4444)
@@ -16,14 +16,16 @@ import React from 'react';
 
 // Color definitions for consistency
 export const BADGE_COLORS = {
-  // CSF Functions
+  // CSF Functions — light values track CSFBadge.js FUNCTION_COLORS (NIST CSF 2.0 wheel).
+  // darkBg/darkText are still the pre-wheel values; dark-palette work lands with the
+  // design tokens. Nothing renders this table today (no caller passes colorScheme="function").
   function: {
-    GOVERN: { bg: '#E8DEF8', text: '#6B21A8', darkBg: '#581c87', darkText: '#e9d5ff' },
-    IDENTIFY: { bg: '#DBEAFE', text: '#1E40AF', darkBg: '#1e3a8a', darkText: '#bfdbfe' },
-    PROTECT: { bg: '#DCFCE7', text: '#166534', darkBg: '#14532d', darkText: '#bbf7d0' },
-    DETECT: { bg: '#FEE2E2', text: '#991B1B', darkBg: '#7f1d1d', darkText: '#fecaca' },
-    RESPOND: { bg: '#FFEDD5', text: '#C2410C', darkBg: '#7c2d12', darkText: '#fed7aa' },
-    RECOVER: { bg: '#FEF3C7', text: '#B45309', darkBg: '#78350f', darkText: '#fde68a' },
+    GOVERN: { bg: '#FBF0BF', text: '#6B5200', darkBg: '#581c87', darkText: '#e9d5ff' },
+    IDENTIFY: { bg: '#D6EBF7', text: '#10527D', darkBg: '#1e3a8a', darkText: '#bfdbfe' },
+    PROTECT: { bg: '#E5E0F5', text: '#463C8A', darkBg: '#14532d', darkText: '#bbf7d0' },
+    DETECT: { bg: '#FCE6C6', text: '#9A5300', darkBg: '#7f1d1d', darkText: '#fecaca' },
+    RESPOND: { bg: '#F8D9D7', text: '#9E2B27', darkBg: '#7c2d12', darkText: '#fed7aa' },
+    RECOVER: { bg: '#D5F3E1', text: '#16713E', darkBg: '#78350f', darkText: '#fde68a' },
   },
   // Entity types
   framework: { bg: '#dbeafe', text: '#1e40af', darkBg: '#1e3a8a', darkText: '#bfdbfe' },

--- a/src/components/CSFBadge.js
+++ b/src/components/CSFBadge.js
@@ -5,14 +5,14 @@ import React from 'react';
  * Displays CSF functions with appropriate color coding matching Confluence styling
  */
 
-// Color mapping for CSF functions (matching Confluence UI)
+// Color mapping for CSF functions (matching the official NIST CSF 2.0 wheel)
 const FUNCTION_COLORS = {
-  'GOVERN': { bg: '#E8DEF8', text: '#6B21A8' },        // Purple
-  'IDENTIFY': { bg: '#DBEAFE', text: '#1E40AF' },     // Blue
-  'PROTECT': { bg: '#DCFCE7', text: '#166534' },      // Green
-  'DETECT': { bg: '#FEE2E2', text: '#991B1B' },       // Red
-  'RESPOND': { bg: '#FFEDD5', text: '#C2410C' },      // Orange
-  'RECOVER': { bg: '#FEF3C7', text: '#B45309' }       // Amber
+  'GOVERN': { bg: '#FBF0BF', text: '#6B5200' },       // Yellow
+  'IDENTIFY': { bg: '#D6EBF7', text: '#10527D' },     // Blue
+  'PROTECT': { bg: '#E5E0F5', text: '#463C8A' },      // Purple
+  'DETECT': { bg: '#FCE6C6', text: '#9A5300' },       // Orange
+  'RESPOND': { bg: '#F8D9D7', text: '#9E2B27' },      // Red
+  'RECOVER': { bg: '#D5F3E1', text: '#16713E' }       // Green
 };
 
 // Extract function code from full function name (e.g., "DETECT (DE)" -> "DETECT")

--- a/src/components/CSFBadge.js
+++ b/src/components/CSFBadge.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 /**
  * CSF Function Badge Component
- * Displays CSF functions with appropriate color coding matching Confluence styling
+ * Displays CSF functions with appropriate color coding matching the NIST CSF 2.0 wheel
  */
 
 // Color mapping for CSF functions (matching the official NIST CSF 2.0 wheel)

--- a/src/index.css
+++ b/src/index.css
@@ -1234,7 +1234,7 @@ nav a:active { text-decoration: none !important; }
   width: 56px;
   height: 56px;
   border-radius: 9999px;
-  background: #000000;
+  background: #ffffff;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1249,7 +1249,7 @@ nav a:active { text-decoration: none !important; }
   display: block;
 }
 .dark .terminal-logo-disc {
-  background: #000000;
+  background: #ffffff;
   border-color: var(--accent);
 }
 .terminal-statusbar-segment {

--- a/src/index.css
+++ b/src/index.css
@@ -1228,8 +1228,8 @@ nav a:active { text-decoration: none !important; }
 }
 .dark .terminal-app-header { background-color: var(--bg-primary); }
 
-/* Black circular disc behind the Simply Cyber white-on-transparent logo
-   so it doesn't wash out on the light cream/blue paper background. */
+/* White circular disc behind the Simply Cyber shield, which is dark-on-transparent
+   and would otherwise disappear against the dark navy header bar. */
 .terminal-logo-disc {
   width: 56px;
   height: 56px;

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -468,12 +468,12 @@ const Dashboard = () => {
 
   // Colors for each CSF function in the trend line chart
   const FUNCTION_LINE_COLORS = {
-    'GOVERN (GV)': '#8b5cf6',
-    'IDENTIFY (ID)': '#3b82f6',
-    'PROTECT (PR)': '#10b981',
-    'DETECT (DE)': '#f59e0b',
-    'RESPOND (RS)': '#ef4444',
-    'RECOVER (RC)': '#6366f1',
+    'GOVERN (GV)': '#E0B011',
+    'IDENTIFY (ID)': '#3B9BD6',
+    'PROTECT (PR)': '#8B7FD0',
+    'DETECT (DE)': '#F39A1F',
+    'RESPOND (RS)': '#D9534F',
+    'RECOVER (RC)': '#47C97A',
   };
 
   // Calculate quarterly trend data: average actualScore per function per quarter

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -468,12 +468,16 @@ const Dashboard = () => {
 
   // Colors for each CSF function in the trend line chart
   const FUNCTION_LINE_COLORS = {
-    'GOVERN (GV)': '#E0B011',
-    'IDENTIFY (ID)': '#3B9BD6',
-    'PROTECT (PR)': '#8B7FD0',
-    'DETECT (DE)': '#F39A1F',
-    'RESPOND (RS)': '#D9534F',
-    'RECOVER (RC)': '#47C97A',
+    // NIST CSF 2.0 wheel hues, held at the lightness that clears WCAG 1.4.11 (3:1)
+    // against BOTH chart backgrounds — white and the dark-mode #1f2937 (see line 178).
+    // The audit report captures this chart onto white whatever theme is active, so a
+    // single set has to satisfy both. Keep any edit above 3:1 on each.
+    'GOVERN (GV)': '#A07E0C',
+    'IDENTIFY (ID)': '#2989C5',
+    'PROTECT (PR)': '#8477CD',
+    'DETECT (DE)': '#BB710A',
+    'RESPOND (RS)': '#DA5753',
+    'RECOVER (RC)': '#2C9455',
   };
 
   // Calculate quarterly trend data: average actualScore per function per quarter

--- a/src/utils/auditReportMarkdown.js
+++ b/src/utils/auditReportMarkdown.js
@@ -566,12 +566,12 @@ The organization's overall cybersecurity maturity is assessed at **${overallMatu
     maturitySection += `#### Score Trends by Quarter\n\n<img src="${trendChartUri}" alt="Quarterly score trends" width="1400" />\n\n`;
     maturitySection += `<div style="display:flex;gap:16px;flex-wrap:wrap;margin-top:4px;font-size:13px">`;
     // Must track FUNCTION_LINE_COLORS in Dashboard.js — the chart above is captured from it.
-    maturitySection += `<span><span style="color:#E0B011;font-weight:700">━━</span> Govern (GV)</span>`;
-    maturitySection += `<span><span style="color:#3B9BD6;font-weight:700">━━</span> Identify (ID)</span>`;
-    maturitySection += `<span><span style="color:#8B7FD0;font-weight:700">━━</span> Protect (PR)</span>`;
-    maturitySection += `<span><span style="color:#F39A1F;font-weight:700">━━</span> Detect (DE)</span>`;
-    maturitySection += `<span><span style="color:#D9534F;font-weight:700">━━</span> Respond (RS)</span>`;
-    maturitySection += `<span><span style="color:#47C97A;font-weight:700">━━</span> Recover (RC)</span>`;
+    maturitySection += `<span><span style="color:#A07E0C;font-weight:700">━━</span> Govern (GV)</span>`;
+    maturitySection += `<span><span style="color:#2989C5;font-weight:700">━━</span> Identify (ID)</span>`;
+    maturitySection += `<span><span style="color:#8477CD;font-weight:700">━━</span> Protect (PR)</span>`;
+    maturitySection += `<span><span style="color:#BB710A;font-weight:700">━━</span> Detect (DE)</span>`;
+    maturitySection += `<span><span style="color:#DA5753;font-weight:700">━━</span> Respond (RS)</span>`;
+    maturitySection += `<span><span style="color:#2C9455;font-weight:700">━━</span> Recover (RC)</span>`;
     maturitySection += `</div>\n\n`;
   }
   if (!barChartUri && !radarChartUri && !trendChartUri) {

--- a/src/utils/auditReportMarkdown.js
+++ b/src/utils/auditReportMarkdown.js
@@ -565,12 +565,13 @@ The organization's overall cybersecurity maturity is assessed at **${overallMatu
   if (trendChartUri) {
     maturitySection += `#### Score Trends by Quarter\n\n<img src="${trendChartUri}" alt="Quarterly score trends" width="1400" />\n\n`;
     maturitySection += `<div style="display:flex;gap:16px;flex-wrap:wrap;margin-top:4px;font-size:13px">`;
-    maturitySection += `<span><span style="color:#8b5cf6;font-weight:700">━━</span> Govern (GV)</span>`;
-    maturitySection += `<span><span style="color:#3b82f6;font-weight:700">━━</span> Identify (ID)</span>`;
-    maturitySection += `<span><span style="color:#10b981;font-weight:700">━━</span> Protect (PR)</span>`;
-    maturitySection += `<span><span style="color:#f59e0b;font-weight:700">━━</span> Detect (DE)</span>`;
-    maturitySection += `<span><span style="color:#ef4444;font-weight:700">━━</span> Respond (RS)</span>`;
-    maturitySection += `<span><span style="color:#6366f1;font-weight:700">━━</span> Recover (RC)</span>`;
+    // Must track FUNCTION_LINE_COLORS in Dashboard.js — the chart above is captured from it.
+    maturitySection += `<span><span style="color:#E0B011;font-weight:700">━━</span> Govern (GV)</span>`;
+    maturitySection += `<span><span style="color:#3B9BD6;font-weight:700">━━</span> Identify (ID)</span>`;
+    maturitySection += `<span><span style="color:#8B7FD0;font-weight:700">━━</span> Protect (PR)</span>`;
+    maturitySection += `<span><span style="color:#F39A1F;font-weight:700">━━</span> Detect (DE)</span>`;
+    maturitySection += `<span><span style="color:#D9534F;font-weight:700">━━</span> Respond (RS)</span>`;
+    maturitySection += `<span><span style="color:#47C97A;font-weight:700">━━</span> Recover (RC)</span>`;
     maturitySection += `</div>\n\n`;
   }
   if (!barChartUri && !radarChartUri && !trendChartUri) {


### PR DESCRIPTION
Aligns the six CSF function colors with the official NIST CSF 2.0 wheel and swaps the header mark to the bare SC shield.

## What changed

**Function colors → NIST CSF 2.0 wheel.** Govern yellow, Identify blue, Protect purple, Detect orange, Respond red, Recover green — replacing the Confluence-derived set (Govern purple, Protect green, Detect red, Respond orange, Recover amber). Applied to the badge palette (`CSFBadge.js`), the dashboard trend lines (`Dashboard.js`), and the exported audit report legend (`auditReportMarkdown.js`).

**Header mark.** The disc now carries `SC_Logo.png` — the crest alone, no wordmark, which was illegible at 56px — on a white background so the navy shield reads. `SC_Logo.png` was already the favicon and all three `manifest.json` icons, so the header now matches the browser tab.

## Two things found while verifying

**The exported audit report legend was going to disagree with its own chart.** The trend chart embedded in the report is captured live from the dashboard, so it picks up the new colors automatically — but the legend beneath it is hand-written and still carried the old palette. Same fix, one file.

**Trend-line contrast.** The wheel hues are designed for a filled wheel, not 2px strokes. Taken literally, four of six lines fell below the WCAG 1.4.11 3:1 minimum for graphical objects, and two were regressions from the colors they replaced:

| | old stroke | on white | literal wheel | on white | shipped | on white | on `#1f2937` |
|---|---|---|---|---|---|---|---|
| Govern | `#8b5cf6` | 4.23 | `#E0B011` | **2.02** | `#A07E0C` | 3.83 | 3.83 |
| Identify | `#3b82f6` | 3.68 | `#3B9BD6` | **3.07** | `#2989C5` | 3.83 | 3.83 |
| Protect | `#10b981` | 2.54 | `#8B7FD0` | 3.47 | `#8477CD` | 3.82 | 3.85 |
| Detect | `#f59e0b` | 2.15 | `#F39A1F` | **2.22** | `#BB710A` | 3.83 | 3.83 |
| Respond | `#ef4444` | 3.76 | `#D9534F` | 3.96 | `#DA5753` | 3.84 | 3.82 |
| Recover | `#6366f1` | 4.47 | `#47C97A` | **2.12** | `#2C9455` | 3.84 | 3.83 |

The shipped values hold each wheel hue and saturation at the lightness where it clears 3:1 against **both** chart backgrounds. It has to be one set rather than a per-theme pair, because the audit report captures the dashboard chart onto white whatever theme is active.

Badge fills are unchanged from the wheel — all six already pass AA for text (4.78:1 to 7.17:1).

## Also

- `BADGE_COLORS.function` in `BadgeSystem.js` held a fourth copy of the old palette. Nothing renders it — no caller passes `colorScheme="function"` — but it would have contradicted the other three sites for the next person who reached for it. Light values now track the wheel; the `darkBg`/`darkText` variants are left for the dark-palette work.
- Three comments that still described the pre-wheel palette (`CSFBadge.js` docblock, `BadgeSystem.js` docblock, the `.terminal-logo-disc` comment in `index.css`, which described a black disc behind a white logo — both halves now inverted).

## Verification

66 test suites / 1187 tests pass, including `theme/contrast.test.js`. `npm run build` clean. ESLint 0 errors on changed files. A render probe through the real `CSFBadge` component confirmed all six badges emit the exact wheel values. Header shield checked in both themes.

## Not in this PR

Radius, elevation, typography, sidebar navigation, the dark-mode palette rework, and dead-class cleanup — those are the later PRs in the sequence. No status, severity, priority, or entity color was touched, including the ones that coincidentally shared a hex with an old function color.

One known follow-up: `ASSESSMENT_CATALOG/6_Audit_Report/Alma-Security-Internal-Audit-Report.md` is a committed sample report generated before this change, so its embedded legend is now stale. Regenerating it is a separate commit.
