### PR TITLE
Add CSF_Wiki scaffold: raw-folder LLM wiki for NIST CSF 2.0

### DIFF
--- a/CSF_Wiki/CONTRIBUTING.md
+++ b/CSF_Wiki/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# CSF_Wiki — Ingestion Instructions
+
+This folder is an LLM wiki, built the Karpathy way: drop raw source material into `raw/`, run a Claude Code session, get back linked markdown nodes in `wiki/`. No vector database, no embeddings, no extra infrastructure — just markdown files and `[[wikilinks]]`. Obsidian is optional; it's only a graph viewer on top of these same files.
+
+Source: `CPAtoCybersecurity/catalyst` issue #79. Confirmed by the repo owner as community-facing — write for a public reader who may not know the CSF Profile app, not an internal team note.
+
+## Raw folder layout
+
+- `raw/nist_csf/` — NIST CSF 2.0 source material: Function/Category/Subcategory text, Implementation Examples. The canonical text already lives in this repo at `sample_csv_exports/yyyy-mm-dd_CSF_Profile.csv` (columns: Function, Function Description, Category ID, Category, Category Description, Subcategory ID, Subcategory Description, Implementation Example) and in `src/stores/comprehensiveAssessmentData.js` / `defaultControlsData.js` (real-world implementation narratives) — treat those as already-ingested raw material, no need to re-drop them.
+- `raw/simply_cyber/` — Simply Cyber video summaries/transcripts. Drop as plain `.md` or `.txt`, one file per video.
+- `raw/threat_briefing/` — Gerry's Daily Cyber Threat Briefing highlights. Same drop convention.
+
+## Wiki node conventions
+
+**File naming:** one file per CSF Subcategory, named by Subcategory ID — `wiki/<Function>/<Subcategory-ID>.md` (e.g. `wiki/GV/GV.OC-01.md`). Category-level and Function-level pages are index pages: `wiki/<Function>/_index.md` for the Function, no separate file needed per Category unless a Category accumulates enough cross-links to warrant its own hub.
+
+**Node content shape:**
+1. Subcategory ID + one-line description (from the canonical CSF text)
+2. Category and Function it belongs to, each a `[[wikilink]]` to that index
+3. Implementation Example(s) from NIST source text
+4. Real-world implementation narrative(s), when available, pulled from `comprehensiveAssessmentData.js` / `defaultControlsData.js`
+5. `## Related` section linking sibling Subcategories, relevant Simply Cyber video highlights, and relevant threat-briefing highlights
+
+**Cross-linking:** use Obsidian-compatible `[[Target-File-Name]]` links (no `.md` extension inside the brackets). Every wiki node must link *up* to its Function index and *down or across* to at least one related node — orphan nodes are a build defect, not acceptable output.
+
+**Linking new raw material into existing nodes:** when a new Simply Cyber or threat-briefing file lands in `raw/`, do NOT create a standalone unlinked page for it. Read it, identify which Subcategory node(s) it's relevant to, and add a link + one-paragraph excerpt into each relevant node's `## Related` section. A raw drop that produces no new links into existing Subcategory nodes was mis-scoped — either it belongs in the wiki somewhere, or it wasn't CSF-relevant material.
+
+## Security+ extension (future)
+
+Same pipeline, parallel subtree: `raw/security_plus/` and `wiki/security_plus/`, one node per exam objective instead of per Subcategory. Do not build this until the CSF side has real content in it — prove the pattern once before forking it.
+
+## What NOT to do
+
+- Do not modify `src/stores/*Data.js` — those are the app's data, this wiki reads from them, it does not fork them.
+- Do not stand up a database, vector store, or search index for this. If retrieval ever gets clunky at scale, that's a future decision, not a default.

--- a/CSF_Wiki/README.md
+++ b/CSF_Wiki/README.md
@@ -18,4 +18,4 @@ Drop a markdown or text file into the matching `raw/` subfolder (NIST material, 
 
 ## Origin
 
-This grew out of an idea from [issue #79](https://github.com/CPAtoCybersecurity/catalyst/issues/79) — a second brain for the CSF, built on Andrej Karpathy's "LLM wiki" pattern: raw folder in, Claude Code reads everything and builds the linked markdown wiki, no vector database or extra infrastructure required.
+This grew out of an internal planning issue — a second brain for the CSF, built on Andrej Karpathy's "LLM wiki" pattern: raw folder in, Claude Code reads everything and builds the linked markdown wiki, no vector database or extra infrastructure required.

--- a/CSF_Wiki/README.md
+++ b/CSF_Wiki/README.md
@@ -1,0 +1,21 @@
+# CSF Wiki
+
+A browsable, cross-linked knowledge base for NIST Cybersecurity Framework 2.0 — built by dropping source material into a folder and letting an LLM organize it into a linked markdown wiki. No app to install to read it: it's plain markdown, viewable on GitHub, or opened in [Obsidian](https://obsidian.md) for a visual graph of how everything connects.
+
+## What's in here
+
+- `wiki/` — one page per CSF Function, Category, and Subcategory, cross-linked to each other and to related Simply Cyber video highlights and Gerry's Daily Cyber Threat Briefing highlights.
+- `raw/` — the source material the wiki is generated from (NIST CSF text, video summaries, briefing highlights). See `CONTRIBUTING.md` if you want to understand or extend the generation process.
+
+## How to browse
+
+- On GitHub: start at [`wiki/GV/_index.md`](wiki/GV/_index.md) and follow the links.
+- In Obsidian: open this `CSF_Wiki` folder as a vault to see the full link graph.
+
+## How to contribute a source
+
+Drop a markdown or text file into the matching `raw/` subfolder (NIST material, a Simply Cyber summary, or a threat-briefing highlight) and open a PR. See `CONTRIBUTING.md` for exactly how new material gets linked into existing wiki nodes.
+
+## Origin
+
+This grew out of an idea from [issue #79](https://github.com/CPAtoCybersecurity/catalyst/issues/79) — a second brain for the CSF, built on Andrej Karpathy's "LLM wiki" pattern: raw folder in, Claude Code reads everything and builds the linked markdown wiki, no vector database or extra infrastructure required.

--- a/CSF_Wiki/wiki/GV/GV.OC-01.md
+++ b/CSF_Wiki/wiki/GV/GV.OC-01.md
@@ -1,0 +1,23 @@
+# GV.OC-01 — The organizational mission is understood and informs cybersecurity risk management
+
+**Function:** [[_index|GOVERN (GV)]] — the organization's cybersecurity risk management strategy, expectations, and policy are established, communicated, and monitored.
+
+**Category:** Organizational Context (GV.OC) — the circumstances (mission, stakeholder expectations, dependencies, and legal, regulatory, and contractual requirements) surrounding the organization's cybersecurity risk management decisions are understood.
+
+## Implementation Example (NIST)
+
+> Ex1: Share the organization's mission (e.g., through vision and mission statements, marketing, and service strategies) to provide a basis for identifying risks that may impede that mission.
+
+## Real-world implementation narrative
+
+From the CSF Profile app's example assessment (Alma Security, a fictional company used as the app's built-in demo dataset):
+
+> Alma Security's mission "to ensure businesses can continuously authenticate their users using their whole selves" is documented on the company website and communicated through quarterly Board briefings and monthly management meetings. Security investments and risk appetite decisions are explicitly tied to mission objectives, including strategic partnerships like the Apple Passkey integration.
+
+Test procedure on file: inquiry with CEO/CISO plus artifact review of the mission statement and Board briefing materials.
+
+## Related
+
+- [[GV.SC-04]] — same GOVERN function, supply-chain risk depends on the same mission-driven criticality reasoning
+- Simply Cyber video highlights: none linked yet — drop a relevant summary in `raw/simply_cyber/` to connect one
+- Threat briefing highlights: none linked yet — drop a relevant highlight in `raw/threat_briefing/` to connect one

--- a/CSF_Wiki/wiki/GV/GV.SC-04.md
+++ b/CSF_Wiki/wiki/GV/GV.SC-04.md
@@ -1,0 +1,21 @@
+# GV.SC-04 — Suppliers are known and prioritized by criticality
+
+**Function:** [[_index|GOVERN (GV)]] — the organization's cybersecurity risk management strategy, expectations, and policy are established, communicated, and monitored.
+
+**Category:** Cybersecurity Supply Chain Risk Management (GV.SC) — cyber supply chain risk management processes are identified, established, managed, monitored, and improved by organizational stakeholders.
+
+## Implementation Example (NIST)
+
+> Ex1: Develop criteria for supplier criticality based on, for example, the sensitivity of data processed or possessed by suppliers, the degree of access to the organization's systems, and the importance of the products or services to the organization's mission.
+
+## Real-world implementation narrative
+
+From the CSF Profile app's example assessment (Alma Security, a fictional company used as the app's built-in demo dataset):
+
+> Alma Security maintains a supplier inventory in ServiceNow with criticality ratings based on three factors: (1) sensitivity of data processed (with biometric data suppliers rated highest), (2) degree of system access granted, and (3) importance to the continuous authentication mission. The Third Party Risk Management Policy defines tiering criteria and requires quarterly reviews with CISO and Procurement sign-off.
+
+## Related
+
+- [[GV.OC-01]] — supplier criticality tiering is downstream of the mission understanding established here
+- Simply Cyber video highlights: none linked yet — drop a relevant summary in `raw/simply_cyber/` to connect one
+- Threat briefing highlights: none linked yet — drop a relevant highlight in `raw/threat_briefing/` to connect one

--- a/CSF_Wiki/wiki/GV/_index.md
+++ b/CSF_Wiki/wiki/GV/_index.md
@@ -1,0 +1,15 @@
+# GOVERN (GV)
+
+The organization's cybersecurity risk management strategy, expectations, and policy are established, communicated, and monitored.
+
+## Categories in this function
+
+### Organizational Context (GV.OC)
+The circumstances (mission, stakeholder expectations, dependencies, and legal, regulatory, and contractual requirements) surrounding the organization's cybersecurity risk management decisions are understood.
+- [[GV.OC-01]] — The organizational mission is understood and informs cybersecurity risk management
+
+### Cybersecurity Supply Chain Risk Management (GV.SC)
+Cyber supply chain risk management processes are identified, established, managed, monitored, and improved by organizational stakeholders.
+- [[GV.SC-04]] — Suppliers are known and prioritized by criticality
+
+*Only two Subcategories are seeded so far — this index is a proof of concept for the wiki pattern, not full GOVERN-function coverage. Remaining GV.OC / GV.SC / GV.RM / GV.RR / GV.PO subcategories come from the same source (`sample_csv_exports/yyyy-mm-dd_CSF_Profile.csv`) as a follow-up build.*

--- a/CSF_Wiki/wiki/_index.md
+++ b/CSF_Wiki/wiki/_index.md
@@ -1,0 +1,12 @@
+# CSF Wiki — Functions
+
+NIST CSF 2.0 organizes cybersecurity risk management into six Functions. Each links to its own index of Categories and Subcategories.
+
+- [[GV/_index|GOVERN (GV)]] — seeded, 2 Subcategories live
+- IDENTIFY (ID) — not yet seeded
+- PROTECT (PR) — not yet seeded
+- DETECT (DE) — not yet seeded
+- RESPOND (RS) — not yet seeded
+- RECOVER (RC) — not yet seeded
+
+Source material for all six functions already exists in this repo at `sample_csv_exports/yyyy-mm-dd_CSF_Profile.csv` and `src/stores/comprehensiveAssessmentData.js` — see `../CLAUDE.md` for how to turn that into wiki nodes for the remaining five Functions.


### PR DESCRIPTION
Addresses CPAtoCybersecurity/catalyst#79.

Karpathy-style raw-folder wiki: drop source material into `raw/`, a Claude Code session organizes it into linked markdown in `wiki/`. No vector DB, no embeddings, no extra infra — just markdown + Obsidian-compatible `[[wikilinks]]`. Obsidian is optional, only a graph viewer on top.

Confirmed community-facing (not internal) by @CPAtoCybersecurity in the issue thread.

**What's here:**
- `CSF_Wiki/raw/{nist_csf,simply_cyber,threat_briefing}/` — drop zones for future source material
- `CSF_Wiki/wiki/` — seeded with a real proof-of-concept: GOVERN function index → `GV.OC-01` + `GV.SC-04` subcategory nodes, cross-linked, sourced from the canonical CSF text already in `sample_csv_exports/yyyy-mm-dd_CSF_Profile.csv`
- `CSF_Wiki/CONTRIBUTING.md` — how new raw material becomes linked wiki nodes (naming convention, linking rule, no-orphans rule, Security+ extension path)
- `CSF_Wiki/README.md` — public-facing explainer

**Not in this PR:** full coverage of the other 5 CSF functions, and no real Simply Cyber / threat-briefing content yet — both need real source material dropped into `raw/` as a follow-up.

Nothing in `src/stores/*` was touched — the wiki reads from existing data, doesn't fork it.