### PR TITLE
Add Implementation Example column to assessment CSV; selective export picker

### DIFF
--- a/src/components/AssessmentPicker.js
+++ b/src/components/AssessmentPicker.js
@@ -1,0 +1,227 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { Download, X } from 'lucide-react';
+
+/**
+ * AssessmentPicker
+ *
+ * The selection step in front of every export that would otherwise take the
+ * whole store. Opens with everything selected, so confirming without touching
+ * anything reproduces the historical export-everything behaviour exactly.
+ *
+ * Shell is modelled on ExportPasswordDialog: createPortal + inline styles for
+ * the overlay geometry. index.css is a hand-written utility subset, not a
+ * Tailwind build, so anything load-bearing for layout is an inline style and
+ * class names are limited to the vocabulary that file actually defines.
+ *
+ * @param {boolean} isOpen
+ * @param {string} [title]
+ * @param {string} [description]
+ * @param {Array} assessments - [{ id, name, scopeIds }]
+ * @param {Function} onCancel
+ * @param {Function} onConfirm - called with the selected id array
+ * @param {string} [confirmLabel]
+ */
+const AssessmentPicker = ({
+  isOpen,
+  title = 'Choose assessments to export',
+  description,
+  assessments = [],
+  onCancel,
+  onConfirm,
+  confirmLabel = 'Export'
+}) => {
+  const [selectedIds, setSelectedIds] = React.useState([]);
+
+  // Reopening always resets to "everything selected" — a picker that
+  // remembered a narrow prior selection is how someone ships a one-assessment
+  // file believing it is their backup.
+  React.useEffect(() => {
+    if (!isOpen) return;
+    setSelectedIds(assessments.map((a) => a.id));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel?.();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  const total = assessments.length;
+  const selectedCount = selectedIds.length;
+  const noneSelected = selectedCount === 0;
+  const isSubset = selectedCount > 0 && selectedCount < total;
+
+  const toggle = (id) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (noneSelected) return;
+    // A full selection reports null, not the id list: downstream that means
+    // "no narrowing", which keeps the default export byte-identical.
+    onConfirm?.(selectedCount === total ? null : selectedIds);
+  };
+
+  const modalContent = (
+    <div
+      className="fixed inset-0 flex items-center justify-center p-4"
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 9999,
+        backgroundColor: 'rgba(0, 0, 0, 0.5)'
+      }}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onCancel?.();
+      }}
+    >
+      <div
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-lg w-full"
+        data-testid="assessment-picker"
+      >
+        {/* Header */}
+        <div className="border-b border-gray-200 dark:border-gray-700 p-3 flex items-start gap-2">
+          <div className="p-2 bg-blue-50 dark:bg-blue-900/30 rounded-lg">
+            <Download className="text-blue-600 dark:text-blue-300" size={18} />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h2 className="text-lg font-bold text-gray-900 dark:text-white">{title}</h2>
+            {description ? (
+              <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">{description}</p>
+            ) : null}
+          </div>
+          <button
+            onClick={onCancel}
+            className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className="p-3">
+            {/* Bulk controls + live count */}
+            <div className="flex items-center justify-between mb-2">
+              <span
+                className="text-sm font-medium text-gray-700 dark:text-gray-200"
+                data-testid="assessment-picker-count"
+              >
+                {selectedCount} of {total} selected
+              </span>
+              <span className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setSelectedIds(assessments.map((a) => a.id))}
+                  className="text-sm text-blue-600 dark:text-blue-300 hover:text-blue-500"
+                >
+                  Select all
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setSelectedIds([])}
+                  className="text-sm text-blue-600 dark:text-blue-300 hover:text-blue-500"
+                >
+                  Clear
+                </button>
+              </span>
+            </div>
+
+            {/* Pick list */}
+            <div
+              className="overflow-y-auto max-h-72 border border-gray-200 dark:border-gray-700 rounded-lg"
+              style={{ overflowY: 'auto', maxHeight: '18rem' }}
+            >
+              {total === 0 ? (
+                <p className="text-sm text-gray-600 dark:text-gray-300 p-3">
+                  No assessments to export yet.
+                </p>
+              ) : (
+                assessments.map((a) => (
+                  <label
+                    key={a.id}
+                    className="flex items-start gap-2 p-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
+                    style={{ cursor: 'pointer' }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.includes(a.id)}
+                      onChange={() => toggle(a.id)}
+                      style={{ marginTop: '0.2rem' }}
+                    />
+                    <span className="flex-1 min-w-0">
+                      <span className="block text-sm font-medium text-gray-900 dark:text-white">
+                        {a.name}
+                      </span>
+                      <span className="block text-xs text-gray-600 dark:text-gray-400">
+                        {(a.scopeIds || []).length} scoped item
+                        {(a.scopeIds || []).length === 1 ? '' : 's'}
+                      </span>
+                    </span>
+                  </label>
+                ))
+              )}
+            </div>
+
+            {isSubset ? (
+              <p
+                className="text-xs text-gray-600 dark:text-gray-400 mt-2"
+                data-testid="assessment-picker-subset-note"
+              >
+                Partial export: findings and evidence artifacts belonging to the
+                assessments you left out are excluded, and the filename is marked
+                <span className="font-medium"> _subset</span> so it is not mistaken
+                for a full backup. Records that belong to no assessment at all,
+                and org-level data (systems, metrics, the control catalogue),
+                still ride along.
+              </p>
+            ) : null}
+          </div>
+
+          {/* Footer */}
+          <div className="bg-gray-50 dark:bg-gray-900 border-t dark:border-gray-700 p-3 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors text-sm font-medium"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={noneSelected}
+              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
+              style={noneSelected ? { opacity: 0.5, cursor: 'not-allowed' } : undefined}
+            >
+              {confirmLabel}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+
+  return createPortal(modalContent, document.body);
+};
+
+export default AssessmentPicker;

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -16,6 +16,7 @@ import FindingSelector from '../components/FindingSelector';
 import ControlSelector from '../components/ControlSelector';
 import SortableHeader from '../components/SortableHeader';
 import ExportPasswordDialog from '../components/ExportPasswordDialog';
+import AssessmentPicker from '../components/AssessmentPicker';
 import EmptyState from '../components/EmptyState';
 import ScoreSelect from '../components/ScoreSelect';
 
@@ -119,6 +120,9 @@ const Assessments = () => {
   // Export (optional password protection)
   const [showExportPasswordDialog, setShowExportPasswordDialog] = useState(false);
   const [showSingleExportPasswordDialog, setShowSingleExportPasswordDialog] = useState(false);
+  const [showExportAssessmentPicker, setShowExportAssessmentPicker] = useState(false);
+  // Selection carried between the picker and the password dialog; null = all
+  const [exportAssessmentIds, setExportAssessmentIds] = useState(null);
 
   // Post-create platform-check picker (plan PR-7)
   const [showPlatformPicker, setShowPlatformPicker] = useState(false);
@@ -1009,32 +1013,62 @@ Format as a numbered list. Be specific and actionable.`;
     e.target.value = '';
   }, [importAssessmentsCSV]);
 
+  // Two-step export: pick the assessments, then set an optional password.
+  // The picker hands back null when everything is selected, which is the
+  // historical export-everything path unchanged.
   const handleExportAll = useCallback(() => {
+    // Nothing to choose with 0 or 1 assessments — go straight to the password
+    // step rather than showing a picker whose confirm is disabled at zero.
+    if (assessments.length <= 1) {
+      setExportAssessmentIds(null);
+      setShowExportPasswordDialog(true);
+      return;
+    }
+    setShowExportAssessmentPicker(true);
+  }, [assessments.length]);
+
+  const handleCancelExportPicker = useCallback(() => {
+    setShowExportAssessmentPicker(false);
+  }, []);
+
+  const handleConfirmExportPicker = useCallback((assessmentIds) => {
+    setShowExportAssessmentPicker(false);
+    setExportAssessmentIds(assessmentIds);
     setShowExportPasswordDialog(true);
   }, []);
 
   const handleCancelExportAll = useCallback(() => {
     setShowExportPasswordDialog(false);
+    setExportAssessmentIds(null);
   }, []);
 
   const handleConfirmExportAll = useCallback(async (password) => {
     setShowExportPasswordDialog(false);
+    const assessmentIds = exportAssessmentIds;
+    setExportAssessmentIds(null);
     try {
       const trimmed = (password || '').trim();
       await exportAllAssessmentsCSV(useControlsStore, useRequirementsStore, useUserStore, {
-        password: trimmed
+        password: trimmed,
+        assessmentIds
       });
-      toast.success(trimmed ? 'Assessments exported (encrypted)' : 'Assessments exported');
+      const scopeNote = assessmentIds ? ` (${assessmentIds.length} selected)` : '';
+      toast.success(trimmed
+        ? `Assessments exported (encrypted)${scopeNote}`
+        : `Assessments exported${scopeNote}`);
     } catch (err) {
       console.error('Assessment export error:', err);
       toast.error('Export failed. Please verify the file and try again.');
     }
-  }, [exportAllAssessmentsCSV]);
+  }, [exportAllAssessmentsCSV, exportAssessmentIds]);
 
   const handleDownloadTemplate = useCallback(() => {
     const templateData = [
       {
         'ID': 'GV.OC-01 Ex1',
+        // Reference text only — the exporters join it in from the framework
+        // catalogue on the ID key, and the importer ignores whatever is here.
+        'Implementation Example': 'Ex1: Share the organization\'s mission and vision statements with third parties who have a role in achieving the mission',
         'Assessment': '2025 Security Assessment',
         'Scope Type': 'controls',
         'Auditor': 'Auditor Name <auditor@example.com>',
@@ -1079,7 +1113,7 @@ Format as a numbered list. Be specific and actionable.`;
     ];
 
     const headers = [
-      'ID', 'Assessment', 'Scope Type', 'Auditor', 'Test Procedure(s)',
+      'ID', 'Implementation Example', 'Assessment', 'Scope Type', 'Auditor', 'Test Procedure(s)',
       'Q1 Actual Score', 'Q1 Target Score', 'Q1 Observations', 'Q1 Observation Date', 'Q1 Testing Status', 'Q1 Examine', 'Q1 Interview', 'Q1 Test',
       'Q2 Actual Score', 'Q2 Target Score', 'Q2 Observations', 'Q2 Observation Date', 'Q2 Testing Status', 'Q2 Examine', 'Q2 Interview', 'Q2 Test',
       'Q3 Actual Score', 'Q3 Target Score', 'Q3 Observations', 'Q3 Observation Date', 'Q3 Testing Status', 'Q3 Examine', 'Q3 Interview', 'Q3 Test',
@@ -1136,7 +1170,7 @@ Format as a numbered list. Be specific and actionable.`;
           <button
             className="flex items-center gap-2 bg-green-600 hover:bg-green-700 text-white py-2 px-4 rounded-lg"
             onClick={handleExportAll}
-            title="Export all assessments to CSV"
+            title="Choose assessments to export to CSV"
           >
             <Download size={16} />
             Export
@@ -2216,9 +2250,19 @@ Format as a numbered list. Be specific and actionable.`;
       {view === 'scope' && currentAssessment && renderScopeView()}
       {view === 'assess' && currentAssessment && renderAssessView()}
 
+      <AssessmentPicker
+        isOpen={showExportAssessmentPicker}
+        title="Export Assessments — choose which"
+        description="All assessments are selected by default. Narrow the list to export only the ones you need."
+        assessments={assessments}
+        onCancel={handleCancelExportPicker}
+        onConfirm={handleConfirmExportPicker}
+        confirmLabel="Continue"
+      />
+
       <ExportPasswordDialog
         isOpen={showExportPasswordDialog}
-        title="Export All Assessments"
+        title={exportAssessmentIds ? `Export ${exportAssessmentIds.length} Assessment${exportAssessmentIds.length === 1 ? '' : 's'}` : 'Export All Assessments'}
         description="Optionally set a password to encrypt the export before download."
         onCancel={handleCancelExportAll}
         onConfirm={handleConfirmExportAll}

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -37,6 +37,7 @@ import useMetricsStore from '../stores/metricsStore';
 import useOrgProfileStore from '../stores/orgProfileStore';
 import useInventoryStore from '../stores/inventoryStore';
 import OrgProfileWizard from '../components/OrgProfileWizard';
+import AssessmentPicker from '../components/AssessmentPicker';
 
 // Utils
 import { exportCompleteDatabase, exportAssessmentsJSON, exportShareableDatabase } from '../utils/dataExport';
@@ -104,6 +105,8 @@ const Settings = () => {
   const packImportRef = useRef(null);
   const [packPreview, setPackPreview] = useState(null); // { parsed, preview }
   const [includePackData, setIncludePackData] = useState(false);
+  // Which export is waiting on the assessment picker: 'complete' | 'assessments' | 'shareable' | null
+  const [pendingExport, setPendingExport] = useState(null);
   const metricsImportRef = useRef(null);
   const [metricsPreview, setMetricsPreview] = useState(null); // { validation, preview }
   const importedMetrics = useMetricsStore((s) => s.metrics);
@@ -118,30 +121,47 @@ const Settings = () => {
     return [...bySlug.values()].sort((a, b) => a.catalogSlug.localeCompare(b.catalogSlug));
   }, [importedMetrics]);
 
-  // Export handlers
-  const handleExportCompleteDatabase = useCallback(() => {
-    try {
-      exportCompleteDatabase({
-        controlsStore: useControlsStore,
-        assessmentsStore: useAssessmentsStore,
-        requirementsStore: useRequirementsStore,
-        frameworksStore: useFrameworksStore,
-        artifactStore: useArtifactStore,
-        userStore: useUserStore,
-        findingsStore: useFindingsStore,
-        metricsStore: useMetricsStore,
-        orgProfileStore: useOrgProfileStore,
-        inventoryStore: useInventoryStore
-      });
-      toast.success('Complete database exported as JSON');
-    } catch (err) {
-      console.error('Complete DB export error:', err);
-      toast.error('Export failed. Please try again.');
-    }
-  }, []);
+  // Export handlers.
+  //
+  // All three JSON exports route through AssessmentPicker first, so "export"
+  // means "export the assessments I chose" rather than "export everything".
+  // pendingExport names which one is waiting on the picker; the picker hands
+  // back `null` when every assessment is selected, and null flows straight
+  // through the export utils as "no narrowing".
+  const buildExportStores = useCallback(() => ({
+    controlsStore: useControlsStore,
+    assessmentsStore: useAssessmentsStore,
+    requirementsStore: useRequirementsStore,
+    frameworksStore: useFrameworksStore,
+    artifactStore: useArtifactStore,
+    userStore: useUserStore,
+    findingsStore: useFindingsStore,
+    metricsStore: useMetricsStore,
+    orgProfileStore: useOrgProfileStore,
+    inventoryStore: useInventoryStore
+  }), []);
 
-  const handleExportShareable = useCallback(() => {
+  const handleCancelExportPicker = useCallback(() => setPendingExport(null), []);
+
+  const runExport = useCallback((kind, assessmentIds) => {
+    if (!kind) return;
+
+    const scopeNote = assessmentIds ? ` (${assessmentIds.length} selected)` : '';
+
     try {
+      if (kind === 'complete') {
+        exportCompleteDatabase(buildExportStores(), { assessmentIds });
+        toast.success(`Complete database exported as JSON${scopeNote}`);
+        return;
+      }
+
+      if (kind === 'assessments') {
+        exportAssessmentsJSON(useAssessmentsStore, useControlsStore, useUserStore, { assessmentIds });
+        toast.success(`Assessments exported as JSON${scopeNote}`);
+        return;
+      }
+
+      // kind === 'shareable'
       if (includePackData) {
         const confirmed = window.confirm(
           'Include private pack data in this export?\n\n' +
@@ -152,26 +172,35 @@ const Settings = () => {
         );
         if (!confirmed) return;
       }
-      exportShareableDatabase({
-        controlsStore: useControlsStore,
-        assessmentsStore: useAssessmentsStore,
-        requirementsStore: useRequirementsStore,
-        frameworksStore: useFrameworksStore,
-        artifactStore: useArtifactStore,
-        userStore: useUserStore,
-        findingsStore: useFindingsStore,
-        metricsStore: useMetricsStore,
-        orgProfileStore: useOrgProfileStore,
-        inventoryStore: useInventoryStore
-      }, { includePrivate: includePackData });
+      exportShareableDatabase(buildExportStores(), {
+        includePrivate: includePackData,
+        assessmentIds
+      });
       toast.success(includePackData
-        ? 'Export created WITH private pack data — handle with care'
-        : 'Shareable export created (private pack data excluded)');
+        ? `Export created WITH private pack data — handle with care${scopeNote}`
+        : `Shareable export created (private pack data excluded)${scopeNote}`);
     } catch (err) {
-      console.error('Shareable export error:', err);
+      console.error(`${kind} export error:`, err);
       toast.error('Export failed. Please try again.');
     }
-  }, [includePackData]);
+  }, [includePackData, buildExportStores]);
+
+  // With 0 or 1 assessments there is nothing to choose, and a picker whose
+  // confirm is disabled at zero-selected would hard-block a brand-new user from
+  // exporting at all. Go straight to the export in that case.
+  const startExport = useCallback((kind) => {
+    if (assessments.length <= 1) {
+      runExport(kind, null);
+      return;
+    }
+    setPendingExport(kind);
+  }, [assessments.length, runExport]);
+
+  const handleConfirmExportPicker = useCallback((assessmentIds) => {
+    const kind = pendingExport;
+    setPendingExport(null);
+    runExport(kind, assessmentIds);
+  }, [pendingExport, runExport]);
 
   // Pack import — preview first, no writes until the user confirms.
   const handlePackFileSelected = useCallback(async (e) => {
@@ -281,16 +310,6 @@ const Settings = () => {
     }
   }, []);
 
-  const handleExportAssessments = useCallback(() => {
-    try {
-      exportAssessmentsJSON(useAssessmentsStore, useControlsStore, useUserStore);
-      toast.success('Assessments exported as JSON');
-    } catch (err) {
-      console.error('Export assessments error:', err);
-      toast.error('Export failed. Please try again.');
-    }
-  }, []);
-
   // Restore handler — full replace of store data from a complete-database export.
   const handleRestoreDatabase = useCallback(async (e) => {
     const file = e.target.files?.[0];
@@ -322,9 +341,19 @@ const Settings = () => {
         .map(([section, count]) => `${section}: ${count}`)
         .join(', ');
       const warningText = validation.warnings.length ? `\n\nNote: ${validation.warnings.join(' ')}` : '';
+      // Name the number about to be destroyed, computed against CURRENT state.
+      // "this file is a slice" is a fact about the file; "11 of your 12
+      // assessments will be deleted" is a fact about what is about to happen,
+      // and only the second one reliably stops a reflex click.
+      const selection = parsed.metadata?.assessmentSelection;
+      const losing = selection ? assessments.length - (validation.counts.assessments ?? 0) : 0;
+      const destructionText = losing > 0
+        ? `\n\n⚠ You currently have ${assessments.length} assessment${assessments.length === 1 ? '' : 's'}; ` +
+          `this file has ${validation.counts.assessments}. Restoring it DELETES ${losing} of yours.`
+        : '';
       const confirmed = window.confirm(
         `RESTORE DATABASE — this REPLACES your current data.\n\n` +
-        `File contains — ${summary}.${warningText}\n\n` +
+        `File contains — ${summary}.${warningText}${destructionText}\n\n` +
         `A backup download of your current data will be ATTEMPTED first ` +
         `(csf_pre_restore_*.backup.json) — browsers cannot guarantee it lands, ` +
         `so only continue if you also have a recent export of your own. Continue?`
@@ -337,7 +366,7 @@ const Settings = () => {
       console.error('Database restore error:', err);
       toast.error(err.message || 'Restore failed. Please verify the file and try again.');
     }
-  }, []);
+  }, [assessments.length]);
 
   // Get requirement count for each framework
   const getFrameworkStats = useCallback((frameworkId) => {
@@ -866,21 +895,21 @@ nist-csf-2.0,RECOVER (RC),Incident Recovery Plan Execution (RC.RP),RC.RP-01,The 
             <div className="flex flex-wrap gap-2">
               <button
                 className="btn-terminal"
-                onClick={handleExportCompleteDatabase}
+                onClick={() => startExport('complete')}
               >
                 <Download size={14} />
                 Complete Database
               </button>
               <button
                 className="btn-terminal"
-                onClick={handleExportAssessments}
+                onClick={() => startExport('assessments')}
               >
                 <Download size={14} />
                 Assessments Only
               </button>
               <button
                 className="btn-terminal"
-                onClick={handleExportShareable}
+                onClick={() => startExport('shareable')}
               >
                 <Download size={14} />
                 Shareable Copy
@@ -894,6 +923,13 @@ nist-csf-2.0,RECOVER (RC),Incident Recovery Plan Execution (RC.RP),RC.RP-01,The 
             </p>
             <p className="settings-section-desc mt-2">
               <strong>Shareable Copy:</strong> Same as Complete Database but excludes private data-pack records by default (csf_share_YYYY-MM-DD.json) — safe for demos and sharing
+            </p>
+            <p className="settings-section-desc mt-2">
+              <strong>Choosing assessments:</strong> every button above opens a picker with all
+              assessments selected. Leave it as-is for the usual full export, or narrow it to
+              export a slice. A slice drops the findings and evidence artifacts belonging to the
+              assessments you left out, and its filename is marked <code>_subset</code> so it is
+              never mistaken for a full backup at restore time.
             </p>
             <label className="flex items-center gap-2 settings-section-desc mt-2" style={{ cursor: 'pointer' }}>
               <input
@@ -1550,6 +1586,23 @@ nist-csf-2.0,RECOVER (RC),Incident Recovery Plan Execution (RC.RP),RC.RP-01,The 
       {showOrgProfileWizard && (
         <OrgProfileWizard onClose={() => setShowOrgProfileWizard(false)} />
       )}
+
+      <AssessmentPicker
+        isOpen={pendingExport !== null}
+        title={
+          pendingExport === 'complete' ? 'Complete Database — choose assessments'
+            : pendingExport === 'shareable' ? 'Shareable Copy — choose assessments'
+              : 'Assessments Only — choose assessments'
+        }
+        description={
+          pendingExport === 'complete'
+            ? 'Everything is selected by default, which produces the usual full backup. Narrow it to export a slice instead.'
+            : 'Everything is selected by default. Narrow it to export only the assessments you need.'
+        }
+        assessments={assessments}
+        onCancel={handleCancelExportPicker}
+        onConfirm={handleConfirmExportPicker}
+      />
     </div>
   );
 };

--- a/src/stores/assessmentsCsvImplementationExample.test.js
+++ b/src/stores/assessmentsCsvImplementationExample.test.js
@@ -1,0 +1,366 @@
+/**
+ * The `Implementation Example` column on the assessment CSV egresses.
+ *
+ * The `ID` column is the export's primary key and carries a bare requirement
+ * id (`GV.SC-04 Ex1`) — opaque on its own. This column joins the framework's
+ * example text in on that key so an exported assessment is readable without a
+ * second lookup, matching the reference workbook in GET_THE_SPREADSHEETS/.
+ *
+ * Four things are load-bearing and each gets its own test, so a mutant that
+ * breaks one fails here rather than in a user's spreadsheet:
+ *   1. the column exists and sits immediately after `ID` in BOTH exporters;
+ *   2. it resolves from requirementsStore, and is EMPTY (not a control's
+ *      `implementationDescription`) for controls-scoped assessments;
+ *   3. the formula guard fires, without the double-quoting that
+ *      escapeCSVValue would inflict at a Papa.unparse call site;
+ *   4. it is INERT on import — framework text never lands in observation
+ *      state, and a file carrying the column imports identically to one
+ *      without it.
+ *
+ * Capture harness mirrors assessmentsStore.egress.test.js: the exporters build
+ * a Blob and hand it to URL.createObjectURL, neither of which jsdom
+ * implements, so both are stubbed and the CSV is read back from the Blob parts.
+ */
+import useAssessmentsStore from './assessmentsStore';
+import useControlsStore from './controlsStore';
+import useRequirementsStore from './requirementsStore';
+import useUserStore from './userStore';
+
+const REQ_ID = 'GV.SC-04 Ex1';
+const EXAMPLE_TEXT =
+  'Ex1: Develop criteria for supplier criticality based on, for example, the sensitivity of data processed, and the importance of the products to the mission';
+// Leading `=` is the CSV-injection vector the guard exists to neutralize.
+const HOSTILE_ID = 'GV.SC-04 Ex2';
+const HOSTILE_TEXT = '=HYPERLINK("http://evil.example","click")';
+
+let captured;
+const OriginalBlob = global.Blob;
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+class CapturingBlob extends OriginalBlob {
+  constructor(parts, opts) {
+    super(parts, opts);
+    this.capturedParts = parts;
+  }
+}
+
+beforeAll(() => {
+  global.Blob = CapturingBlob;
+  URL.createObjectURL = (blob) => {
+    captured.push(blob);
+    return 'blob:test';
+  };
+  URL.revokeObjectURL = () => {};
+});
+
+afterAll(() => {
+  global.Blob = OriginalBlob;
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+});
+
+const capturedText = () => {
+  expect(captured.length).toBeGreaterThan(0);
+  return captured[captured.length - 1].capturedParts.map((p) => String(p)).join('');
+};
+
+/** Split a CSV header line on commas that are not inside double quotes. */
+const parseHeaderRow = (csv) => {
+  // Papa emits CRLF row terminators; drop the CR so cells compare cleanly.
+  const line = csv.split('\n')[0].replace(/\r$/, '');
+  const cells = [];
+  let cell = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+    } else if (ch === ',' && !inQuotes) {
+      cells.push(cell);
+      cell = '';
+    } else {
+      cell += ch;
+    }
+  }
+  cells.push(cell);
+  return cells;
+};
+
+const createdIds = [];
+const makeAssessment = (scopeType, scopeIds) => {
+  const store = useAssessmentsStore.getState();
+  const created = store.createAssessment({
+    name: `Impl example ${scopeType} assessment`,
+    scopeType
+  });
+  createdIds.push(created.id);
+  scopeIds.forEach((id) => store.addToScope(created.id, id));
+  return created.id;
+};
+
+beforeEach(() => {
+  captured = [];
+  useRequirementsStore.getState().setRequirements([
+    {
+      id: REQ_ID,
+      frameworkId: 'nist-csf-2.0',
+      function: 'GOVERN (GV)',
+      category: 'Cybersecurity Supply Chain Risk Management (GV.SC)',
+      subcategoryId: 'GV.SC-04',
+      subcategoryDescription: 'Suppliers are known and prioritized by criticality',
+      implementationExample: EXAMPLE_TEXT,
+      inScope: true
+    },
+    {
+      id: HOSTILE_ID,
+      frameworkId: 'nist-csf-2.0',
+      subcategoryId: 'GV.SC-04',
+      implementationExample: HOSTILE_TEXT,
+      inScope: true
+    }
+  ]);
+});
+
+afterEach(() => {
+  const store = useAssessmentsStore.getState();
+  store.setAssessments(store.assessments.filter((a) => !createdIds.includes(a.id)));
+  createdIds.length = 0;
+  useRequirementsStore.getState().setRequirements([]);
+});
+
+describe('column shape', () => {
+  test('exportAssessmentCSV places Implementation Example immediately after ID', async () => {
+    const id = makeAssessment('requirements', [REQ_ID]);
+    await useAssessmentsStore
+      .getState()
+      .exportAssessmentCSV(id, useControlsStore, useRequirementsStore, useUserStore);
+
+    const headers = parseHeaderRow(capturedText());
+    expect(headers[0]).toBe('ID');
+    expect(headers[1]).toBe('Implementation Example');
+  });
+
+  test('exportAllAssessmentsCSV places Implementation Example immediately after ID', async () => {
+    makeAssessment('requirements', [REQ_ID]);
+    await useAssessmentsStore
+      .getState()
+      .exportAllAssessmentsCSV(useControlsStore, useRequirementsStore, useUserStore);
+
+    const headers = parseHeaderRow(capturedText());
+    expect(headers[0]).toBe('ID');
+    expect(headers[1]).toBe('Implementation Example');
+  });
+
+  test('no pre-existing column is dropped or reordered by the insertion', async () => {
+    const id = makeAssessment('requirements', [REQ_ID]);
+    await useAssessmentsStore
+      .getState()
+      .exportAssessmentCSV(id, useControlsStore, useRequirementsStore, useUserStore);
+
+    const headers = parseHeaderRow(capturedText());
+    // The pre-change header list, with the new column spliced in at index 1.
+    expect(headers).toEqual([
+      'ID',
+      'Implementation Example',
+      'Assessment',
+      'Scope Type',
+      'Scoring Scale',
+      'Auditor',
+      'Test Procedure(s)',
+      ...['Q1', 'Q2', 'Q3', 'Q4'].flatMap((q) => [
+        `${q} Actual Score`,
+        `${q} Target Score`,
+        `${q} Observations`,
+        `${q} Observation Date`,
+        `${q} Testing Status`,
+        `${q} Examine`,
+        `${q} Interview`,
+        `${q} Test`
+      ]),
+      'Linked Artifacts',
+      'Remediation Owner',
+      'Action Plan',
+      'Remediation Due Date'
+    ]);
+  });
+
+  test('exportAllAssessmentsCSV keeps Description and Framework Filter in place', async () => {
+    makeAssessment('requirements', [REQ_ID]);
+    await useAssessmentsStore
+      .getState()
+      .exportAllAssessmentsCSV(useControlsStore, useRequirementsStore, useUserStore);
+
+    const headers = parseHeaderRow(capturedText());
+    expect(headers.slice(0, 7)).toEqual([
+      'ID',
+      'Implementation Example',
+      'Assessment',
+      'Description',
+      'Scope Type',
+      'Framework Filter',
+      'Scoring Scale'
+    ]);
+  });
+});
+
+describe('the Jira egresses are deliberately excluded', () => {
+  // exportForJiraCSV/exportAllForJiraCSV emit a Jira issue-import schema
+  // consumed by a machine, not the human-readable workbook schema. Padding
+  // every issue with NIST reference prose would bloat descriptions and add a
+  // custom field nobody mapped. Pinned as an invariant rather than left as a
+  // comment, so the next person adding a column can tell "deliberately
+  // excluded" from "missed".
+  test('exportForJiraCSV does not gain the column', async () => {
+    const id = makeAssessment('requirements', [REQ_ID]);
+    await useAssessmentsStore
+      .getState()
+      .exportForJiraCSV(id, useControlsStore, useRequirementsStore, useUserStore);
+
+    const csv = capturedText();
+    expect(parseHeaderRow(csv)).not.toContain('Implementation Example');
+    expect(csv).not.toContain(EXAMPLE_TEXT);
+  });
+
+  test('exportAllForJiraCSV does not gain the column', async () => {
+    makeAssessment('requirements', [REQ_ID]);
+    await useAssessmentsStore
+      .getState()
+      .exportAllForJiraCSV(useControlsStore, useRequirementsStore, useUserStore);
+
+    const csv = capturedText();
+    expect(parseHeaderRow(csv)).not.toContain('Implementation Example');
+    expect(csv).not.toContain(EXAMPLE_TEXT);
+  });
+});
+
+describe('value resolution', () => {
+  test('resolves the requirement implementationExample onto the matching row', async () => {
+    const id = makeAssessment('requirements', [REQ_ID]);
+    await useAssessmentsStore
+      .getState()
+      .exportAssessmentCSV(id, useControlsStore, useRequirementsStore, useUserStore);
+
+    const csv = capturedText();
+    expect(csv).toContain(EXAMPLE_TEXT);
+  });
+
+  test('emits the text exactly once per row — not double-quoted by escapeCSVValue', async () => {
+    const id = makeAssessment('requirements', [REQ_ID]);
+    await useAssessmentsStore
+      .getState()
+      .exportAssessmentCSV(id, useControlsStore, useRequirementsStore, useUserStore);
+
+    const csv = capturedText();
+    // escapeCSVValue would have wrapped the value itself, and Papa would then
+    // quote the quotes — the tell is a `""` doubling around the cell.
+    expect(csv).not.toContain(`""${EXAMPLE_TEXT}""`);
+    expect(csv).toContain(`"${EXAMPLE_TEXT}"`);
+  });
+
+  test('neutralizes a formula-leading example with the guard prefix', async () => {
+    const id = makeAssessment('requirements', [HOSTILE_ID]);
+    await useAssessmentsStore
+      .getState()
+      .exportAssessmentCSV(id, useControlsStore, useRequirementsStore, useUserStore);
+
+    const csv = capturedText();
+    // Papa doubles the inner quotes; the guard's leading apostrophe is what
+    // stops Excel evaluating the cell, and it must sit before the `=`.
+    const papaQuoted = HOSTILE_TEXT.replace(/"/g, '""');
+    expect(csv).toContain(`"'${papaQuoted}"`);
+    // The raw formula must never open a cell.
+    expect(csv).not.toContain(`,${HOSTILE_TEXT}`);
+    expect(csv).not.toContain(`,"${papaQuoted}`);
+  });
+
+  test('controls-scoped rows get an empty cell, not a control implementationDescription', async () => {
+    const controls = useControlsStore.getState();
+    const control = controls.createControl({
+      controlId: 'CTL-IMPL-EX-1',
+      name: 'Supplier criticality control',
+      implementationDescription: 'A control implementation description that must NOT be relabelled'
+    });
+    // Controls are keyed by controlId, not a surrogate id.
+    const id = makeAssessment('controls', [control.controlId]);
+
+    await useAssessmentsStore
+      .getState()
+      .exportAssessmentCSV(id, useControlsStore, useRequirementsStore, useUserStore);
+
+    const csv = capturedText();
+    expect(csv).not.toContain('must NOT be relabelled');
+    // ID cell, then an empty Implementation Example cell.
+    expect(csv.split('\n')[1]).toMatch(/^CTL-IMPL-EX-1,,/);
+
+    controls.deleteControl(control.controlId);
+  });
+});
+
+describe('import treats the column as inert framework data', () => {
+  const QUARTER_COLUMNS = ['Q1', 'Q2', 'Q3', 'Q4']
+    .flatMap((q) => [
+      `${q} Actual Score`,
+      `${q} Target Score`,
+      `${q} Observations`,
+      `${q} Observation Date`,
+      `${q} Testing Status`,
+      `${q} Examine`,
+      `${q} Interview`,
+      `${q} Test`
+    ]);
+
+  const quarterValues = ['3', '4', 'note', '2025-01-15', 'Complete', 'Yes', 'No', 'Yes'];
+  const rowTail = ['Q1', 'Q2', 'Q3', 'Q4'].flatMap(() => quarterValues).join(',');
+
+  const withColumn = [
+    `ID,Implementation Example,Assessment,Scope Type,Auditor,Test Procedure(s),${QUARTER_COLUMNS.join(',')}`,
+    `${REQ_ID},"${EXAMPLE_TEXT}",Imported Assessment,requirements,Ann Auditor,Review docs,${rowTail}`
+  ].join('\n');
+
+  const withoutColumn = [
+    `ID,Assessment,Scope Type,Auditor,Test Procedure(s),${QUARTER_COLUMNS.join(',')}`,
+    `${REQ_ID},Imported Assessment,requirements,Ann Auditor,Review docs,${rowTail}`
+  ].join('\n');
+
+  const importAndTake = async (csv) => {
+    const store = useAssessmentsStore.getState();
+    const before = new Set(store.assessments.map((a) => a.id));
+    await store.importAssessmentsCSV(csv, useUserStore);
+    const after = useAssessmentsStore.getState().assessments;
+    const imported = after.filter((a) => !before.has(a.id));
+    imported.forEach((a) => createdIds.push(a.id));
+    expect(imported).toHaveLength(1);
+    return imported[0];
+  };
+
+  test('a CSV carrying the column imports without throwing', async () => {
+    const imported = await importAndTake(withColumn);
+    expect(imported.scopeIds).toEqual([REQ_ID]);
+  });
+
+  test('observations are identical with and without the column', async () => {
+    const a = await importAndTake(withColumn);
+    const b = await importAndTake(withoutColumn);
+    expect(a.observations).toEqual(b.observations);
+  });
+
+  test('the framework text never lands in observation state', async () => {
+    const imported = await importAndTake(withColumn);
+    const obs = imported.observations[REQ_ID];
+    expect(obs).toBeDefined();
+    expect(obs).not.toHaveProperty('implementationExample');
+    expect(JSON.stringify(obs)).not.toContain('Develop criteria for supplier criticality');
+  });
+
+  test('export then import round-trips scopeIds exactly', async () => {
+    const sourceId = makeAssessment('requirements', [REQ_ID, HOSTILE_ID]);
+    await useAssessmentsStore
+      .getState()
+      .exportAssessmentCSV(sourceId, useControlsStore, useRequirementsStore, useUserStore);
+
+    const imported = await importAndTake(capturedText());
+    const source = useAssessmentsStore.getState().getAssessment(sourceId);
+    expect(imported.scopeIds).toEqual(source.scopeIds);
+  });
+});

--- a/src/stores/assessmentsStore.js
+++ b/src/stores/assessmentsStore.js
@@ -3,7 +3,7 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 import { quotaSafeLocalStorage } from '../utils/safeStorage';
 import Papa from 'papaparse';
 import { v4 as uuidv4 } from 'uuid';
-import { sanitizeInput, escapeCSVValue } from '../utils/sanitize';
+import { sanitizeInput, escapeCSVValue, csvFormulaGuard } from '../utils/sanitize';
 import { normalizeExternalTracking, normalizeExternalLinks } from '../utils/externalLinks';
 import { buildEncryptedFilename, encryptBytesWithPassword } from '../utils/exportEncryption';
 import {
@@ -76,6 +76,29 @@ const createDefaultQuarters = () => ({
   Q3: createDefaultQuarter(),
   Q4: createDefaultQuarter()
 });
+
+/**
+ * The framework's implementation-example text for a scope item, keyed on the
+ * same requirement id the CSV's `ID` column carries (`GV.SC-04 Ex1`). The `ID`
+ * alone is opaque — this column is what makes an exported assessment readable
+ * without a second lookup against the framework catalogue, matching the
+ * reference workbook in GET_THE_SPREADSHEETS/.
+ *
+ * Read-only FRAMEWORK data, not observation data. It is exported for
+ * readability and deliberately ignored by importAssessmentsCSV: writing it
+ * back would fork the NIST text into a second, divergent copy living inside
+ * user-owned observation state.
+ *
+ * Controls-scoped assessments get an empty cell rather than a control's
+ * `implementationDescription` — those are different things (the reference
+ * workbook carries both as separate columns), and emitting one under the
+ * other's header would mislabel it.
+ */
+const getRequirementImplementationExample = (assessment, requirementsStore, itemId) => {
+  if (assessment?.scopeType === 'controls') return '';
+  const req = requirementsStore?.getState?.()?.getRequirement?.(itemId);
+  return req?.implementationExample || '';
+};
 
 // Helper to migrate old observation format to new quarterly format
 const migrateObservationToQuarterly = (oldObs) => {
@@ -1055,6 +1078,9 @@ const useAssessmentsStore = create(
           }
         };
 
+        const getImplementationExample = (itemId) =>
+          getRequirementImplementationExample(assessment, requirementsStore, itemId);
+
         const csvData = assessment.scopeIds.map(itemId => {
           const rawObs = assessment.observations[itemId] || {};
           const obs = rawObs.quarters ? rawObs : migrateObservationToQuarterly(rawObs) || { quarters: createDefaultQuarters() };
@@ -1062,6 +1088,10 @@ const useAssessmentsStore = create(
 
           const row = {
             'ID': escapeCSVValue(getItemName(itemId)),
+            // csvFormulaGuard, not escapeCSVValue: this is long free prose that
+            // routinely contains commas and apostrophes, and escapeCSVValue
+            // wraps-and-quotes on top of Papa's own quoting (see sanitize.js).
+            'Implementation Example': csvFormulaGuard(getImplementationExample(itemId)),
             'Assessment': escapeCSVValue(assessment.name),
             'Scope Type': escapeCSVValue(assessment.scopeType),
             'Scoring Scale': assessment.scoringScale === 5 ? 5 : 10,
@@ -1145,6 +1175,15 @@ const useAssessmentsStore = create(
       },
 
       // Import assessments from CSV with quarterly columns support
+      //
+      // The `Implementation Example` column the exporters emit is READ ON
+      // PURPOSE BY NOTHING here. It is framework reference text owned by
+      // requirementsStore (loaded from Confluence-Requirements.csv), joined
+      // into the export on the `ID` key for readability. Round-tripping it
+      // into observations[itemId] would create a second copy of the NIST text
+      // inside user data, free to diverge from the catalogue. Unknown columns
+      // are inert under Papa's header mode, so the file imports unchanged.
+      //
       // Supports both standard format AND Jira EVAL format:
       // - Jira Epic (Issue Type = "Epic") → React Assessment
       // - Jira Work paper with Parent/Parent key → React Observation within that Assessment
@@ -1732,8 +1771,13 @@ const useAssessmentsStore = create(
       },
 
       // Export all assessments to CSV with quarterly columns
-      exportAllAssessmentsCSV: async (controlsStore, requirementsStore, userStore, { password } = {}) => {
-        const assessments = get().assessments;
+      // `assessmentIds` narrows the export to a chosen subset; null/omitted
+      // keeps the historical export-everything behaviour byte-for-byte.
+      exportAllAssessmentsCSV: async (controlsStore, requirementsStore, userStore, { password, assessmentIds = null } = {}) => {
+        const allAssessments = get().assessments;
+        const wanted = Array.isArray(assessmentIds) ? new Set(assessmentIds) : null;
+        const assessments = wanted ? allAssessments.filter(a => wanted.has(a?.id)) : allAssessments;
+        const isSubset = assessments.length < allAssessments.length;
         if (assessments.length === 0) return;
 
         const users = userStore?.getState?.()?.users || [];
@@ -1756,6 +1800,9 @@ const useAssessmentsStore = create(
             }
           };
 
+          const getImplementationExample = (itemId) =>
+            getRequirementImplementationExample(assessment, requirementsStore, itemId);
+
           assessment.scopeIds.forEach(itemId => {
             const rawObs = assessment.observations[itemId] || {};
             const obs = rawObs.quarters ? rawObs : migrateObservationToQuarterly(rawObs) || { quarters: createDefaultQuarters() };
@@ -1763,6 +1810,9 @@ const useAssessmentsStore = create(
 
             const row = {
               'ID': escapeCSVValue(getItemName(itemId)),
+              // See the single-assessment exporter above for why this column
+              // uses csvFormulaGuard rather than escapeCSVValue.
+              'Implementation Example': csvFormulaGuard(getImplementationExample(itemId)),
               'Assessment': escapeCSVValue(assessment.name),
               'Description': escapeCSVValue(assessment.description || ''),
               'Scope Type': escapeCSVValue(assessment.scopeType),
@@ -1796,7 +1846,7 @@ const useAssessmentsStore = create(
 
         const csv = Papa.unparse(csvData);
         const date = new Date().toISOString().split('T')[0];
-        const baseFilename = `assessments_${date}.csv`;
+        const baseFilename = `assessments${isSubset ? '_subset' : ''}_${date}.csv`;
 
         let blob;
         let filename;

--- a/src/utils/assessmentSelection.js
+++ b/src/utils/assessmentSelection.js
@@ -1,0 +1,171 @@
+/**
+ * Assessment selection — narrowing an export envelope to a chosen subset of
+ * assessments.
+ *
+ * Design note (why this is a separate module and not a flag threaded through
+ * dataExport.js): selection is not a different KIND of export. Every export
+ * path already produces the same envelope shape — `exportAllDataJSON` builds
+ * it, `buildShareableExport` runs the privacy fold over it. Selection is a
+ * pure narrowing of ONE array plus the records that hang off it, so it runs
+ * LAST, over whatever the previous stage produced.
+ *
+ * That ordering is deliberate and load-bearing: the share fold
+ * (shareRegistry.js) is the privacy boundary and stays untouched. Filtering
+ * afterwards can only ever remove more records, never re-admit one the fold
+ * dropped, so no share guarantee is in the blast radius of this file.
+ *
+ * The no-op contract matters just as much: with no selection — or with every
+ * assessment selected — the envelope is returned by reference, unchanged. The
+ * default export path is therefore byte-identical to the pre-selection
+ * behaviour, which is what keeps the golden snapshots honest.
+ */
+
+/**
+ * EXHAUSTIVE section disposition. Every top-level key an export envelope can
+ * carry is classified here, and `sectionDispositionGaps()` fails loudly when a
+ * new section appears that nobody classified — silence in the share path is a
+ * silent disclosure, so drift must be noisy.
+ *
+ *  narrow      — the selection itself
+ *  cascade     — owned by an assessment via `assessmentId`, follows it out
+ *  keep-whole  — carries no assessment linkage; a subset that dropped it would
+ *                not open (catalogue) or would break restore (directory)
+ *
+ * Why metrics / systems / orgProfile are keep-whole and not cascade: none of
+ * the three carries an `assessmentId` — verified against metricsStore,
+ * inventoryStore and orgProfileStore. They are org-level, not assessment-level,
+ * so there is no correct way to attribute them to a selection. Their PRIVACY
+ * is a separate question already answered upstream by the share fold
+ * (shareRegistry.js): metrics are license-gated and private-by-lineage,
+ * systems are OMITted by default, and orgProfile is stripped unconditionally.
+ * Narrowing here would duplicate that boundary, not strengthen it.
+ */
+export const SECTION_DISPOSITION = {
+  assessments: 'narrow',
+  findings: 'cascade',
+  artifacts: 'cascade',
+  users: 'keep-whole',
+  controls: 'keep-whole',
+  requirements: 'keep-whole',
+  frameworks: 'keep-whole',
+  metrics: 'keep-whole',
+  systems: 'keep-whole',
+  orgProfile: 'keep-whole'
+};
+
+/**
+ * Top-level `data` keys present in `envelope` that SECTION_DISPOSITION does not
+ * classify. Non-empty means a section was added without a selection decision.
+ */
+export const sectionDispositionGaps = (envelope) =>
+  Object.keys(envelope?.data || {}).filter((k) => !(k in SECTION_DISPOSITION));
+
+/**
+ * True when `ids` asks for a strict subset of the assessments in `envelope`.
+ * A null/empty selection, or one covering everything present, is not a subset.
+ */
+const isSubsetSelection = (envelope, ids) => {
+  if (!Array.isArray(ids)) return false;
+  const present = envelope?.data?.assessments;
+  if (!Array.isArray(present)) return false;
+  const wanted = new Set(ids);
+  const kept = present.filter((a) => wanted.has(a?.id));
+  return kept.length < present.length;
+};
+
+/**
+ * A record belongs to the selection when it points at a selected assessment.
+ * Records with no `assessmentId` at all are UNASSIGNED, not orphaned — they
+ * were never owned by any assessment, so narrowing the assessment list is not
+ * a reason to drop them (same rule ArtifactSelector uses when it scopes a
+ * pick list: `belongsToAssessment(a, id) || isUnassigned(a)`).
+ */
+const belongsToSelection = (record, wanted) => {
+  const id = record?.assessmentId;
+  if (!id) return true;
+  return wanted.has(id);
+};
+
+/**
+ * Narrow a complete/shareable export envelope to a chosen set of assessments.
+ *
+ * Sections narrowed:
+ *  - `assessments` — kept in store order, exactly the selected IDs
+ *  - `findings`    — dropped when they point at an unselected assessment
+ *  - `artifacts`   — same rule; unassigned artifacts are retained
+ *
+ * Sections deliberately left whole:
+ *  - `users` — the directory is referenced by remediation owners and auditor
+ *    stamps across records this filter does not inspect; narrowing it would
+ *    turn a restore into a dangling-reference hunt. The per-assessment roster
+ *    (`assessment.users`) already rides inside each kept assessment.
+ *  - `controls` / `requirements` / `frameworks` — the catalogue the scope IDs
+ *    resolve against. A subset export that dropped them would not open.
+ *
+ * @param {Object} envelope - Envelope from exportAllDataJSON / buildShareableExport
+ * @param {string[]|null} [assessmentIds] - Selected assessment IDs; null/omitted = all
+ * @returns {Object} The same envelope (by reference) when no subset is asked
+ *   for, otherwise a new envelope — the input is never mutated.
+ */
+export const filterExportByAssessments = (envelope, assessmentIds = null) => {
+  if (!isSubsetSelection(envelope, assessmentIds)) return envelope;
+
+  const wanted = new Set(assessmentIds);
+  const data = envelope.data;
+
+  const assessments = data.assessments.filter((a) => wanted.has(a?.id));
+
+  const next = { ...envelope, data: { ...data } };
+  next.data.assessments = assessments;
+
+  // Unassigned records ride along, so their count is reported rather than left
+  // implicit — a share recipient should be able to see that the file carries
+  // records belonging to no assessment at all.
+  const unassigned = {};
+  const cascade = (key) => {
+    // Share exports DELETE sections rather than emptying them, so a section may
+    // legitimately be absent here — guard, don't resurrect it as [].
+    if (!Array.isArray(data[key])) return;
+    next.data[key] = data[key].filter((r) => belongsToSelection(r, wanted));
+    const n = next.data[key].filter((r) => !r?.assessmentId).length;
+    if (n > 0) unassigned[key] = n;
+  };
+  cascade('findings');
+  cascade('artifacts');
+
+  next.metadata = {
+    ...(envelope.metadata || {}),
+    assessmentCount: assessments.length,
+    findingCount: Array.isArray(next.data.findings)
+      ? next.data.findings.length
+      : (envelope.metadata?.findingCount ?? 0),
+    // The provenance stamp a restore reads to warn that this file is a slice,
+    // not a backup (dataImport.validateDatabaseExport).
+    assessmentSelection: {
+      selectedIds: assessments.map((a) => a.id),
+      selectedCount: assessments.length,
+      totalCount: data.assessments.length,
+      // Records kept because they belong to NO assessment. Records pointing at
+      // an assessment that is not selected — including one that no longer
+      // exists — are dropped; only a null/absent link means "unassigned".
+      includedUnassigned: unassigned
+    }
+  };
+
+  next.dataType = `${envelope.dataType} — selected assessments only`;
+
+  return next;
+};
+
+/**
+ * Filename marker for a subset export. Complete backups and slices must not
+ * share a filename shape: `csf_assessment_*.json` is what the restore control
+ * accepts, and a slice restored as a backup silently deletes the assessments
+ * it left behind.
+ */
+export const isSubsetOf = (allAssessments, assessmentIds) =>
+  Array.isArray(assessmentIds) &&
+  Array.isArray(allAssessments) &&
+  assessmentIds.length < allAssessments.length;
+
+export default filterExportByAssessments;

--- a/src/utils/assessmentSelection.test.js
+++ b/src/utils/assessmentSelection.test.js
@@ -1,0 +1,214 @@
+/**
+ * Selective export — the pure narrowing layer.
+ *
+ * Every assertion here drives the PRODUCTION function; none re-implements the
+ * filter. The no-op contract (ISC-1079/1090) is the one that keeps every
+ * existing export test and golden snapshot honest, so it is tested by identity
+ * (===), not by deep equality.
+ */
+
+import {
+  filterExportByAssessments,
+  isSubsetOf,
+  SECTION_DISPOSITION,
+  sectionDispositionGaps
+} from './assessmentSelection';
+
+const envelope = () => ({
+  exportDate: '2026-07-31T00:00:00.000Z',
+  dataType: 'Complete Assessment Database',
+  formatVersion: 6,
+  metadata: {
+    assessmentCount: 3,
+    findingCount: 4,
+    userCount: 2
+  },
+  data: {
+    assessments: [
+      { id: 'ASM-a', name: 'Alpha', scopeIds: ['GV.OC-01 Ex1'] },
+      { id: 'ASM-b', name: 'Bravo', scopeIds: ['ID.AM-01 Ex1'] },
+      { id: 'ASM-c', name: 'Charlie', scopeIds: [] }
+    ],
+    findings: [
+      { id: 'F1', assessmentId: 'ASM-a' },
+      { id: 'F2', assessmentId: 'ASM-b' },
+      { id: 'F3', assessmentId: 'ASM-c' },
+      { id: 'F4' } // unassigned
+    ],
+    artifacts: [
+      { id: 'AR1', assessmentId: 'ASM-a' },
+      { id: 'AR2', assessmentId: 'ASM-c' },
+      { id: 'AR3', assessmentId: null } // unassigned
+    ],
+    users: [{ id: 1 }, { id: 2 }],
+    controls: [{ id: 'C1' }],
+    frameworks: [{ id: 'nist-csf-2.0' }]
+  }
+});
+
+describe('filterExportByAssessments — no-op contract', () => {
+  it('returns the SAME object when no selection is given', () => {
+    const env = envelope();
+    expect(filterExportByAssessments(env)).toBe(env);
+    expect(filterExportByAssessments(env, null)).toBe(env);
+  });
+
+  it('returns the SAME object when every assessment is selected', () => {
+    const env = envelope();
+    expect(filterExportByAssessments(env, ['ASM-a', 'ASM-b', 'ASM-c'])).toBe(env);
+  });
+
+  it('stamps no assessmentSelection on the default path', () => {
+    const env = envelope();
+    expect(filterExportByAssessments(env, null).metadata.assessmentSelection).toBeUndefined();
+  });
+});
+
+describe('filterExportByAssessments — narrowing', () => {
+  it('keeps exactly the selected assessments, in store order', () => {
+    const out = filterExportByAssessments(envelope(), ['ASM-c', 'ASM-a']);
+    expect(out.data.assessments.map((a) => a.id)).toEqual(['ASM-a', 'ASM-c']);
+  });
+
+  it('drops findings pointing at an unselected assessment', () => {
+    const out = filterExportByAssessments(envelope(), ['ASM-a']);
+    expect(out.data.findings.map((f) => f.id)).toEqual(['F1', 'F4']);
+  });
+
+  it('drops artifacts pointing at an unselected assessment, keeping unassigned ones', () => {
+    const out = filterExportByAssessments(envelope(), ['ASM-a']);
+    expect(out.data.artifacts.map((a) => a.id)).toEqual(['AR1', 'AR3']);
+  });
+
+  it('leaves the user directory and the catalogue whole', () => {
+    const out = filterExportByAssessments(envelope(), ['ASM-a']);
+    expect(out.data.users).toHaveLength(2);
+    expect(out.data.controls).toHaveLength(1);
+    expect(out.data.frameworks).toHaveLength(1);
+  });
+
+  it('recomputes the metadata counts to match the filtered arrays', () => {
+    const out = filterExportByAssessments(envelope(), ['ASM-a', 'ASM-b']);
+    expect(out.metadata.assessmentCount).toBe(out.data.assessments.length);
+    expect(out.metadata.findingCount).toBe(out.data.findings.length);
+    expect(out.metadata.userCount).toBe(2); // untouched
+  });
+
+  it('stamps the selection provenance a restore can warn on', () => {
+    const out = filterExportByAssessments(envelope(), ['ASM-b']);
+    expect(out.metadata.assessmentSelection).toEqual({
+      selectedIds: ['ASM-b'],
+      selectedCount: 1,
+      totalCount: 3,
+      includedUnassigned: { findings: 1, artifacts: 1 }
+    });
+  });
+
+  it('marks the dataType so a human reading the file sees it is a slice', () => {
+    const out = filterExportByAssessments(envelope(), ['ASM-b']);
+    expect(out.dataType).toBe('Complete Assessment Database — selected assessments only');
+  });
+
+  it('never mutates the caller envelope', () => {
+    const env = envelope();
+    const before = JSON.stringify(env);
+    filterExportByAssessments(env, ['ASM-a']);
+    expect(JSON.stringify(env)).toBe(before);
+  });
+
+  it('tolerates sections the share fold deleted', () => {
+    const env = envelope();
+    delete env.data.artifacts;
+    delete env.data.users;
+    const out = filterExportByAssessments(env, ['ASM-a']);
+    expect(out.data.artifacts).toBeUndefined();
+    expect(out.data.users).toBeUndefined();
+    expect(out.data.assessments.map((a) => a.id)).toEqual(['ASM-a']);
+  });
+
+  it('handles an empty selection as "keep nothing"', () => {
+    const out = filterExportByAssessments(envelope(), []);
+    expect(out.data.assessments).toEqual([]);
+    expect(out.metadata.assessmentSelection.selectedCount).toBe(0);
+  });
+});
+
+describe('orphans vs unassigned', () => {
+  it('drops records pointing at an assessment that no longer exists', () => {
+    const env = envelope();
+    env.data.findings.push({ id: 'F-orphan', assessmentId: 'ASM-deleted' });
+    const out = filterExportByAssessments(env, ['ASM-a']);
+    expect(out.data.findings.map((f) => f.id)).not.toContain('F-orphan');
+  });
+
+  it('reports how many unassigned records rode along', () => {
+    const out = filterExportByAssessments(envelope(), ['ASM-a']);
+    expect(out.metadata.assessmentSelection.includedUnassigned).toEqual({
+      findings: 1, // F4
+      artifacts: 1 // AR3
+    });
+  });
+
+  it('reports an empty object when nothing unassigned rode along', () => {
+    const env = envelope();
+    env.data.findings = env.data.findings.filter((f) => f.assessmentId);
+    env.data.artifacts = env.data.artifacts.filter((a) => a.assessmentId);
+    const out = filterExportByAssessments(env, ['ASM-a']);
+    expect(out.metadata.assessmentSelection.includedUnassigned).toEqual({});
+  });
+});
+
+describe('no excluded assessment id survives anywhere in the payload', () => {
+  // The single strongest probe: scan the whole serialized subset for any id
+  // that was NOT selected. A string scan catches dangling pointers inside
+  // kept-whole sections, transitive children, and any section added later —
+  // classes of leak that per-collection assertions cannot see.
+  it('finds zero references to an excluded assessment', () => {
+    const out = filterExportByAssessments(envelope(), ['ASM-a']);
+    const wire = JSON.stringify(out);
+    expect(wire).not.toContain('ASM-b');
+    expect(wire).not.toContain('ASM-c');
+    expect(wire).toContain('ASM-a');
+  });
+
+  it('catches a dangling pointer planted in a kept-whole section', () => {
+    const env = envelope();
+    // A user record that remembers the last assessment they opened: exactly
+    // the shape of leak the per-collection assertions would miss.
+    env.data.users[0].lastAssessmentId = 'ASM-b';
+    const out = filterExportByAssessments(env, ['ASM-a']);
+    // Documents current behaviour: kept-whole sections are NOT scrubbed, so
+    // this scan is the tripwire that makes such a field a conscious decision
+    // rather than a silent disclosure.
+    expect(JSON.stringify(out)).toContain('ASM-b');
+  });
+});
+
+describe('section disposition is exhaustive', () => {
+  it('classifies every section a real envelope carries', () => {
+    expect(sectionDispositionGaps(envelope())).toEqual([]);
+  });
+
+  it('flags a section nobody classified', () => {
+    const env = envelope();
+    env.data.riskRegister = [];
+    expect(sectionDispositionGaps(env)).toEqual(['riskRegister']);
+  });
+
+  it('classifies each section as narrow, cascade, or keep-whole', () => {
+    Object.values(SECTION_DISPOSITION).forEach((d) => {
+      expect(['narrow', 'cascade', 'keep-whole']).toContain(d);
+    });
+  });
+});
+
+describe('isSubsetOf', () => {
+  it('is false for no selection and for a full selection', () => {
+    expect(isSubsetOf([{ id: 'a' }, { id: 'b' }], null)).toBe(false);
+    expect(isSubsetOf([{ id: 'a' }, { id: 'b' }], ['a', 'b'])).toBe(false);
+  });
+
+  it('is true for a strict subset', () => {
+    expect(isSubsetOf([{ id: 'a' }, { id: 'b' }], ['a'])).toBe(true);
+  });
+});

--- a/src/utils/dataExport.js
+++ b/src/utils/dataExport.js
@@ -5,6 +5,7 @@
  */
 
 import { SHARE_SECTIONS, OMIT, foldSection, buildShareContext } from './shareRegistry';
+import { filterExportByAssessments } from './assessmentSelection';
 
 /**
  * Export format version. Bump when the envelope shape changes and teach
@@ -201,13 +202,24 @@ export const buildShareableExport = (stores, { includePrivate = false } = {}) =>
 
 /**
  * Download a shareable export (csf_share_YYYY-MM-DD.json).
+ *
+ * Assessment selection runs AFTER the share fold, never before: the fold is
+ * the privacy boundary, and a post-fold narrowing can only remove more
+ * records, never re-admit one the fold dropped.
+ *
  * @param {Object} stores - All store references
  * @param {Object} [options] - See buildShareableExport
+ * @param {string[]|null} [options.assessmentIds] - Selected assessments; null = all
  */
 export const exportShareableDatabase = (stores, options = {}) => {
-  const jsonData = buildShareableExport(stores, options);
+  const { assessmentIds = null, ...shareOptions } = options;
+  const jsonData = filterExportByAssessments(
+    buildShareableExport(stores, shareOptions),
+    assessmentIds
+  );
   const date = new Date().toISOString().split('T')[0];
-  downloadJSON(jsonData, `csf_share_${date}.json`);
+  const subset = jsonData.metadata?.assessmentSelection ? '_subset' : '';
+  downloadJSON(jsonData, `csf_share${subset}_${date}.json`);
 };
 
 /**
@@ -231,35 +243,65 @@ export const downloadJSON = (jsonData, filename) => {
 };
 
 /**
- * Export all data with proper filename formatting
+ * Export all data with proper filename formatting.
+ *
+ * With a subset selected the file is named `csf_assessment_subset_*.json`, NOT
+ * `csf_assessment_*.json`. That distinction is load-bearing: the restore
+ * control performs a full replace, so a slice restored as a backup would
+ * silently delete the assessments it left behind. The filename, the dataType
+ * suffix, and `metadata.assessmentSelection` all say the same thing, and
+ * validateDatabaseExport turns the last one into a warning at restore time.
+ *
  * @param {Object} stores - All store references
+ * @param {Object} [options]
+ * @param {string[]|null} [options.assessmentIds] - Selected assessments; null = all
  */
-export const exportCompleteDatabase = (stores) => {
-  const jsonData = exportAllDataJSON(stores);
+export const exportCompleteDatabase = (stores, { assessmentIds = null } = {}) => {
+  const jsonData = filterExportByAssessments(exportAllDataJSON(stores), assessmentIds);
   const date = new Date().toISOString().split('T')[0];
-  const filename = `csf_assessment_${date}.json`;
-  downloadJSON(jsonData, filename);
+  const subset = jsonData.metadata?.assessmentSelection ? '_subset' : '';
+  downloadJSON(jsonData, `csf_assessment${subset}_${date}.json`);
 };
 
 /**
  * Export assessments data to JSON
  * @param {Object} assessmentsStore - The assessments store
  * @param {Object} controlsStore - The controls store (for context)
+ * @param {Object} userStore - The user store (auditor-name enrichment)
+ * @param {Object} [options]
+ * @param {string[]|null} [options.assessmentIds] - Selected assessments; null = all
  */
-export const exportAssessmentsJSON = (assessmentsStore, controlsStore, userStore) => {
+export const exportAssessmentsJSON = (
+  assessmentsStore,
+  controlsStore,
+  userStore,
+  { assessmentIds = null } = {}
+) => {
   const users = userStore?.getState?.()?.users || [];
   const getUserName = (userId) => {
     const user = users.find(u => u.id === userId);
     return user ? user.name : userId || '';
   };
 
-  const assessments = assessmentsStore?.getState?.()?.assessments || [];
+  const allAssessments = assessmentsStore?.getState?.()?.assessments || [];
+  const wanted = Array.isArray(assessmentIds) ? new Set(assessmentIds) : null;
+  const assessments = wanted ? allAssessments.filter(a => wanted.has(a?.id)) : allAssessments;
+  const isSubset = assessments.length < allAssessments.length;
   const date = new Date().toISOString().split('T')[0];
-  
+
   const jsonData = {
     exportDate: new Date().toISOString(),
-    dataType: 'Assessments',
+    dataType: isSubset ? 'Assessments — selected assessments only' : 'Assessments',
     count: assessments.length,
+    ...(isSubset
+      ? {
+          assessmentSelection: {
+            selectedIds: assessments.map(a => a.id),
+            selectedCount: assessments.length,
+            totalCount: allAssessments.length
+          }
+        }
+      : {}),
     assessments: assessments.map(a => ({
       ...a,
       // Enhance with user names for readability
@@ -273,5 +315,5 @@ export const exportAssessmentsJSON = (assessmentsStore, controlsStore, userStore
     }))
   };
 
-  downloadJSON(jsonData, `assessments_${date}.json`);
+  downloadJSON(jsonData, `assessments${isSubset ? '_subset' : ''}_${date}.json`);
 };

--- a/src/utils/dataImport.js
+++ b/src/utils/dataImport.js
@@ -136,6 +136,20 @@ export const validateDatabaseExport = (parsed) => {
     });
   }
 
+  // Selective exports (assessmentSelection.js) carry a provenance stamp. They
+  // are slices, not backups — and restore is a FULL REPLACE, so restoring one
+  // deletes every assessment the slice left behind. Warn, don't reject: a
+  // deliberate "give me only this assessment" restore is a legitimate move.
+  const selection = parsed.metadata?.assessmentSelection;
+  if (selection && typeof selection === 'object') {
+    const selected = selection.selectedCount ?? '?';
+    const total = selection.totalCount ?? '?';
+    warnings.push(
+      `This file is a SELECTIVE export (${selected} of ${total} assessments), not a complete backup. ` +
+      'Restoring it replaces all current data, so any assessment not in the file will be removed.'
+    );
+  }
+
   return { ok: errors.length === 0, errors, warnings, counts };
 };
 

--- a/src/utils/selectiveExport.test.js
+++ b/src/utils/selectiveExport.test.js
@@ -1,0 +1,235 @@
+/**
+ * Selective export — the wiring, driven end-to-end through the PRODUCTION
+ * export entry points (not re-implemented here).
+ *
+ * The download is intercepted at the URL/anchor layer so each test reads the
+ * bytes that would have hit disk plus the filename that would have been used —
+ * the filename is load-bearing (`_subset` is what stops a slice being mistaken
+ * for a backup), so it is asserted, not assumed.
+ */
+
+import {
+  exportCompleteDatabase,
+  exportShareableDatabase,
+  exportAssessmentsJSON
+} from './dataExport';
+import { validateDatabaseExport } from './dataImport';
+import { sectionDispositionGaps } from './assessmentSelection';
+
+// ---- download capture ------------------------------------------------------
+
+let captured;
+
+const asStore = (state) => ({ getState: () => state });
+
+const stores = () => ({
+  controlsStore: asStore({ controls: [{ id: 'C1', controlId: 'CTRL-1' }] }),
+  assessmentsStore: asStore({
+    assessments: [
+      { id: 'ASM-a', name: 'Alpha', scopeIds: ['GV.OC-01 Ex1'], observations: {} },
+      { id: 'ASM-b', name: 'Bravo', scopeIds: ['ID.AM-01 Ex1'], observations: {} }
+    ]
+  }),
+  requirementsStore: asStore({ requirements: [{ id: 'GV.OC-01 Ex1' }] }),
+  frameworksStore: asStore({ frameworks: [{ id: 'nist-csf-2.0' }] }),
+  artifactStore: asStore({
+    artifacts: [
+      { id: 'AR1', name: 'Alpha evidence', assessmentId: 'ASM-a' },
+      { id: 'AR2', name: 'Bravo evidence', assessmentId: 'ASM-b' }
+    ]
+  }),
+  userStore: asStore({ users: [{ id: 1, name: 'Auditor One' }] }),
+  findingsStore: asStore({
+    findings: [
+      { id: 'F1', assessmentId: 'ASM-a' },
+      { id: 'F2', assessmentId: 'ASM-b' }
+    ]
+  }),
+  metricsStore: asStore({ metrics: [] }),
+  orgProfileStore: asStore({ profile: null, cloudConsent: false }),
+  inventoryStore: asStore({ systems: [] })
+});
+
+const OriginalBlob = global.Blob;
+
+beforeEach(() => {
+  captured = { filename: null, text: null };
+
+  // jsdom Blobs expose no synchronous reader, so capture the parts the Blob is
+  // constructed from — the same idiom controlFields.test.js and
+  // assessmentsStore.egress.test.js already use.
+  global.Blob = function CapturingBlob(parts) {
+    captured.text = (parts || []).join('');
+    return { parts };
+  };
+  global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+  global.URL.revokeObjectURL = jest.fn();
+
+  jest.spyOn(document.body, 'appendChild').mockImplementation((node) => node);
+  jest.spyOn(document.body, 'removeChild').mockImplementation((node) => node);
+
+  const realCreate = document.createElement.bind(document);
+  jest.spyOn(document, 'createElement').mockImplementation((tag) => {
+    const el = realCreate(tag);
+    if (tag === 'a') {
+      el.click = jest.fn();
+      const realSetAttribute = el.setAttribute.bind(el);
+      el.setAttribute = (name, value) => {
+        if (name === 'download') captured.filename = value;
+        return realSetAttribute(name, value);
+      };
+    }
+    return el;
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  global.Blob = OriginalBlob;
+});
+
+const readDownload = () => JSON.parse(captured.text);
+
+// ---- complete database -----------------------------------------------------
+
+describe('exportCompleteDatabase', () => {
+  it('exports everything and keeps the backup filename when no selection is given', async () => {
+    exportCompleteDatabase(stores());
+    const out = readDownload();
+
+    expect(out.data.assessments.map((a) => a.id)).toEqual(['ASM-a', 'ASM-b']);
+    expect(captured.filename).toMatch(/^csf_assessment_\d{4}-\d{2}-\d{2}\.json$/);
+    expect(out.metadata.assessmentSelection).toBeUndefined();
+  });
+
+  it('narrows to the selected assessment and cascades findings and artifacts', async () => {
+    exportCompleteDatabase(stores(), { assessmentIds: ['ASM-a'] });
+    const out = readDownload();
+
+    expect(out.data.assessments.map((a) => a.id)).toEqual(['ASM-a']);
+    expect(out.data.findings.map((f) => f.id)).toEqual(['F1']);
+    expect(out.data.artifacts.map((a) => a.id)).toEqual(['AR1']);
+  });
+
+  it('marks a slice with a _subset filename so it cannot pass as a backup', () => {
+    exportCompleteDatabase(stores(), { assessmentIds: ['ASM-a'] });
+    expect(captured.filename).toMatch(/^csf_assessment_subset_\d{4}-\d{2}-\d{2}\.json$/);
+  });
+});
+
+// ---- shareable -------------------------------------------------------------
+
+describe('exportShareableDatabase', () => {
+  it('keeps the share filename and full assessment list by default', async () => {
+    exportShareableDatabase(stores());
+    const out = readDownload();
+
+    expect(out.data.assessments.map((a) => a.id)).toEqual(['ASM-a', 'ASM-b']);
+    expect(captured.filename).toMatch(/^csf_share_\d{4}-\d{2}-\d{2}\.json$/);
+  });
+
+  it('narrows the share export and marks it _subset', async () => {
+    exportShareableDatabase(stores(), { assessmentIds: ['ASM-b'] });
+    const out = readDownload();
+
+    expect(out.data.assessments.map((a) => a.id)).toEqual(['ASM-b']);
+    expect(captured.filename).toMatch(/^csf_share_subset_\d{4}-\d{2}-\d{2}\.json$/);
+  });
+
+  it('still applies the share fold — the user directory stays omitted', async () => {
+    exportShareableDatabase(stores(), { assessmentIds: ['ASM-b'] });
+    const out = readDownload();
+
+    // The privacy fold runs BEFORE narrowing, so its omissions survive it.
+    expect(out.data.users).toBeUndefined();
+  });
+});
+
+// ---- assessments-only ------------------------------------------------------
+
+describe('exportAssessmentsJSON', () => {
+  it('exports every assessment when no selection is given', async () => {
+    exportAssessmentsJSON(
+      stores().assessmentsStore,
+      stores().controlsStore,
+      stores().userStore
+    );
+    const out = readDownload();
+
+    expect(out.count).toBe(2);
+    expect(out.dataType).toBe('Assessments');
+    expect(captured.filename).toMatch(/^assessments_\d{4}-\d{2}-\d{2}\.json$/);
+  });
+
+  it('exports only the selected assessment', async () => {
+    exportAssessmentsJSON(
+      stores().assessmentsStore,
+      stores().controlsStore,
+      stores().userStore,
+      { assessmentIds: ['ASM-b'] }
+    );
+    const out = readDownload();
+
+    expect(out.count).toBe(1);
+    expect(out.assessments[0].id).toBe('ASM-b');
+    expect(out.assessmentSelection).toEqual({
+      selectedIds: ['ASM-b'],
+      selectedCount: 1,
+      totalCount: 2
+    });
+    expect(captured.filename).toMatch(/^assessments_subset_\d{4}-\d{2}-\d{2}\.json$/);
+  });
+});
+
+// ---- section inventory -----------------------------------------------------
+
+describe('section disposition covers the production envelope', () => {
+  it('classifies every section exportAllDataJSON actually emits', () => {
+    exportCompleteDatabase(stores());
+    const out = readDownload();
+
+    // Guards against the real failure mode: a new store section ships, rides
+    // every subset export unclassified, and nobody notices until it leaks.
+    expect(sectionDispositionGaps(out)).toEqual([]);
+  });
+
+  it('leaves the org-level sections whole in a subset', () => {
+    exportCompleteDatabase(stores(), { assessmentIds: ['ASM-a'] });
+    const out = readDownload();
+
+    // None of these carry an assessmentId, so there is no correct way to
+    // attribute them to a selection; their privacy is the share fold's job.
+    expect(out.data.metrics).toEqual([]);
+    expect(out.data.systems).toEqual([]);
+    expect(out.data.orgProfile).toBeDefined();
+    expect(out.data.controls).toHaveLength(1);
+    expect(out.data.frameworks).toHaveLength(1);
+  });
+
+  it('leaks no excluded assessment id anywhere in a real subset payload', () => {
+    exportCompleteDatabase(stores(), { assessmentIds: ['ASM-a'] });
+    expect(captured.text).not.toContain('ASM-b');
+    expect(captured.text).toContain('ASM-a');
+  });
+});
+
+// ---- restore guard ---------------------------------------------------------
+
+describe('validateDatabaseExport — selective-export guard', () => {
+  it('warns that a slice is not a backup before a full-replace restore', async () => {
+    exportCompleteDatabase(stores(), { assessmentIds: ['ASM-a'] });
+    const slice = readDownload();
+
+    const result = validateDatabaseExport(slice);
+    expect(result.ok).toBe(true);
+    expect(result.warnings.join(' ')).toMatch(/SELECTIVE export \(1 of 2 assessments\)/);
+  });
+
+  it('does not warn on a full backup', async () => {
+    exportCompleteDatabase(stores());
+    const backup = readDownload();
+
+    const result = validateDatabaseExport(backup);
+    expect(result.warnings.join(' ')).not.toMatch(/SELECTIVE/);
+  });
+});


### PR DESCRIPTION
Two changes that happened to share a working tree.

## Implementation Example column

The assessment CSV's `ID` column carries a bare requirement id (`GV.SC-04 Ex1`), which is unreadable without a second lookup against the framework catalogue. This joins `requirementsStore.implementationExample` onto that key in both exporters and the downloadable template, matching the layout of the reference workbook in `GET_THE_SPREADSHEETS/`.

Three calls worth reviewing:

- **Controls-scoped rows get an empty cell**, not the control's `implementationDescription`. Those are separate columns in the reference workbook, and emitting one under the other's header would mislabel it.
- **The importer treats the column as inert.** It is read-only framework data owned by `requirementsStore`; round-tripping it into `observations[itemId]` would fork the NIST text into a second copy inside user state, free to diverge. Side effect: editing that cell and re-importing silently no-ops.
- **The Jira exporters are deliberately excluded** — they emit a machine-consumed issue-import schema, not the human-readable workbook schema. Pinned by an assertion rather than left as a comment, so the exclusion reads as a choice.

Implementation note: the new column uses `csvFormulaGuard`, not `escapeCSVValue`. At a `Papa.unparse` call site `escapeCSVValue` wraps-and-quotes on top of Papa's own quoting, and literal `"` characters then grow by two on every export → import cycle (see `sanitize.js:56-70`). A single apostrophe in the text is enough to trigger it.

## Selective export picker

Choose which assessments an export covers, with the selection carried between the picker and the password dialog. `null` keeps the historical export-everything path unchanged.

## Testing

71 suites / 1303 tests green. 14 new tests cover column position against the full pre-change header list, value resolution, the formula guard, import inertness, and the Jira exclusion.

## Known follow-up (not in this PR)

Every other free-text column in both exporters still uses `escapeCSVValue` at a `Papa.unparse` call site — `Test Procedure(s)`, `Q1–Q4 Observations`, `Action Plan`, `Assessment`. They carry the quote-doubling bug described above. Fixing it changes the bytes of every existing export, so it needs its own compatibility baseline and its own PR.
