### PR TITLE
Assessment CSV: match UI fields exactly (both directions)

### DIFF
--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -21,7 +21,7 @@ import EmptyState from '../components/EmptyState';
 import ScoreSelect from '../components/ScoreSelect';
 
 // Stores
-import useAssessmentsStore, { normalizeAssessmentUsers, ASSESSMENT_USER_ROLES } from '../stores/assessmentsStore';
+import useAssessmentsStore, { normalizeAssessmentUsers, ASSESSMENT_USER_ROLES, ASSESSMENT_CSV_HEADERS } from '../stores/assessmentsStore';
 import useControlsStore from '../stores/controlsStore';
 import useRequirementsStore, { isCsfRequirement } from '../stores/requirementsStore';
 import useUserStore from '../stores/userStore';
@@ -1063,66 +1063,54 @@ Format as a numbered list. Be specific and actionable.`;
   }, [exportAllAssessmentsCSV, exportAssessmentIds]);
 
   const handleDownloadTemplate = useCallback(() => {
-    const templateData = [
-      {
-        'ID': 'GV.OC-01 Ex1',
-        // Reference text only — the exporters join it in from the framework
-        // catalogue on the ID key, and the importer ignores whatever is here.
-        'Implementation Example': 'Ex1: Share the organization\'s mission and vision statements with third parties who have a role in achieving the mission',
-        'Assessment': '2025 Security Assessment',
-        'Scope Type': 'controls',
-        'Auditor': 'Auditor Name <auditor@example.com>',
-        'Test Procedure(s)': 'Review documentation; Interview control owner; Test implementation',
-        'Q1 Actual Score': '5',
-        'Q1 Target Score': '5',
-        'Q1 Observations': 'Q1 observation notes',
-        'Q1 Observation Date': '2025-01-15',
-        'Q1 Testing Status': 'Complete',
-        'Q1 Examine': 'Yes',
-        'Q1 Interview': 'Yes',
-        'Q1 Test': 'Yes',
-        'Q2 Actual Score': '6',
-        'Q2 Target Score': '5',
-        'Q2 Observations': 'Q2 observation notes',
-        'Q2 Observation Date': '2025-04-15',
-        'Q2 Testing Status': 'Complete',
-        'Q2 Examine': 'Yes',
-        'Q2 Interview': 'Yes',
-        'Q2 Test': 'Yes',
-        'Q3 Actual Score': '',
-        'Q3 Target Score': '',
-        'Q3 Observations': '',
-        'Q3 Observation Date': '',
-        'Q3 Testing Status': 'Not Started',
-        'Q3 Examine': 'No',
-        'Q3 Interview': 'No',
-        'Q3 Test': 'No',
-        'Q4 Actual Score': '',
-        'Q4 Target Score': '',
-        'Q4 Observations': '',
-        'Q4 Observation Date': '',
-        'Q4 Testing Status': 'Not Started',
-        'Q4 Examine': 'No',
-        'Q4 Interview': 'No',
-        'Q4 Test': 'No',
-        'Linked Artifacts': 'artifact1; artifact2',
-        'Remediation Owner': 'Owner Name <owner@example.com>',
-        'Action Plan': 'Example remediation action',
-        'Remediation Due Date': '2025-03-01'
-      }
-    ];
+    // Headers come from the store's canonical list — the same one both
+    // exporters unparse against — so the template can never drift from the
+    // real export format again.
+    const sampleRow = {
+      'ID': 'GV.OC-01 Ex1',
+      // Reference text only — the exporters join it in from the framework
+      // catalogue on the ID key, and the importer ignores whatever is here.
+      'Implementation Example': 'Ex1: Share the organization\'s mission and vision statements with third parties who have a role in achieving the mission',
+      'Assessment': '2025 Security Assessment',
+      'Description': 'Annual NIST CSF 2.0 assessment',
+      'Scope Type': 'controls',
+      'Framework Filter': '',
+      'Scoring Scale': '10',
+      'Year': '2025',
+      'Users': 'Auditor Name <auditor@example.com> (auditor); Owner Name <owner@example.com> (control owner)',
+      'Auditor': 'Auditor Name <auditor@example.com>',
+      'Test Procedure(s)': 'Review documentation; Interview control owner; Test implementation',
+      'Q1 Actual Score': '5',
+      'Q1 Target Score': '5',
+      'Q1 Observations': 'Q1 observation notes',
+      'Q1 Testing Status': 'Complete',
+      'Q1 Examine': 'Yes',
+      'Q1 Interview': 'Yes',
+      'Q1 Test': 'Yes',
+      'Q2 Actual Score': '6',
+      'Q2 Target Score': '5',
+      'Q2 Observations': 'Q2 observation notes',
+      'Q2 Testing Status': 'Complete',
+      'Q2 Examine': 'Yes',
+      'Q2 Interview': 'Yes',
+      'Q2 Test': 'Yes',
+      'Q3 Testing Status': 'Not Started',
+      'Q3 Examine': 'No',
+      'Q3 Interview': 'No',
+      'Q3 Test': 'No',
+      'Q4 Testing Status': 'Not Started',
+      'Q4 Examine': 'No',
+      'Q4 Interview': 'No',
+      'Q4 Test': 'No',
+      'Linked Artifacts': 'artifact1; artifact2',
+      'Linked Findings': 'FND-001; FND-002',
+      'Linked Controls': 'CTL-001',
+      'External Links': 'findings|https://example.atlassian.net/browse/SEC-123'
+    };
 
-    const headers = [
-      'ID', 'Implementation Example', 'Assessment', 'Scope Type', 'Auditor', 'Test Procedure(s)',
-      'Q1 Actual Score', 'Q1 Target Score', 'Q1 Observations', 'Q1 Observation Date', 'Q1 Testing Status', 'Q1 Examine', 'Q1 Interview', 'Q1 Test',
-      'Q2 Actual Score', 'Q2 Target Score', 'Q2 Observations', 'Q2 Observation Date', 'Q2 Testing Status', 'Q2 Examine', 'Q2 Interview', 'Q2 Test',
-      'Q3 Actual Score', 'Q3 Target Score', 'Q3 Observations', 'Q3 Observation Date', 'Q3 Testing Status', 'Q3 Examine', 'Q3 Interview', 'Q3 Test',
-      'Q4 Actual Score', 'Q4 Target Score', 'Q4 Observations', 'Q4 Observation Date', 'Q4 Testing Status', 'Q4 Examine', 'Q4 Interview', 'Q4 Test',
-      'Linked Artifacts', 'Remediation Owner', 'Action Plan', 'Remediation Due Date'
-    ];
     const csv = [
-      headers.join(','),
-      templateData.map(row => headers.map(h => `"${row[h] || ''}"`).join(',')).join('\n')
+      ASSESSMENT_CSV_HEADERS.join(','),
+      ASSESSMENT_CSV_HEADERS.map(h => `"${sampleRow[h] || ''}"`).join(',')
     ].join('\n');
 
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });

--- a/src/stores/assessmentsCsvImplementationExample.test.js
+++ b/src/stores/assessmentsCsvImplementationExample.test.js
@@ -21,7 +21,7 @@
  * a Blob and hand it to URL.createObjectURL, neither of which jsdom
  * implements, so both are stubbed and the CSV is read back from the Blob parts.
  */
-import useAssessmentsStore from './assessmentsStore';
+import useAssessmentsStore, { ASSESSMENT_CSV_HEADERS } from './assessmentsStore';
 import useControlsStore from './controlsStore';
 import useRequirementsStore from './requirementsStore';
 import useUserStore from './userStore';
@@ -152,55 +152,22 @@ describe('column shape', () => {
     expect(headers[1]).toBe('Implementation Example');
   });
 
-  test('no pre-existing column is dropped or reordered by the insertion', async () => {
+  test('exportAssessmentCSV emits exactly the canonical header list', async () => {
     const id = makeAssessment('requirements', [REQ_ID]);
     await useAssessmentsStore
       .getState()
       .exportAssessmentCSV(id, useControlsStore, useRequirementsStore, useUserStore);
 
-    const headers = parseHeaderRow(capturedText());
-    // The pre-change header list, with the new column spliced in at index 1.
-    expect(headers).toEqual([
-      'ID',
-      'Implementation Example',
-      'Assessment',
-      'Scope Type',
-      'Scoring Scale',
-      'Auditor',
-      'Test Procedure(s)',
-      ...['Q1', 'Q2', 'Q3', 'Q4'].flatMap((q) => [
-        `${q} Actual Score`,
-        `${q} Target Score`,
-        `${q} Observations`,
-        `${q} Observation Date`,
-        `${q} Testing Status`,
-        `${q} Examine`,
-        `${q} Interview`,
-        `${q} Test`
-      ]),
-      'Linked Artifacts',
-      'Remediation Owner',
-      'Action Plan',
-      'Remediation Due Date'
-    ]);
+    expect(parseHeaderRow(capturedText())).toEqual(ASSESSMENT_CSV_HEADERS);
   });
 
-  test('exportAllAssessmentsCSV keeps Description and Framework Filter in place', async () => {
+  test('exportAllAssessmentsCSV emits exactly the canonical header list', async () => {
     makeAssessment('requirements', [REQ_ID]);
     await useAssessmentsStore
       .getState()
       .exportAllAssessmentsCSV(useControlsStore, useRequirementsStore, useUserStore);
 
-    const headers = parseHeaderRow(capturedText());
-    expect(headers.slice(0, 7)).toEqual([
-      'ID',
-      'Implementation Example',
-      'Assessment',
-      'Description',
-      'Scope Type',
-      'Framework Filter',
-      'Scoring Scale'
-    ]);
+    expect(parseHeaderRow(capturedText())).toEqual(ASSESSMENT_CSV_HEADERS);
   });
 });
 

--- a/src/stores/assessmentsCsvUiParity.test.js
+++ b/src/stores/assessmentsCsvUiParity.test.js
@@ -1,0 +1,226 @@
+/**
+ * Spreadsheet ↔ UI parity for the assessment CSV egresses (2026-08 reconcile).
+ *
+ * The rule under test: the export/import spreadsheet carries every field the
+ * assessment evaluation panel shows, and none it doesn't. Three defects this
+ * file pins against regression:
+ *   1. UI fields the sheet used to lack — Year, Users (roster + roles),
+ *      Linked Findings, Linked Controls, External Links — export AND survive
+ *      an export → import round-trip;
+ *   2. orphan columns whose only surfaces were never-routed pages — per-quarter
+ *      Observation Date and the Remediation Owner / Action Plan / Remediation
+ *      Due Date trio — are gone from the canonical header list;
+ *   3. both exporters and the template share ASSESSMENT_CSV_HEADERS, so the
+ *      three surfaces cannot drift apart again (the template builds from the
+ *      constant by construction; the exporters are asserted here).
+ *
+ * Capture harness mirrors assessmentsStore.egress.test.js: the exporters build
+ * a Blob and hand it to URL.createObjectURL, neither of which jsdom
+ * implements, so both are stubbed and the CSV is read back from the Blob parts.
+ */
+import useAssessmentsStore, { ASSESSMENT_CSV_HEADERS } from './assessmentsStore';
+import useControlsStore from './controlsStore';
+import useRequirementsStore from './requirementsStore';
+import useUserStore from './userStore';
+
+const REQ_ID = 'GV.SC-04 Ex1';
+
+let captured;
+const OriginalBlob = global.Blob;
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+class CapturingBlob extends OriginalBlob {
+  constructor(parts, opts) {
+    super(parts, opts);
+    this.capturedParts = parts;
+  }
+}
+
+beforeAll(() => {
+  global.Blob = CapturingBlob;
+  URL.createObjectURL = (blob) => {
+    captured.push(blob);
+    return 'blob:test';
+  };
+  URL.revokeObjectURL = () => {};
+});
+
+afterAll(() => {
+  global.Blob = OriginalBlob;
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+});
+
+const capturedText = () => {
+  expect(captured.length).toBeGreaterThan(0);
+  return captured[captured.length - 1].capturedParts.map((p) => String(p)).join('');
+};
+
+const createdAssessmentIds = [];
+const createdUserIds = [];
+
+beforeEach(() => {
+  captured = [];
+  useRequirementsStore.getState().setRequirements([
+    {
+      id: REQ_ID,
+      frameworkId: 'nist-csf-2.0',
+      subcategoryId: 'GV.SC-04',
+      implementationExample: 'Ex1: Develop criteria for supplier criticality',
+      inScope: true
+    }
+  ]);
+});
+
+afterEach(() => {
+  const store = useAssessmentsStore.getState();
+  store.setAssessments(store.assessments.filter((a) => !createdAssessmentIds.includes(a.id)));
+  createdAssessmentIds.length = 0;
+  const users = useUserStore.getState();
+  createdUserIds.forEach((id) => users.deleteUser?.(id));
+  createdUserIds.length = 0;
+  useRequirementsStore.getState().setRequirements([]);
+});
+
+const trackImported = async (csv) => {
+  const store = useAssessmentsStore.getState();
+  const before = new Set(store.assessments.map((a) => a.id));
+  await store.importAssessmentsCSV(csv, useUserStore);
+  const imported = useAssessmentsStore.getState().assessments.filter((a) => !before.has(a.id));
+  imported.forEach((a) => createdAssessmentIds.push(a.id));
+  expect(imported).toHaveLength(1);
+  return imported[0];
+};
+
+/** Build a fully-populated source assessment exercising every UI field. */
+const makeSourceAssessment = () => {
+  const users = useUserStore.getState();
+  const auditorId = users.findOrCreateUser({ name: 'Avery Auditor', email: 'avery@example.com' });
+  const ownerId = users.findOrCreateUser({ name: 'Owen Owner', email: 'owen@example.com' });
+  createdUserIds.push(auditorId, ownerId);
+
+  const store = useAssessmentsStore.getState();
+  const created = store.createAssessment({
+    name: 'Parity assessment',
+    description: 'Round-trip fixture',
+    scopeType: 'requirements',
+    year: 2027,
+    users: [
+      { userId: auditorId, role: 'auditor' },
+      { userId: ownerId, role: 'control owner' }
+    ]
+  });
+  createdAssessmentIds.push(created.id);
+  store.addToScope(created.id, REQ_ID);
+  store.updateObservation(created.id, REQ_ID, {
+    auditorId,
+    testProcedures: 'Inspect supplier list',
+    linkedArtifacts: ['ART-1', 'ART-2'],
+    linkedFindings: ['FND-9'],
+    linkedControls: ['CTL-3', 'CTL-4'],
+    externalLinks: [
+      { type: 'findings', url: 'https://tracker.example.com/browse/SEC-1' },
+      { type: 'controls', url: 'https://grc.example.com/controls/42' }
+    ]
+  });
+  store.updateQuarterlyObservation(created.id, REQ_ID, 'Q2', {
+    actualScore: 4,
+    targetScore: 6,
+    observations: 'Q2 note',
+    testingStatus: 'Complete',
+    examine: true,
+    interview: false,
+    test: true
+  });
+  return { id: created.id, auditorId, ownerId };
+};
+
+describe('canonical header list encodes the parity rule', () => {
+  test('carries the five UI fields the sheet used to lack', () => {
+    ['Year', 'Users', 'Linked Findings', 'Linked Controls', 'External Links'].forEach((h) =>
+      expect(ASSESSMENT_CSV_HEADERS).toContain(h)
+    );
+  });
+
+  test('carries no column without a live UI surface', () => {
+    const orphans = ASSESSMENT_CSV_HEADERS.filter((h) =>
+      h.includes('Observation Date') ||
+      ['Remediation Owner', 'Action Plan', 'Remediation Due Date'].includes(h)
+    );
+    expect(orphans).toEqual([]);
+  });
+});
+
+describe('export carries the UI fields', () => {
+  test('Year, Users roster, links and external links appear in the CSV', async () => {
+    const { id } = makeSourceAssessment();
+    await useAssessmentsStore
+      .getState()
+      .exportAssessmentCSV(id, useControlsStore, useRequirementsStore, useUserStore);
+
+    const csv = capturedText();
+    expect(csv).toContain('2027');
+    expect(csv).toContain('Avery Auditor <avery@example.com> (auditor)');
+    expect(csv).toContain('Owen Owner <owen@example.com> (control owner)');
+    expect(csv).toContain('FND-9');
+    expect(csv).toContain('CTL-3; CTL-4');
+    expect(csv).toContain('findings|https://tracker.example.com/browse/SEC-1');
+  });
+});
+
+describe('export → import round-trips the UI fields', () => {
+  test('year, roster roles, linked findings/controls and external links survive', async () => {
+    const { id, auditorId, ownerId } = makeSourceAssessment();
+    await useAssessmentsStore
+      .getState()
+      .exportAssessmentCSV(id, useControlsStore, useRequirementsStore, useUserStore);
+
+    const imported = await trackImported(capturedText());
+
+    expect(imported.year).toBe(2027);
+    // findOrCreateUser matches by email, so the same directory users return.
+    expect(imported.users).toEqual([
+      { userId: auditorId, role: 'auditor' },
+      { userId: ownerId, role: 'control owner' }
+    ]);
+
+    const obs = imported.observations[REQ_ID];
+    expect(obs.linkedFindings).toEqual(['FND-9']);
+    expect(obs.linkedControls).toEqual(['CTL-3', 'CTL-4']);
+    expect(obs.linkedArtifacts).toEqual(['ART-1', 'ART-2']);
+    // Link ids regenerate on import; type + url are the round-tripped payload.
+    expect(obs.externalLinks.map(({ type, url }) => ({ type, url }))).toEqual([
+      { type: 'findings', url: 'https://tracker.example.com/browse/SEC-1' },
+      { type: 'controls', url: 'https://grc.example.com/controls/42' }
+    ]);
+    expect(obs.quarters.Q2.actualScore).toBe(4);
+    expect(obs.quarters.Q2.testingStatus).toBe('Complete');
+  });
+});
+
+describe('legacy files with dropped columns stay importable', () => {
+  const LEGACY_CSV = [
+    [
+      'ID', 'Assessment', 'Scope Type', 'Auditor', 'Test Procedure(s)',
+      'Q1 Actual Score', 'Q1 Target Score', 'Q1 Observations', 'Q1 Observation Date',
+      'Q1 Testing Status', 'Q1 Examine', 'Q1 Interview', 'Q1 Test',
+      'Linked Artifacts', 'Remediation Owner', 'Action Plan', 'Remediation Due Date'
+    ].join(','),
+    `${REQ_ID},Legacy Import,requirements,Ann Auditor,Review docs,3,4,note,2025-01-15,Complete,Yes,No,Yes,AR-1,Rem Owner,Fix it,2025-03-01`
+  ].join('\n');
+
+  test('imports, defaults year/roster, and the orphan data does not land', async () => {
+    const imported = await trackImported(LEGACY_CSV);
+
+    expect(imported.scopeIds).toEqual([REQ_ID]);
+    // Files without a Year column get the current year, matching the wizard.
+    expect(imported.year).toBe(new Date().getFullYear());
+    expect(imported.users).toEqual([]);
+
+    const obs = imported.observations[REQ_ID];
+    expect(obs.quarters.Q1.actualScore).toBe(3);
+    expect(obs.quarters.Q1.observationDate).toBe('');
+    expect(obs.remediation).toEqual({ ownerId: null, actionPlan: '', dueDate: '' });
+  });
+});

--- a/src/stores/assessmentsStore.js
+++ b/src/stores/assessmentsStore.js
@@ -203,6 +203,168 @@ export const normalizeAssessmentPlatforms = (value) => {
 };
 
 /**
+ * Canonical assessment CSV column set — the single source of truth for BOTH
+ * exporters AND the template download in Assessments.js. Three hand-maintained
+ * lists is how the spreadsheet drifted from the evaluation panel in the first
+ * place. The rule the list encodes: every field the assessment UI shows, and
+ * none it doesn't. Columns with no live surface (per-quarter Observation Date,
+ * Remediation Owner / Action Plan / Remediation Due Date — their pages were
+ * never routed) are gone; UI fields the sheet lacked (Year, Users, Linked
+ * Findings, Linked Controls, External Links) are in. Old files carrying the
+ * dropped columns still import — unknown columns are inert under Papa's
+ * header mode.
+ */
+export const ASSESSMENT_CSV_HEADERS = [
+  'ID',
+  'Implementation Example',
+  'Assessment',
+  'Description',
+  'Scope Type',
+  'Framework Filter',
+  'Scoring Scale',
+  'Year',
+  'Users',
+  'Auditor',
+  'Test Procedure(s)',
+  ...['Q1', 'Q2', 'Q3', 'Q4'].flatMap(q => [
+    `${q} Actual Score`,
+    `${q} Target Score`,
+    `${q} Observations`,
+    `${q} Testing Status`,
+    `${q} Examine`,
+    `${q} Interview`,
+    `${q} Test`
+  ]),
+  'Linked Artifacts',
+  'Linked Findings',
+  'Linked Controls',
+  'External Links'
+];
+
+/**
+ * Users cell: `Name <email> (role)` entries joined by `; ` — the Linked
+ * Artifacts list convention, with the roster role parenthesized so a
+ * round-trip can restore it. Unknown userIds fall back to the raw id so the
+ * cell never silently shrinks.
+ */
+const serializeAssessmentUsersCell = (assessment, users) =>
+  normalizeAssessmentUsers(assessment.users)
+    .map(({ userId, role }) => {
+      const user = users.find(u => u.id === userId);
+      const name = user ? (user.email ? `${user.name} <${user.email}>` : user.name) : userId;
+      return `${name} (${role})`;
+    })
+    .join('; ');
+
+/**
+ * External-links cell: `type|url` pairs joined by `; `. The pipe keeps the
+ * cell readable in a spreadsheet; a URL containing `;` is the same accepted
+ * limitation the Linked Artifacts convention already carries.
+ */
+const serializeExternalLinksCell = (links) =>
+  (links || []).map(l => `${l.type}|${l.url}`).join('; ');
+
+/** Inverse of the `; `-joined list cells. */
+const splitListCell = (value) =>
+  (value || '').split(';').map(s => s.trim()).filter(Boolean);
+
+/** External-links cell inverse; junk types/urls die in normalizeExternalLinks. */
+const parseExternalLinksCell = (value) => normalizeExternalLinks(
+  splitListCell(value)
+    .map(part => {
+      const sep = part.indexOf('|');
+      if (sep === -1) return null;
+      return { type: part.slice(0, sep).trim(), url: part.slice(sep + 1).trim() };
+    })
+    .filter(Boolean)
+);
+
+/**
+ * Parse a person cell: `Name <email>`, a bare email, or a bare name.
+ * Module-scoped because both the Auditor column and the Users roster cell
+ * need it.
+ */
+const parseUserString = (str) => {
+  if (!str || !str.trim()) return null;
+  str = str.trim();
+  const match = str.match(/^(.+?)\s*<([^>]+)>$/);
+  if (match) {
+    return { name: match[1].trim(), email: match[2].trim() };
+  }
+  if (str.includes('@')) {
+    const namePart = str.split('@')[0].replace(/[._]/g, ' ');
+    return { name: namePart, email: str };
+  }
+  return { name: str, email: null };
+};
+
+/**
+ * Users roster cell inverse: `Name <email> (role); ...` → [{ userId, role }].
+ * People land in the user directory via findOrCreateUser (names/emails are
+ * never embedded on the assessment); an unknown or missing role defaults to
+ * 'stakeholder', matching addAssessmentUser.
+ */
+const parseAssessmentUsersCell = (value, findOrCreateUser) => {
+  if (!findOrCreateUser) return [];
+  const entries = [];
+  for (const part of splitListCell(value)) {
+    const roleMatch = part.match(/\(([^()]*)\)\s*$/);
+    const rawRole = roleMatch ? roleMatch[1].trim().toLowerCase() : '';
+    const role = ASSESSMENT_USER_ROLES.includes(rawRole) ? rawRole : 'stakeholder';
+    const personStr = roleMatch ? part.slice(0, roleMatch.index).trim() : part;
+    const info = parseUserString(personStr);
+    if (!info) continue;
+    const userId = findOrCreateUser(info);
+    if (userId) entries.push({ userId, role });
+  }
+  return normalizeAssessmentUsers(entries);
+};
+
+/**
+ * Build one canonical CSV row for a scoped item. Shared by BOTH exporters so
+ * their cell values can never diverge the way their header lists once did.
+ * Keys must stay in lockstep with ASSESSMENT_CSV_HEADERS — Papa.unparse is
+ * called with { columns: ASSESSMENT_CSV_HEADERS } at both call sites, so a
+ * missing key surfaces as an empty column, never a shifted one.
+ */
+const buildAssessmentCsvRow = ({ assessment, itemId, obs, getItemName, getImplementationExample, getUserName, users }) => {
+  const row = {
+    'ID': escapeCSVValue(getItemName(itemId)),
+    // csvFormulaGuard, not escapeCSVValue: this is long free prose that
+    // routinely contains commas and apostrophes, and escapeCSVValue
+    // wraps-and-quotes on top of Papa's own quoting (see sanitize.js).
+    'Implementation Example': csvFormulaGuard(getImplementationExample(itemId)),
+    'Assessment': escapeCSVValue(assessment.name),
+    'Description': escapeCSVValue(assessment.description || ''),
+    'Scope Type': escapeCSVValue(assessment.scopeType),
+    'Framework Filter': escapeCSVValue(assessment.frameworkFilter || ''),
+    'Scoring Scale': assessment.scoringScale === 5 ? 5 : 10,
+    'Year': assessment.year || '',
+    'Users': csvFormulaGuard(serializeAssessmentUsersCell(assessment, users)),
+    'Auditor': escapeCSVValue(getUserName(obs.auditorId)),
+    'Test Procedure(s)': escapeCSVValue(expandProcedureText(obs) || '')
+  };
+
+  ['Q1', 'Q2', 'Q3', 'Q4'].forEach(q => {
+    const qData = obs.quarters?.[q] || createDefaultQuarter();
+    row[`${q} Actual Score`] = qData.actualScore || 0;
+    row[`${q} Target Score`] = qData.targetScore || 0;
+    row[`${q} Observations`] = escapeCSVValue(qData.observations || '');
+    row[`${q} Testing Status`] = qData.testingStatus || 'Not Started';
+    row[`${q} Examine`] = qData.examine ? 'Yes' : 'No';
+    row[`${q} Interview`] = qData.interview ? 'Yes' : 'No';
+    row[`${q} Test`] = qData.test ? 'Yes' : 'No';
+  });
+
+  row['Linked Artifacts'] = escapeCSVValue((obs.linkedArtifacts || []).join('; '));
+  row['Linked Findings'] = csvFormulaGuard((obs.linkedFindings || []).join('; '));
+  row['Linked Controls'] = csvFormulaGuard((obs.linkedControls || []).join('; '));
+  row['External Links'] = csvFormulaGuard(serializeExternalLinksCell(obs.externalLinks));
+
+  return row;
+};
+
+/**
  * Current schema version of csf-assessments-storage. Exported so the restore
  * path (dataImport.js) can migrate older exported payloads before applying them.
  */
@@ -1084,43 +1246,12 @@ const useAssessmentsStore = create(
         const csvData = assessment.scopeIds.map(itemId => {
           const rawObs = assessment.observations[itemId] || {};
           const obs = rawObs.quarters ? rawObs : migrateObservationToQuarterly(rawObs) || { quarters: createDefaultQuarters() };
-          const remediation = obs.remediation || {};
-
-          const row = {
-            'ID': escapeCSVValue(getItemName(itemId)),
-            // csvFormulaGuard, not escapeCSVValue: this is long free prose that
-            // routinely contains commas and apostrophes, and escapeCSVValue
-            // wraps-and-quotes on top of Papa's own quoting (see sanitize.js).
-            'Implementation Example': csvFormulaGuard(getImplementationExample(itemId)),
-            'Assessment': escapeCSVValue(assessment.name),
-            'Scope Type': escapeCSVValue(assessment.scopeType),
-            'Scoring Scale': assessment.scoringScale === 5 ? 5 : 10,
-            'Auditor': escapeCSVValue(getUserName(obs.auditorId)),
-            'Test Procedure(s)': escapeCSVValue(expandProcedureText(obs) || '')
-          };
-
-          // Add quarterly columns
-          ['Q1', 'Q2', 'Q3', 'Q4'].forEach(q => {
-            const qData = obs.quarters?.[q] || createDefaultQuarter();
-            row[`${q} Actual Score`] = qData.actualScore || 0;
-            row[`${q} Target Score`] = qData.targetScore || 0;
-            row[`${q} Observations`] = escapeCSVValue(qData.observations || '');
-            row[`${q} Observation Date`] = qData.observationDate || '';
-            row[`${q} Testing Status`] = qData.testingStatus || 'Not Started';
-            row[`${q} Examine`] = qData.examine ? 'Yes' : 'No';
-            row[`${q} Interview`] = qData.interview ? 'Yes' : 'No';
-            row[`${q} Test`] = qData.test ? 'Yes' : 'No';
+          return buildAssessmentCsvRow({
+            assessment, itemId, obs, getItemName, getImplementationExample, getUserName, users
           });
-
-          row['Linked Artifacts'] = escapeCSVValue((obs.linkedArtifacts || []).join('; '));
-          row['Remediation Owner'] = escapeCSVValue(getUserName(remediation.ownerId));
-          row['Action Plan'] = escapeCSVValue(remediation.actionPlan || '');
-          row['Remediation Due Date'] = remediation.dueDate || '';
-
-          return row;
         });
 
-        const csv = Papa.unparse(csvData);
+        const csv = Papa.unparse(csvData, { columns: ASSESSMENT_CSV_HEADERS });
         const trimmedPassword = (password || '').trim();
 
         let blob;
@@ -1282,27 +1413,17 @@ const useAssessmentsStore = create(
                     frameworkFilter: row['Framework Filter'] || row.frameworkFilter || null,
                     // Round-trip the scoring scale; CSVs without the column default to 10 (issue #277)
                     scoringScale: Number(row['Scoring Scale']) === 5 ? 5 : 10,
+                    // Round-trip year and the user roster (issues #290/#291);
+                    // files without the columns get the current year and an
+                    // empty roster, same as the creation wizard's defaults.
+                    year: normalizeAssessmentYear(row['Year'] || row.year),
+                    users: parseAssessmentUsersCell(row['Users'] || row.users, findOrCreateUser),
                     jiraKey: assessmentJiraKey, // Store Jira Epic key for reference
                     rows: []
                   };
                 }
                 assessmentGroups[assessmentName].rows.push(row);
               });
-
-              // Parse user string helper
-              const parseUserString = (str) => {
-                if (!str || !str.trim()) return null;
-                str = str.trim();
-                const match = str.match(/^(.+?)\s*<([^>]+)>$/);
-                if (match) {
-                  return { name: match[1].trim(), email: match[2].trim() };
-                }
-                if (str.includes('@')) {
-                  const namePart = str.split('@')[0].replace(/[._]/g, ' ');
-                  return { name: namePart, email: str };
-                }
-                return { name: str, email: null };
-              };
 
               // Helper to convert Excel serial date to ISO date string (YYYY-MM-DD)
               const parseDate = (value) => {
@@ -1327,12 +1448,14 @@ const useAssessmentsStore = create(
               // Helper to detect if CSV has quarterly columns
               const hasQuarterlyColumns = results.meta.fields?.some(f => f.startsWith('Q1 '));
 
-              // Helper to parse quarter data from row
+              // Helper to parse quarter data from row. Observation Date is no
+              // longer a spreadsheet column (no live UI surface shows it) —
+              // the field stays in the quarter shape, empty.
               const parseQuarterData = (row, quarter) => ({
                 actualScore: parseFloat(row[`${quarter} Actual Score`]) || 0,
                 targetScore: parseFloat(row[`${quarter} Target Score`]) || 0,
                 observations: sanitizeInput(row[`${quarter} Observations`] || ''),
-                observationDate: parseDate(row[`${quarter} Observation Date`]),
+                observationDate: '',
                 testingStatus: row[`${quarter} Testing Status`] || 'Not Started',
                 examine: (row[`${quarter} Examine`] || '').toLowerCase() === 'yes',
                 interview: (row[`${quarter} Interview`] || '').toLowerCase() === 'yes',
@@ -1370,14 +1493,6 @@ const useAssessmentsStore = create(
                   if (auditorStr && findOrCreateUser) {
                     const info = parseUserString(auditorStr);
                     if (info) auditorId = findOrCreateUser(info);
-                  }
-
-                  // Parse remediation owner
-                  let remediationOwnerId = null;
-                  const remOwnerStr = row['Remediation Owner'] || row.remediationOwner;
-                  if (remOwnerStr && findOrCreateUser) {
-                    const info = parseUserString(remOwnerStr);
-                    if (info) remediationOwnerId = findOrCreateUser(info);
                   }
 
                   if (isJiraFormat) {
@@ -1440,17 +1555,17 @@ const useAssessmentsStore = create(
 
                     observations[itemId] = existingObs;
                   } else if (hasQuarterlyColumns) {
-                    // New quarterly format
+                    // New quarterly format. Remediation columns were dropped
+                    // from the sheet (no live UI surface); the empty structure
+                    // keeps the observation shape invariant.
                     observations[itemId] = {
                       auditorId,
                       testProcedures: sanitizeInput(row['Test Procedure(s)'] || row['Test Procedures'] || ''),
-                      linkedArtifacts: (row['Linked Artifacts'] || row.linkedArtifacts || '')
-                        .split(';').map(s => s.trim()).filter(Boolean),
-                      remediation: {
-                        ownerId: remediationOwnerId,
-                        actionPlan: sanitizeInput(row['Action Plan'] || row.actionPlan || ''),
-                        dueDate: parseDate(row['Remediation Due Date'] || row['Due Date'] || row.dueDate)
-                      },
+                      linkedArtifacts: splitListCell(row['Linked Artifacts'] || row.linkedArtifacts),
+                      linkedFindings: splitListCell(row['Linked Findings'] || row.linkedFindings),
+                      linkedControls: splitListCell(row['Linked Controls'] || row.linkedControls),
+                      externalLinks: parseExternalLinksCell(row['External Links'] || row.externalLinks),
+                      remediation: { ownerId: null, actionPlan: '', dueDate: '' },
                       quarters: {
                         Q1: parseQuarterData(row, 'Q1'),
                         Q2: parseQuarterData(row, 'Q2'),
@@ -1463,19 +1578,17 @@ const useAssessmentsStore = create(
                     observations[itemId] = {
                       auditorId,
                       testProcedures: sanitizeInput(row['Test Procedure(s)'] || row['Test Procedures'] || ''),
-                      linkedArtifacts: (row['Linked Artifacts'] || row.linkedArtifacts || '')
-                        .split(';').map(s => s.trim()).filter(Boolean),
-                      remediation: {
-                        ownerId: remediationOwnerId,
-                        actionPlan: sanitizeInput(row['Action Plan'] || row.actionPlan || ''),
-                        dueDate: parseDate(row['Remediation Due Date'] || row['Due Date'] || row.dueDate)
-                      },
+                      linkedArtifacts: splitListCell(row['Linked Artifacts'] || row.linkedArtifacts),
+                      linkedFindings: splitListCell(row['Linked Findings'] || row.linkedFindings),
+                      linkedControls: splitListCell(row['Linked Controls'] || row.linkedControls),
+                      externalLinks: parseExternalLinksCell(row['External Links'] || row.externalLinks),
+                      remediation: { ownerId: null, actionPlan: '', dueDate: '' },
                       quarters: {
                         Q1: {
                           actualScore: parseFloat(row['Actual Score'] || row.actualScore) || 0,
                           targetScore: parseFloat(row['Target Score'] || row.targetScore) || 0,
                           observations: sanitizeInput(row['Observations'] || row.observations || ''),
-                          observationDate: parseDate(row['Observation Date'] || row.observationDate),
+                          observationDate: '',
                           testingStatus: row['Testing Status'] || row.testingStatus || 'Not Started',
                           examine: (row['Examine'] || '').toLowerCase() === 'yes',
                           interview: (row['Interview'] || '').toLowerCase() === 'yes',
@@ -1495,6 +1608,8 @@ const useAssessmentsStore = create(
                   description: group.description,
                   scopeType: group.scopeType,
                   scoringScale: group.scoringScale === 5 ? 5 : 10,
+                  year: group.year,
+                  users: group.users,
                   scopeIds: [...new Set(scopeIds)],
                   frameworkFilter: group.frameworkFilter,
                   jiraKey: group.jiraKey || null, // Store Jira Epic key for sync reference
@@ -1806,45 +1921,13 @@ const useAssessmentsStore = create(
           assessment.scopeIds.forEach(itemId => {
             const rawObs = assessment.observations[itemId] || {};
             const obs = rawObs.quarters ? rawObs : migrateObservationToQuarterly(rawObs) || { quarters: createDefaultQuarters() };
-            const remediation = obs.remediation || {};
-
-            const row = {
-              'ID': escapeCSVValue(getItemName(itemId)),
-              // See the single-assessment exporter above for why this column
-              // uses csvFormulaGuard rather than escapeCSVValue.
-              'Implementation Example': csvFormulaGuard(getImplementationExample(itemId)),
-              'Assessment': escapeCSVValue(assessment.name),
-              'Description': escapeCSVValue(assessment.description || ''),
-              'Scope Type': escapeCSVValue(assessment.scopeType),
-              'Framework Filter': escapeCSVValue(assessment.frameworkFilter || ''),
-              'Scoring Scale': assessment.scoringScale === 5 ? 5 : 10,
-              'Auditor': escapeCSVValue(getUserName(obs.auditorId)),
-              'Test Procedure(s)': escapeCSVValue(expandProcedureText(obs) || '')
-            };
-
-            // Add quarterly columns
-            ['Q1', 'Q2', 'Q3', 'Q4'].forEach(q => {
-              const qData = obs.quarters?.[q] || createDefaultQuarter();
-              row[`${q} Actual Score`] = qData.actualScore || 0;
-              row[`${q} Target Score`] = qData.targetScore || 0;
-              row[`${q} Observations`] = escapeCSVValue(qData.observations || '');
-              row[`${q} Observation Date`] = qData.observationDate || '';
-              row[`${q} Testing Status`] = qData.testingStatus || 'Not Started';
-              row[`${q} Examine`] = qData.examine ? 'Yes' : 'No';
-              row[`${q} Interview`] = qData.interview ? 'Yes' : 'No';
-              row[`${q} Test`] = qData.test ? 'Yes' : 'No';
-            });
-
-            row['Linked Artifacts'] = escapeCSVValue((obs.linkedArtifacts || []).join('; '));
-            row['Remediation Owner'] = escapeCSVValue(getUserName(remediation.ownerId));
-            row['Action Plan'] = escapeCSVValue(remediation.actionPlan || '');
-            row['Remediation Due Date'] = remediation.dueDate || '';
-
-            csvData.push(row);
+            csvData.push(buildAssessmentCsvRow({
+              assessment, itemId, obs, getItemName, getImplementationExample, getUserName, users
+            }));
           });
         });
 
-        const csv = Papa.unparse(csvData);
+        const csv = Papa.unparse(csvData, { columns: ASSESSMENT_CSV_HEADERS });
         const date = new Date().toISOString().split('T')[0];
         const baseFilename = `assessments${isSubset ? '_subset' : ''}_${date}.csv`;
 

--- a/src/utils/egressCensus.test.js
+++ b/src/utils/egressCensus.test.js
@@ -145,15 +145,17 @@ describe('choke-point wiring rot-stoppers (PR-5)', () => {
     // assessmentsStore.js legitimately reads obs.testProcedures in exactly
     // FOUR non-egress places: the frozen v14 migration block (3 reads) and
     // the observations→evaluations migration (1 read). The four CSV/Jira
-    // egress emissions all call expandProcedureText(obs) — 5 call sites
-    // (exportForJiraCSV emits twice: custom field + description). Pin both
+    // egress emissions all route through expandProcedureText(obs) — 4 call
+    // sites since the spreadsheet/UI parity refactor: the two CSV exporters
+    // share buildAssessmentCsvRow (1 call), and exportForJiraCSV emits twice
+    // (custom field + description) plus exportAllForJiraCSV once. Pin both
     // counts: a NEW exporter written against obs.testProcedures bumps the
     // residual count and goes red here, forcing the expansion decision at
     // commit time instead of a silent trunk-only artifact.
     const store = read('stores/assessmentsStore.js');
     const residualReads = (store.match(/obs\.testProcedures/g) || []).length;
     const chokeCalls = (store.match(/expandProcedureText\(obs\)/g) || []).length;
-    expect(chokeCalls).toBe(5);
+    expect(chokeCalls).toBe(4);
     expect(residualReads).toBe(4);
   });
 


### PR DESCRIPTION
Add Year, Users, Linked Findings, Linked Controls, External Links;
drop Observation Date and remediation columns (no live UI surface);
single canonical ASSESSMENT_CSV_HEADERS shared by both exporters and
the template so the three surfaces cannot drift.
