### PR TITLE
Update evidence retention guidelines in PROC-evidence-preservation-guide

### DIFF
--- a/ASSESSMENT_CATALOG/5_Artifacts/Procedures/PROC-evidence-preservation-guide.md
+++ b/ASSESSMENT_CATALOG/5_Artifacts/Procedures/PROC-evidence-preservation-guide.md
@@ -101,8 +101,7 @@ Evidence attached to a ServiceNow incident ticket is retained per the ticket's o
 schedule, which follows the [Information Security Policy](../Policies/POL-information-security.md)
 (ALMA-POL-2025-001). Evidence relevant to an incident still under active review by Internal Audit or
 Legal is held past the standard schedule until that review closes, consistent with the Business
-Continuity Plan (ALMA-SOP-2025-013) referenced in the playbook's own Related Documents table — not
-itself written up as a standalone artifact in this catalog yet.
+Continuity Plan (ALMA-SOP-2025-013).
 
 ---
 


### PR DESCRIPTION
Clarified retention of evidence related to ServiceNow incidents and removed reference to the playbook's Related Documents table.