### PR TITLE
Per-record comments with @mentions + field-level change audit log

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
+import useUserStore from '../stores/userStore';
 import {
   LayoutDashboard,
   Users,
@@ -89,6 +90,36 @@ const NavGroups = ({ pathname, onNavigate }) => (
   </>
 );
 
+// Who comments and audit-log entries are attributed to. Honor-system by
+// design — the app has no authentication; this is a directory pick.
+const ActingUserSelect = () => {
+  const users = useUserStore((state) => state.users);
+  const currentUserId = useUserStore((state) => state.currentUserId);
+  const setCurrentUser = useUserStore((state) => state.setCurrentUser);
+
+  return (
+    <div className="app-acting-user">
+      <label className="app-acting-user-label" htmlFor="acting-user-select">Acting as</label>
+      <select
+        id="acting-user-select"
+        value={currentUserId ?? ''}
+        onChange={(e) => {
+          const raw = e.target.value;
+          if (raw === '') { setCurrentUser(null); return; }
+          // ids are numeric for seeded users, uuid strings for created ones
+          const user = users.find(u => String(u.id) === raw);
+          setCurrentUser(user ? user.id : null);
+        }}
+      >
+        <option value="">Not selected (System)</option>
+        {users.map((user) => (
+          <option key={user.id} value={String(user.id)}>{user.name}</option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
 const Brand = () => (
   <div className="app-sidebar-brand">
     <div className="terminal-logo-disc">
@@ -151,6 +182,7 @@ const Navigation = () => {
         <nav className="app-sidebar-nav">
           <NavGroups pathname={pathname} />
         </nav>
+        <ActingUserSelect />
       </aside>
 
       {/* Drawer trigger — only visible below 1024px (see CSS). */}
@@ -180,6 +212,7 @@ const Navigation = () => {
             <nav className="app-sidebar-nav">
               <NavGroups pathname={pathname} onNavigate={closeDrawer} />
             </nav>
+            <ActingUserSelect />
           </div>
         </div>
       )}

--- a/src/components/PlatformAddendumBadges.test.js
+++ b/src/components/PlatformAddendumBadges.test.js
@@ -99,6 +99,7 @@ describe('PlatformAddendumBadges', () => {
       findingsStore: storeOf({ findings: data.findings, setFindings: jest.fn() }),
       metricsStore: storeOf({ metrics: data.metrics, setMetrics: jest.fn() }),
       inventoryStore: storeOf({ systems: [], setSystems: jest.fn() }),
+      commentsStore: storeOf({ comments: [], setComments: jest.fn() }),
       orgProfileStore: storeOf({ profile: null, cloudConsent: false, setProfileState: jest.fn() })
     };
     const parsed = JSON.parse(JSON.stringify(exportAllDataJSON(stores)));

--- a/src/components/RecordPanel.js
+++ b/src/components/RecordPanel.js
@@ -1,0 +1,366 @@
+import React, { useState, useEffect, useMemo, useRef } from 'react';
+import { MessageSquare, History, X, Send, Trash2 } from 'lucide-react';
+import useCommentsStore, { segmentMentions, MAX_COMMENT_LENGTH } from '../stores/commentsStore';
+import useAuditLogStore from '../stores/auditLogStore';
+import useUserStore from '../stores/userStore';
+import { ACTION_META, formatAuditTimestamp } from '../utils/auditActions';
+
+/**
+ * RecordPanel — the shared right-docked Comments + History panel for
+ * Assessment Evaluation records, Controls, and Findings.
+ *
+ * Positioning is inline style, not utility classes: this repo's index.css is
+ * a hand-rolled subset with no `right-0`/`w-96`, so the two existing right
+ * panels (Findings, RequirementDetailPanel) hand-roll position/top/right/
+ * bottom the same way. zIndex 1100 sits above the Findings slide-over (1000)
+ * and every `z-50` modal; react-hot-toast (9999) stays on top, correctly.
+ */
+
+// Comment text renders as plain JSX text — mentions get a highlighted span.
+// No dangerouslySetInnerHTML anywhere in this file, by policy.
+const CommentText = ({ text, users }) => {
+  const segments = segmentMentions(text, users);
+  return (
+    <span style={{ overflowWrap: 'anywhere' }}>
+      {segments.map((seg, i) =>
+        seg.userId !== undefined ? (
+          <span key={i} className="text-blue-600 dark:text-blue-400 font-medium">{seg.text}</span>
+        ) : (
+          <React.Fragment key={i}>{seg.text}</React.Fragment>
+        )
+      )}
+    </span>
+  );
+};
+
+const ActionBadge = ({ action }) => {
+  const meta = ACTION_META[action] || { label: action, color: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200' };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${meta.color}`}>
+      {meta.label}
+    </span>
+  );
+};
+
+/**
+ * Top-right trigger for the panel — drop into a record header's button
+ * cluster. Shows a count badge when the record has comments.
+ */
+export const CommentsButton = ({ onClick, targetType, targetId, title = 'Comments' }) => {
+  const count = useCommentsStore((state) =>
+    state.comments.filter(c => c.targetType === targetType && c.targetId === targetId).length
+  );
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      aria-label={title}
+      className="relative flex items-center gap-1.5 px-2.5 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+    >
+      <MessageSquare size={14} />
+      {count > 0 && (
+        <span className="inline-flex items-center justify-center rounded-full bg-blue-600 text-white text-xs font-medium" style={{ minWidth: 18, height: 18, padding: '0 4px' }}>
+          {count}
+        </span>
+      )}
+    </button>
+  );
+};
+
+const RecordPanel = ({ open, onClose, targetType, targetId, title }) => {
+  const [tab, setTab] = useState('comments');
+  const [draft, setDraft] = useState('');
+  const [confirmDeleteId, setConfirmDeleteId] = useState(null);
+  const [mentionQuery, setMentionQuery] = useState(null); // null = dropdown closed
+  const textareaRef = useRef(null);
+
+  const users = useUserStore((state) => state.users);
+  const currentUserName = useUserStore((state) => state.getCurrentUserName());
+  const comments = useCommentsStore((state) => state.comments);
+  const addComment = useCommentsStore((state) => state.addComment);
+  const deleteComment = useCommentsStore((state) => state.deleteComment);
+  const entries = useAuditLogStore((state) => state.entries);
+
+  const recordComments = useMemo(
+    () => comments
+      .filter(c => c.targetType === targetType && c.targetId === targetId)
+      .sort((a, b) => (a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0)),
+    [comments, targetType, targetId]
+  );
+  const recordEntries = useMemo(
+    () => entries.filter(e => e.targetType === targetType && e.targetId === targetId),
+    [entries, targetType, targetId]
+  );
+
+  // Escape closes the mention dropdown first, then the panel. Capture phase +
+  // stopPropagation so the Escape that closes this overlay can never also
+  // close the record modal/panel underneath it.
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (e) => {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      setMentionQuery((q) => {
+        if (q !== null) return null;
+        onClose();
+        return null;
+      });
+    };
+    document.addEventListener('keydown', onKey, true);
+    return () => document.removeEventListener('keydown', onKey, true);
+  }, [open, onClose]);
+
+  // Reset transient state when the target record changes.
+  useEffect(() => {
+    setDraft('');
+    setConfirmDeleteId(null);
+    setMentionQuery(null);
+  }, [targetType, targetId]);
+
+  const mentionSuggestions = useMemo(() => {
+    if (mentionQuery === null) return [];
+    const q = mentionQuery.toLowerCase();
+    return users
+      .filter(u => typeof u.name === 'string' && u.name.toLowerCase().includes(q))
+      .slice(0, 6);
+  }, [mentionQuery, users]);
+
+  const handleDraftChange = (e) => {
+    const value = e.target.value;
+    setDraft(value);
+    const caret = e.target.selectionStart ?? value.length;
+    const beforeCaret = value.slice(0, caret);
+    const match = beforeCaret.match(/@(\S*)$/);
+    setMentionQuery(match ? match[1] : null);
+  };
+
+  const insertMention = (user) => {
+    const el = textareaRef.current;
+    const caret = el?.selectionStart ?? draft.length;
+    const beforeCaret = draft.slice(0, caret);
+    const replaced = beforeCaret.replace(/@(\S*)$/, `@${user.name} `);
+    setDraft(replaced + draft.slice(caret));
+    setMentionQuery(null);
+    el?.focus();
+  };
+
+  const submit = () => {
+    const added = addComment({ targetType, targetId, text: draft, entity: title });
+    if (added) {
+      setDraft('');
+      setMentionQuery(null);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      data-testid="record-panel"
+      className="flex flex-col bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-700"
+      style={{
+        position: 'fixed',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        width: 'min(400px, 92vw)',
+        zIndex: 1100,
+        boxShadow: '-4px 0 20px rgba(0,0,0,0.15)'
+      }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center gap-2" style={{ minWidth: 0 }}>
+          <MessageSquare size={16} className="text-gray-500 dark:text-gray-400" />
+          <span className="text-sm font-semibold text-gray-900 dark:text-white truncate" title={title}>
+            {title}
+          </span>
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Close panel"
+          className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 rounded"
+        >
+          <X size={18} />
+        </button>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex border-b border-gray-200 dark:border-gray-700">
+        <button
+          onClick={() => setTab('comments')}
+          className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium ${tab === 'comments'
+            ? 'text-blue-600 dark:text-blue-400 border-b-2 border-blue-600'
+            : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'}`}
+        >
+          <MessageSquare size={14} />
+          Comments{recordComments.length > 0 ? ` (${recordComments.length})` : ''}
+        </button>
+        <button
+          onClick={() => setTab('history')}
+          className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium ${tab === 'history'
+            ? 'text-blue-600 dark:text-blue-400 border-b-2 border-blue-600'
+            : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'}`}
+        >
+          <History size={14} />
+          History{recordEntries.length > 0 ? ` (${recordEntries.length})` : ''}
+        </button>
+      </div>
+
+      {tab === 'comments' ? (
+        <>
+          {/* Comment list */}
+          <div className="flex-1 overflow-y-auto px-4 py-3">
+            {recordComments.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-10 text-center">
+                <MessageSquare size={32} className="text-gray-300 dark:text-gray-600 mb-2" />
+                <p className="text-sm text-gray-500 dark:text-gray-400 font-medium">No comments yet</p>
+                <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                  Start the conversation — use @ to tag a teammate.
+                </p>
+              </div>
+            ) : (
+              recordComments.map((comment) => (
+                <div key={comment.id} className="mb-3 pb-3 border-b border-gray-100 dark:border-gray-800">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2" style={{ minWidth: 0 }}>
+                      <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                        {comment.authorName}
+                      </span>
+                      <span className="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">
+                        {formatAuditTimestamp(comment.createdAt)}
+                      </span>
+                    </div>
+                    {confirmDeleteId === comment.id ? (
+                      <span className="flex items-center gap-1 whitespace-nowrap">
+                        <button
+                          onClick={() => { deleteComment(comment.id, title); setConfirmDeleteId(null); }}
+                          className="text-xs font-medium text-red-600 dark:text-red-400 hover:underline"
+                        >
+                          Delete
+                        </button>
+                        <button
+                          onClick={() => setConfirmDeleteId(null)}
+                          className="text-xs text-gray-500 dark:text-gray-400 hover:underline"
+                        >
+                          Cancel
+                        </button>
+                      </span>
+                    ) : (
+                      <button
+                        onClick={() => setConfirmDeleteId(comment.id)}
+                        aria-label="Delete comment"
+                        className="p-1 text-gray-300 dark:text-gray-600 hover:text-red-500 dark:hover:text-red-400 rounded"
+                      >
+                        <Trash2 size={13} />
+                      </button>
+                    )}
+                  </div>
+                  <div className="text-sm text-gray-700 dark:text-gray-200 mt-1">
+                    <CommentText text={comment.text} users={users} />
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+
+          {/* Composer */}
+          <div className="border-t border-gray-200 dark:border-gray-700 px-4 py-3 relative">
+            {mentionQuery !== null && mentionSuggestions.length > 0 && (
+              <div
+                className="absolute bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded shadow-xl overflow-y-auto"
+                style={{ bottom: '100%', left: 16, right: 16, marginBottom: 4, maxHeight: 180, zIndex: 10 }}
+                data-testid="mention-suggestions"
+              >
+                {mentionSuggestions.map((user) => (
+                  <button
+                    key={user.id}
+                    onClick={() => insertMention(user)}
+                    className="w-full text-left px-3 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"
+                  >
+                    <span className="font-medium">{user.name}</span>
+                    {user.title && (
+                      <span className="text-xs text-gray-400 dark:text-gray-500 ml-1">{user.title}</span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+            <div className="text-xs text-gray-400 dark:text-gray-500 mb-1">
+              Commenting as <span className="font-medium text-gray-600 dark:text-gray-300">{currentUserName}</span>
+            </div>
+            <textarea
+              ref={textareaRef}
+              value={draft}
+              onChange={handleDraftChange}
+              placeholder="Add a comment — @ to tag"
+              rows={3}
+              maxLength={MAX_COMMENT_LENGTH}
+              className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              style={{ resize: 'none' }}
+            />
+            <div className="flex items-center justify-between mt-2">
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                {draft.length}/{MAX_COMMENT_LENGTH}
+              </span>
+              <button
+                onClick={submit}
+                disabled={!draft.trim()}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                <Send size={13} />
+                Comment
+              </button>
+            </div>
+          </div>
+        </>
+      ) : (
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          {recordEntries.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-10 text-center">
+              <History size={32} className="text-gray-300 dark:text-gray-600 mb-2" />
+              <p className="text-sm text-gray-500 dark:text-gray-400 font-medium">No changes recorded yet</p>
+              <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                Edits to this record will appear here with who and when.
+              </p>
+            </div>
+          ) : (
+            recordEntries.map((entry) => (
+              <div key={entry.id} className="mb-3 pb-3 border-b border-gray-100 dark:border-gray-800">
+                <div className="flex items-center justify-between gap-2">
+                  <ActionBadge action={entry.action} />
+                  <span className="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">
+                    {formatAuditTimestamp(entry.timestamp)}
+                  </span>
+                </div>
+                <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  <span className="font-medium text-gray-700 dark:text-gray-200">{entry.user || 'System'}</span>
+                  {entry.field ? <> · {entry.field}</> : null}
+                </div>
+                {(entry.oldValue != null || entry.newValue != null) && (
+                  <div className="flex items-center gap-1.5 text-xs mt-1" style={{ flexWrap: 'wrap' }}>
+                    {entry.oldValue != null && (
+                      <span className="px-1.5 py-0.5 bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded font-mono" style={{ overflowWrap: 'anywhere' }}>
+                        {entry.oldValue}
+                      </span>
+                    )}
+                    {entry.oldValue != null && entry.newValue != null && (
+                      <span className="text-gray-400">→</span>
+                    )}
+                    {entry.newValue != null && (
+                      <span className="px-1.5 py-0.5 bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded font-mono" style={{ overflowWrap: 'anywhere' }}>
+                        {entry.newValue}
+                      </span>
+                    )}
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RecordPanel;

--- a/src/components/RecordPanel.js
+++ b/src/components/RecordPanel.js
@@ -72,6 +72,11 @@ const RecordPanel = ({ open, onClose, targetType, targetId, title }) => {
   const [draft, setDraft] = useState('');
   const [confirmDeleteId, setConfirmDeleteId] = useState(null);
   const [mentionQuery, setMentionQuery] = useState(null); // null = dropdown closed
+  // Ref mirror so the Escape handler can branch WITHOUT side effects inside
+  // a state updater (StrictMode double-invokes updaters; onClose in one is
+  // a render-phase setState hazard).
+  const mentionQueryRef = useRef(null);
+  mentionQueryRef.current = mentionQuery;
   const textareaRef = useRef(null);
 
   const users = useUserStore((state) => state.users);
@@ -100,11 +105,11 @@ const RecordPanel = ({ open, onClose, targetType, targetId, title }) => {
     const onKey = (e) => {
       if (e.key !== 'Escape') return;
       e.stopPropagation();
-      setMentionQuery((q) => {
-        if (q !== null) return null;
+      if (mentionQueryRef.current !== null) {
+        setMentionQuery(null);
+      } else {
         onClose();
-        return null;
-      });
+      }
     };
     document.addEventListener('keydown', onKey, true);
     return () => document.removeEventListener('keydown', onKey, true);
@@ -138,7 +143,9 @@ const RecordPanel = ({ open, onClose, targetType, targetId, title }) => {
     const el = textareaRef.current;
     const caret = el?.selectionStart ?? draft.length;
     const beforeCaret = draft.slice(0, caret);
-    const replaced = beforeCaret.replace(/@(\S*)$/, `@${user.name} `);
+    // Function replacer: a directory name containing $&, $1, $$ etc. must be
+    // inserted literally, not treated as a replacement pattern.
+    const replaced = beforeCaret.replace(/@(\S*)$/, () => `@${user.name} `);
     setDraft(replaced + draft.slice(caret));
     setMentionQuery(null);
     el?.focus();

--- a/src/components/RecordPanel.test.js
+++ b/src/components/RecordPanel.test.js
@@ -67,6 +67,18 @@ describe('RecordPanel', () => {
     expect(screen.getByText('@Nadia.Khan')).toBeInTheDocument();
   });
 
+  test('mention insertion is literal even for names with replacement patterns', () => {
+    useUserStore.setState({
+      users: [...USERS, { id: 9, name: 'Bad $& Actor', title: 'QA', email: 'b@x.com' }],
+      currentUserId: 1
+    });
+    render(<RecordPanel open onClose={() => {}} {...target} title="FND-panel-1" />);
+    const textarea = screen.getByPlaceholderText(/add a comment/i);
+    fireEvent.change(textarea, { target: { value: 'cc @Bad' } });
+    fireEvent.click(screen.getByText('Bad $& Actor'));
+    expect(textarea).toHaveValue('cc @Bad $& Actor ');
+  });
+
   test('History tab lists a scoped change with actor and old → new', () => {
     useAuditLogStore.getState().addEntry({
       action: 'finding_updated', entity: 'FND-panel-1', field: 'status',

--- a/src/components/RecordPanel.test.js
+++ b/src/components/RecordPanel.test.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import RecordPanel, { CommentsButton } from './RecordPanel';
+import useCommentsStore from '../stores/commentsStore';
+import useAuditLogStore from '../stores/auditLogStore';
+import useUserStore from '../stores/userStore';
+
+const USERS = [
+  { id: 1, name: 'Gerry.Callahan', title: 'CISO', email: 'g@x.com' },
+  { id: 2, name: 'Nadia.Khan', title: 'D&R Lead', email: 'n@x.com' }
+];
+
+const target = { targetType: 'finding', targetId: 'FND-panel-1' };
+
+beforeEach(() => {
+  window.localStorage.clear();
+  useCommentsStore.setState({ comments: [] });
+  useAuditLogStore.setState({ entries: [] });
+  useUserStore.setState({ users: USERS, currentUserId: 1 });
+});
+
+describe('RecordPanel', () => {
+  test('renders nothing when closed', () => {
+    render(<RecordPanel open={false} onClose={() => {}} {...target} title="FND-panel-1" />);
+    expect(screen.queryByTestId('record-panel')).not.toBeInTheDocument();
+  });
+
+  test('shows empty states on both tabs', () => {
+    render(<RecordPanel open onClose={() => {}} {...target} title="FND-panel-1" />);
+    expect(screen.getByText('No comments yet')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /history/i }));
+    expect(screen.getByText('No changes recorded yet')).toBeInTheDocument();
+  });
+
+  test('adds a comment with author, timestamp, and clears the composer', () => {
+    render(<RecordPanel open onClose={() => {}} {...target} title="FND-panel-1" />);
+    const textarea = screen.getByPlaceholderText(/add a comment/i);
+    fireEvent.change(textarea, { target: { value: 'First note' } });
+    fireEvent.click(screen.getByRole('button', { name: /^comment$/i }));
+    expect(screen.getByText('First note')).toBeInTheDocument();
+    // the author name appears in the comment row AND the "Commenting as" footer
+    expect(screen.getAllByText('Gerry.Callahan').length).toBeGreaterThanOrEqual(2);
+    expect(textarea).toHaveValue('');
+    // date-stamped: the stored comment carries an ISO timestamp that renders
+    const stored = useCommentsStore.getState().comments[0];
+    expect(new Date(stored.createdAt).toISOString()).toBe(stored.createdAt);
+  });
+
+  test('typing @ opens the user suggestion dropdown, filtered by prefix', () => {
+    render(<RecordPanel open onClose={() => {}} {...target} title="FND-panel-1" />);
+    const textarea = screen.getByPlaceholderText(/add a comment/i);
+    fireEvent.change(textarea, { target: { value: 'ping @Nad' } });
+    const dropdown = screen.getByTestId('mention-suggestions');
+    expect(dropdown).toBeInTheDocument();
+    expect(within(dropdown).getByText('Nadia.Khan')).toBeInTheDocument();
+    expect(within(dropdown).queryByText('Gerry.Callahan')).not.toBeInTheDocument();
+  });
+
+  test('selecting a suggestion inserts the mention and it renders highlighted', () => {
+    render(<RecordPanel open onClose={() => {}} {...target} title="FND-panel-1" />);
+    const textarea = screen.getByPlaceholderText(/add a comment/i);
+    fireEvent.change(textarea, { target: { value: 'ping @Nad' } });
+    fireEvent.click(screen.getByText('Nadia.Khan'));
+    expect(textarea).toHaveValue('ping @Nadia.Khan ');
+    fireEvent.click(screen.getByRole('button', { name: /^comment$/i }));
+    expect(useCommentsStore.getState().comments[0].mentions).toEqual([2]);
+    expect(screen.getByText('@Nadia.Khan')).toBeInTheDocument();
+  });
+
+  test('History tab lists a scoped change with actor and old → new', () => {
+    useAuditLogStore.getState().addEntry({
+      action: 'finding_updated', entity: 'FND-panel-1', field: 'status',
+      oldValue: 'Not Started', newValue: 'In Progress', ...target
+    });
+    render(<RecordPanel open onClose={() => {}} {...target} title="FND-panel-1" />);
+    fireEvent.click(screen.getByRole('button', { name: /history/i }));
+    expect(screen.getByText('Finding Updated')).toBeInTheDocument();
+    expect(screen.getByText('Not Started')).toBeInTheDocument();
+    expect(screen.getByText('In Progress')).toBeInTheDocument();
+    expect(screen.getByText('Gerry.Callahan')).toBeInTheDocument();
+  });
+
+  test('Escape closes the panel without reaching underlying document handlers', () => {
+    const onClose = jest.fn();
+    const underlying = jest.fn();
+    document.addEventListener('keydown', underlying); // bubble phase, like a modal
+    render(<RecordPanel open onClose={onClose} {...target} title="FND-panel-1" />);
+    fireEvent.keyDown(screen.getByPlaceholderText(/add a comment/i), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(underlying).not.toHaveBeenCalled();
+    document.removeEventListener('keydown', underlying);
+  });
+
+  test('comment delete is two-step and logs comment_deleted', () => {
+    useCommentsStore.getState().addComment({ ...target, text: 'to remove' });
+    render(<RecordPanel open onClose={() => {}} {...target} title="FND-panel-1" />);
+    fireEvent.click(screen.getByRole('button', { name: /delete comment/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+    expect(useCommentsStore.getState().comments).toHaveLength(0);
+    const actions = useAuditLogStore.getState().getEntriesForRecord(target.targetType, target.targetId).map(e => e.action);
+    expect(actions).toContain('comment_deleted');
+  });
+});
+
+describe('CommentsButton', () => {
+  test('shows a count badge only when comments exist', () => {
+    const { rerender } = render(<CommentsButton onClick={() => {}} {...target} />);
+    expect(screen.getByRole('button', { name: /comments/i })).toBeInTheDocument();
+    expect(screen.queryByText('1')).not.toBeInTheDocument();
+    useCommentsStore.getState().addComment({ ...target, text: 'one' });
+    rerender(<CommentsButton onClick={() => {}} {...target} />);
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -1848,3 +1848,27 @@ nav a:active { text-decoration: none !important; }
 .app-toolbar-segment { min-height: 28px; min-width: 34px; }
 .app-drawer-trigger { min-height: 34px; min-width: 34px; }
 .btn-terminal { min-height: 28px; }
+
+/* Acting-user selector (sidebar + drawer): who comments and audit entries
+   are attributed to. Theme-var surface so both modes inherit correctly. */
+.app-acting-user {
+  padding: 10px 12px;
+  border-top: 1px solid var(--border-color);
+}
+.app-acting-user-label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-faint);
+  letter-spacing: 0.02em;
+  margin-bottom: 4px;
+}
+.app-acting-user select {
+  width: 100%;
+  font-size: 12px;
+  padding: 4px 6px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -765,9 +765,9 @@ Format as a numbered list. Be specific and actionable.`;
         updateObservation(created.id, itemId, wizardAttachObservation(bankEntry, attachPlan.offersByItem[itemId], orgProfile, {
           substituteName: tailorWithProfile,
           adaptStack: adaptStackRefs
-        }));
+        }), { log: false });
       } else if (generatedProcedures[itemId]) {
-        updateObservation(created.id, itemId, { testProcedures: generatedProcedures[itemId] });
+        updateObservation(created.id, itemId, { testProcedures: generatedProcedures[itemId] }, { log: false });
       }
     }
 

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -19,9 +19,10 @@ import ExportPasswordDialog from '../components/ExportPasswordDialog';
 import AssessmentPicker from '../components/AssessmentPicker';
 import EmptyState from '../components/EmptyState';
 import ScoreSelect from '../components/ScoreSelect';
+import RecordPanel, { CommentsButton } from '../components/RecordPanel';
 
 // Stores
-import useAssessmentsStore, { normalizeAssessmentUsers, ASSESSMENT_USER_ROLES, ASSESSMENT_CSV_HEADERS } from '../stores/assessmentsStore';
+import useAssessmentsStore, { normalizeAssessmentUsers, ASSESSMENT_USER_ROLES, ASSESSMENT_CSV_HEADERS, evaluationTargetId } from '../stores/assessmentsStore';
 import useControlsStore from '../stores/controlsStore';
 import useRequirementsStore, { isCsfRequirement } from '../stores/requirementsStore';
 import useUserStore from '../stores/userStore';
@@ -107,6 +108,8 @@ const Assessments = () => {
   const [view, setView] = useState('list'); // 'list', 'scope', 'assess'
   const [editMode, setEditMode] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState(null);
+  // Comments/History panel for the open evaluation record
+  const [recordPanelOpen, setRecordPanelOpen] = useState(false);
   // Quarter sourced from the global uiStore so the terminal status bar
   // selectors stay in sync. Internal code keeps using 'Q1'..'Q4' strings.
   const selectedQuarterNum = useUIStore((s) => s.selectedQuarter);
@@ -1625,6 +1628,11 @@ Format as a numbered list. Be specific and actionable.`;
                 </div>
               </div>
               <div className="flex items-center gap-3">
+                <CommentsButton
+                  targetType="evaluation"
+                  targetId={evaluationTargetId(currentAssessmentId, selectedItemId)}
+                  onClick={() => setRecordPanelOpen(true)}
+                />
                 {editMode ? (
                   <select
                     value={currentObservation.quarters?.[selectedQuarter]?.testingStatus || 'Not Started'}
@@ -1662,6 +1670,14 @@ Format as a numbered list. Be specific and actionable.`;
               </div>
             </div>
           </div>
+
+          <RecordPanel
+            open={recordPanelOpen}
+            onClose={() => setRecordPanelOpen(false)}
+            targetType="evaluation"
+            targetId={evaluationTargetId(currentAssessmentId, selectedItemId)}
+            title={`${currentAssessment?.name || 'Assessment'} / ${currentItem.type === 'control' ? currentItem.controlId : currentItem.subcategoryId || currentItem.id}`}
+          />
 
           {/* Two-column layout like Jira - 50/50 split */}
           <div className="grid grid-cols-2 flex-1 min-h-0 overflow-hidden">

--- a/src/pages/AuditLog.js
+++ b/src/pages/AuditLog.js
@@ -1,42 +1,9 @@
 import React, { useState, useMemo } from 'react';
 import { Download, Trash2, History, Search, Filter } from 'lucide-react';
 import useAuditLogStore from '../stores/auditLogStore';
-
-// Human-readable action labels and badge colors
-const ACTION_META = {
-  score_changed: { label: 'Score Changed', color: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200' },
-  status_changed: { label: 'Status Changed', color: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200' },
-  finding_created: { label: 'Finding Created', color: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' },
-  finding_updated: { label: 'Finding Updated', color: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200' },
-  finding_deleted: { label: 'Finding Deleted', color: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' },
-  observation_updated: { label: 'Observation Updated', color: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200' },
-};
-
-const ACTION_OPTIONS = [
-  { value: '', label: 'All Actions' },
-  { value: 'score_changed', label: 'Score Changed' },
-  { value: 'status_changed', label: 'Status Changed' },
-  { value: 'finding_created', label: 'Finding Created' },
-  { value: 'finding_updated', label: 'Finding Updated' },
-  { value: 'finding_deleted', label: 'Finding Deleted' },
-  { value: 'observation_updated', label: 'Observation Updated' },
-];
-
-const formatTimestamp = (isoString) => {
-  if (!isoString) return '—';
-  try {
-    return new Intl.DateTimeFormat('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-    }).format(new Date(isoString));
-  } catch {
-    return isoString;
-  }
-};
+// Action labels/colors + timestamp formatting are shared with the per-record
+// History tab (RecordPanel) — one home in utils/auditActions.js.
+import { ACTION_META, ACTION_OPTIONS, formatAuditTimestamp as formatTimestamp } from '../utils/auditActions';
 
 const ActionBadge = ({ action }) => {
   const meta = ACTION_META[action] || { label: action, color: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200' };

--- a/src/pages/Findings.js
+++ b/src/pages/Findings.js
@@ -12,6 +12,7 @@ import { SCOPE_ALL, SCOPE_UNASSIGNED, filterByScope, resolveScopeStamp, defaultS
 import useSort from '../hooks/useSort';
 import EmptyState from '../components/EmptyState';
 import Markdown from '../components/Markdown';
+import RecordPanel, { CommentsButton } from '../components/RecordPanel';
 import { formatInlineMarkdown } from '../utils/markdownText';
 
 const Findings = () => {
@@ -63,6 +64,8 @@ const Findings = () => {
   const [editMode, setEditMode] = useState(false);
   const [errors, setErrors] = useState({});
   const [selectedFinding, setSelectedFinding] = useState(null);
+  // Comments/History panel for the open finding
+  const [recordPanelOpen, setRecordPanelOpen] = useState(false);
 
   // Panel resize state
   const [panelWidth, setPanelWidth] = useState(480);
@@ -581,6 +584,13 @@ const Findings = () => {
                   </span>
                 </div>
                 <div className="flex items-center gap-2">
+                  {selectedFinding && (
+                    <CommentsButton
+                      targetType="finding"
+                      targetId={selectedFinding.id}
+                      onClick={() => setRecordPanelOpen(true)}
+                    />
+                  )}
                   {!editMode && selectedFinding && (
                     <>
                       <button
@@ -611,6 +621,16 @@ const Findings = () => {
                   </button>
                 </div>
               </div>
+
+              {selectedFinding && (
+                <RecordPanel
+                  open={recordPanelOpen}
+                  onClose={() => setRecordPanelOpen(false)}
+                  targetType="finding"
+                  targetId={selectedFinding.id}
+                  title={selectedFinding.jiraKey || selectedFinding.id}
+                />
+              )}
 
               {/* Summary */}
               <div className="mb-6">

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -36,6 +36,7 @@ import useFindingsStore from '../stores/findingsStore';
 import useMetricsStore from '../stores/metricsStore';
 import useOrgProfileStore from '../stores/orgProfileStore';
 import useInventoryStore from '../stores/inventoryStore';
+import useCommentsStore from '../stores/commentsStore';
 import OrgProfileWizard from '../components/OrgProfileWizard';
 import AssessmentPicker from '../components/AssessmentPicker';
 
@@ -138,7 +139,8 @@ const Settings = () => {
     findingsStore: useFindingsStore,
     metricsStore: useMetricsStore,
     orgProfileStore: useOrgProfileStore,
-    inventoryStore: useInventoryStore
+    inventoryStore: useInventoryStore,
+    commentsStore: useCommentsStore
   }), []);
 
   const handleCancelExportPicker = useCallback(() => setPendingExport(null), []);
@@ -328,7 +330,8 @@ const Settings = () => {
         findingsStore: useFindingsStore,
         metricsStore: useMetricsStore,
         orgProfileStore: useOrgProfileStore,
-        inventoryStore: useInventoryStore
+        inventoryStore: useInventoryStore,
+        commentsStore: useCommentsStore
       };
 
       const validation = validateDatabaseExport(parsed);

--- a/src/pages/UserControls.js
+++ b/src/pages/UserControls.js
@@ -377,6 +377,11 @@ const UserControls = () => {
       setNewControl(prev => ({ ...prev, [field]: value }));
     } else if (selectedControlId) {
       updateControl(selectedControlId, { [field]: value });
+      // Controls are keyed by controlId, so editing it renames the record —
+      // follow it, or the panel (and the store's next write) targets a ghost.
+      if (field === 'controlId' && value && value !== selectedControlId) {
+        setSelectedControlId(value);
+      }
     }
   }, [isCreating, selectedControlId, updateControl]);
 

--- a/src/pages/UserControls.js
+++ b/src/pages/UserControls.js
@@ -12,6 +12,7 @@ import { sanitizeExternalUrl } from '../utils/externalLinks';
 import FrameworkBadge from '../components/FrameworkBadge';
 import UserSelector from '../components/UserSelector';
 import DropdownPortal from '../components/DropdownPortal';
+import RecordPanel, { CommentsButton } from '../components/RecordPanel';
 import SortableHeader from '../components/SortableHeader';
 
 // Stores
@@ -70,6 +71,8 @@ const UserControls = () => {
   const [detailPanelOpen, setDetailPanelOpen] = useState(false);
   const [editMode, setEditMode] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
+  // Comments/History panel for the open control
+  const [recordPanelOpen, setRecordPanelOpen] = useState(false);
 
   // New control form state
   const [newControl, setNewControl] = useState({
@@ -875,6 +878,13 @@ const UserControls = () => {
                   <div className="flex items-center justify-between gap-2">
                     <h2 className="text-xl font-bold font-mono">{currentControl.controlId}</h2>
                     <div className="flex items-center gap-2">
+                      {!isCreating && (
+                        <CommentsButton
+                          targetType="control"
+                          targetId={currentControl.controlId}
+                          onClick={() => setRecordPanelOpen(true)}
+                        />
+                      )}
                       <button
                         onClick={() => setDetailPanelOpen(false)}
                         className="p-1.5 rounded-full hover:bg-gray-200 text-gray-500"
@@ -922,6 +932,16 @@ const UserControls = () => {
                       )}
                     </div>
                   </div>
+
+                  {!isCreating && (
+                    <RecordPanel
+                      open={recordPanelOpen}
+                      onClose={() => setRecordPanelOpen(false)}
+                      targetType="control"
+                      targetId={currentControl.controlId}
+                      title={currentControl.name ? `${currentControl.controlId} ${currentControl.name}` : currentControl.controlId}
+                    />
+                  )}
 
                   {/* Control Details */}
                   <div className="bg-white p-4 rounded-lg shadow-sm border space-y-4">

--- a/src/stores/assessmentsStore.js
+++ b/src/stores/assessmentsStore.js
@@ -19,6 +19,7 @@ import { getBankProcedure, BANK_VERSION } from '../utils/procedureBank';
 import { expandProcedureText } from '../utils/platformBank';
 import { cleanCommunityMarkdown } from '../utils/relatedSection.mjs';
 import useAuditLogStore from './auditLogStore';
+import useCommentsStore from './commentsStore';
 
 // The demo assessment's user roster (issue #297): the 8 shipped Alma
 // directory users, so the example demonstrates the per-assessment user scope
@@ -967,6 +968,9 @@ const useAssessmentsStore = create(
           set({ currentAssessmentId: null });
         }
         if (existing) {
+          // Sweep the assessment's discussion and every evaluation thread
+          // under it; the audit trail is retained.
+          useCommentsStore.getState().deleteCommentsForAssessment(assessmentId);
           useAuditLogStore.getState().addEntry({
             action: 'assessment_deleted',
             entity: existing.name,

--- a/src/stores/assessmentsStore.js
+++ b/src/stores/assessmentsStore.js
@@ -368,6 +368,13 @@ const buildAssessmentCsvRow = ({ assessment, itemId, obs, getItemName, getImplem
  * Current schema version of csf-assessments-storage. Exported so the restore
  * path (dataImport.js) can migrate older exported payloads before applying them.
  */
+/**
+ * Stable comment/audit target id for one evaluation record (an observation
+ * within an assessment). Shared by the store's change logging and the
+ * evaluation detail view's RecordPanel so both always scope identically.
+ */
+export const evaluationTargetId = (assessmentId, itemId) => `${assessmentId}::${itemId}`;
+
 export const ASSESSMENTS_SCHEMA_VERSION = 16;
 
 /**
@@ -865,6 +872,12 @@ const useAssessmentsStore = create(
         const updatedAssessments = [...assessments, newAssessment];
         get().setAssessments(updatedAssessments);
         set({ currentAssessmentId: newId });
+        useAuditLogStore.getState().addEntry({
+          action: 'assessment_created',
+          entity: newAssessment.name,
+          targetType: 'assessment',
+          targetId: newId
+        });
         return newAssessment;
       },
 
@@ -872,6 +885,23 @@ const useAssessmentsStore = create(
       // normalized at the producer so no future edit surface can persist an
       // unnormalized config (issue #288 doctrine).
       updateAssessment: (assessmentId, updates) => {
+        // Rename logging only — observation edits route through
+        // updateObservation (which logs field-level) and land here as an
+        // `observations` payload that must not double-log.
+        if (updates && updates.name !== undefined) {
+          const beforeAssessment = get().getAssessment(assessmentId);
+          if (beforeAssessment && beforeAssessment.name !== updates.name) {
+            useAuditLogStore.getState().addEntry({
+              action: 'assessment_updated',
+              entity: updates.name,
+              field: 'name',
+              oldValue: beforeAssessment.name,
+              newValue: updates.name,
+              targetType: 'assessment',
+              targetId: assessmentId
+            });
+          }
+        }
         let safeUpdates = updates;
         if (updates && updates.externalTracking !== undefined) {
           safeUpdates = { ...safeUpdates, externalTracking: normalizeExternalTracking(updates.externalTracking) };
@@ -930,10 +960,19 @@ const useAssessmentsStore = create(
 
       // Delete assessment
       deleteAssessment: (assessmentId) => {
+        const existing = get().getAssessment(assessmentId);
         const updatedAssessments = get().assessments.filter(a => a.id !== assessmentId);
         get().setAssessments(updatedAssessments);
         if (get().currentAssessmentId === assessmentId) {
           set({ currentAssessmentId: null });
+        }
+        if (existing) {
+          useAuditLogStore.getState().addEntry({
+            action: 'assessment_deleted',
+            entity: existing.name,
+            targetType: 'assessment',
+            targetId: assessmentId
+          });
         }
       },
 
@@ -1061,31 +1100,28 @@ const useAssessmentsStore = create(
 
         get().updateAssessment(assessmentId, { observations: updatedObservations });
 
-        // Audit logging: record score and status changes
-        const entityLabel = `${assessment.name} / ${itemId}`;
-        const logEntry = useAuditLogStore.getState().addEntry;
-
-        if (observationData.score !== undefined && observationData.score !== currentObservation.score) {
-          logEntry({
-            action: 'score_changed',
-            entity: entityLabel,
-            field: 'score',
-            oldValue: currentObservation.score,
-            newValue: observationData.score,
-            user: 'System'
-          });
-        }
-
-        if (observationData.testingStatus !== undefined && observationData.testingStatus !== currentObservation.testingStatus) {
-          logEntry({
-            action: 'status_changed',
-            entity: entityLabel,
-            field: 'testingStatus',
-            oldValue: currentObservation.testingStatus,
-            newValue: observationData.testingStatus,
-            user: 'System'
-          });
-        }
+        // Audit logging: field-level diffs on the evaluation record,
+        // attributed to the acting user. Score/status keep their historical
+        // action names; everything else logs as observation_updated.
+        useAuditLogStore.getState().logFieldChanges({
+          targetType: 'evaluation',
+          targetId: evaluationTargetId(assessmentId, itemId),
+          entity: `${assessment.name} / ${itemId}`,
+          before: currentObservation,
+          after: sanitizedData,
+          defaultAction: 'observation_updated',
+          fields: [
+            { key: 'score', action: 'score_changed' },
+            { key: 'testingStatus', action: 'status_changed' },
+            'testProcedures',
+            'auditorId',
+            {
+              key: 'remediation',
+              label: 'remediation.actionPlan',
+              get: (obj) => obj?.remediation?.actionPlan
+            }
+          ]
+        });
       },
 
       // Update quarterly observation data for a specific quarter
@@ -1117,6 +1153,25 @@ const useAssessmentsStore = create(
         };
 
         get().updateAssessment(assessmentId, { observations: updatedObservations });
+
+        // Field-level change log for the quarter's editable fields.
+        useAuditLogStore.getState().logFieldChanges({
+          targetType: 'evaluation',
+          targetId: evaluationTargetId(assessmentId, itemId),
+          entity: `${assessment.name} / ${itemId}`,
+          before: currentQuarter,
+          after: {
+            score: quarterData.score,
+            testingStatus: quarterData.testingStatus,
+            // compare the sanitized text that was actually persisted
+            observations: quarterData.observations === undefined ? undefined : sanitizedQuarterData.observations
+          },
+          fields: [
+            { key: 'score', label: `${quarter} score`, action: 'score_changed' },
+            { key: 'testingStatus', label: `${quarter} testingStatus`, action: 'status_changed' },
+            { key: 'observations', label: `${quarter} observations`, action: 'observation_updated' }
+          ]
+        });
       },
 
       // Get assessment progress (considers all quarters - complete if any quarter is complete)

--- a/src/stores/assessmentsStore.js
+++ b/src/stores/assessmentsStore.js
@@ -1046,7 +1046,10 @@ const useAssessmentsStore = create(
       // Update observation for a scoped item
       // observationData can include: auditorId, testProcedures, linkedArtifacts, remediation
       // For quarterly data, use updateQuarterlyObservation instead
-      updateObservation: (assessmentId, itemId, observationData) => {
+      // options.log defaults true for user edits; programmatic bulk lanes
+      // (wizard bank-attach loop, migration seeding) pass { log: false } so a
+      // 105-item attach cannot flood the audit log's retention cap.
+      updateObservation: (assessmentId, itemId, observationData, options = {}) => {
         const assessment = get().getAssessment(assessmentId);
         if (!assessment) return;
 
@@ -1103,6 +1106,7 @@ const useAssessmentsStore = create(
         // Audit logging: field-level diffs on the evaluation record,
         // attributed to the acting user. Score/status keep their historical
         // action names; everything else logs as observation_updated.
+        if (options.log === false) return;
         useAuditLogStore.getState().logFieldChanges({
           targetType: 'evaluation',
           targetId: evaluationTargetId(assessmentId, itemId),

--- a/src/stores/assessmentsStore.js
+++ b/src/stores/assessmentsStore.js
@@ -1161,13 +1161,15 @@ const useAssessmentsStore = create(
           entity: `${assessment.name} / ${itemId}`,
           before: currentQuarter,
           after: {
-            score: quarterData.score,
+            actualScore: quarterData.actualScore,
+            targetScore: quarterData.targetScore,
             testingStatus: quarterData.testingStatus,
             // compare the sanitized text that was actually persisted
             observations: quarterData.observations === undefined ? undefined : sanitizedQuarterData.observations
           },
           fields: [
-            { key: 'score', label: `${quarter} score`, action: 'score_changed' },
+            { key: 'actualScore', label: `${quarter} actualScore`, action: 'score_changed' },
+            { key: 'targetScore', label: `${quarter} targetScore`, action: 'score_changed' },
             { key: 'testingStatus', label: `${quarter} testingStatus`, action: 'status_changed' },
             { key: 'observations', label: `${quarter} observations`, action: 'observation_updated' }
           ]

--- a/src/stores/auditLogStore.js
+++ b/src/stores/auditLogStore.js
@@ -1,27 +1,131 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { v4 as uuidv4 } from 'uuid';
+import useUserStore from './userStore';
+import { csvFormulaGuard } from '../utils/sanitize';
+
+// Retention cap — oldest entries fall off past this count. Raised from 500
+// when field-level logging across three entity types landed; at ~250 bytes
+// per truncated entry this is ~250KB of localStorage worst-case.
+const MAX_ENTRIES = 1000;
+
+// Values stored in oldValue/newValue are truncated so a pasted document
+// can't bloat localStorage through the log.
+const MAX_VALUE_LENGTH = 120;
+
+// Several edit surfaces (Controls detail panel, evaluation edit mode) write
+// to their store on every keystroke. Consecutive changes to the same field of
+// the same record by the same actor within this window UPDATE the newest
+// matching entry instead of appending — the log records "A → final text",
+// not one row per character.
+export const COALESCE_WINDOW_MS = 5 * 60 * 1000;
+
+const truncateValue = (v) => {
+  if (v == null) return null;
+  const s = String(v);
+  return s.length > MAX_VALUE_LENGTH ? `${s.slice(0, MAX_VALUE_LENGTH - 1)}…` : s;
+};
+
+/**
+ * Resolve the acting user's display name for attribution. Falls back to
+ * 'System' when no acting user is selected (or the user was deleted).
+ */
+export const getActorName = () => {
+  try {
+    return useUserStore.getState().getCurrentUserName();
+  } catch {
+    return 'System';
+  }
+};
 
 const useAuditLogStore = create(
   persist(
     (set, get) => ({
       entries: [],
 
-      // Add a log entry
-      addEntry: ({ action, entity, field, oldValue, newValue, user }) => {
+      // Add a log entry. targetType/targetId scope the entry to a record
+      // ('evaluation' | 'control' | 'finding' | 'assessment') so per-record
+      // history views can query it; legacy entries without them still render.
+      addEntry: ({ action, entity, field, oldValue, newValue, user, targetType, targetId }) => {
+        const now = Date.now();
+        const actor = user || getActorName();
+        const entries = get().entries;
+
+        // Coalesce keystroke-grain updates: newest entry for the same
+        // action + record + field + actor within the window absorbs this
+        // change instead of a new row appearing per keystroke.
+        if (field && targetType && targetId) {
+          const idx = entries.findIndex(e =>
+            e.action === action &&
+            e.targetType === targetType &&
+            e.targetId === targetId &&
+            e.field === field &&
+            e.user === actor
+          );
+          if (idx !== -1 && now - new Date(entries[idx].timestamp).getTime() < COALESCE_WINDOW_MS) {
+            const truncatedNew = truncateValue(newValue);
+            // Typed back to the original value — the net change is nothing;
+            // drop the entry entirely rather than logging a no-op. Only when
+            // the comparison is unambiguous: a truncated stored oldValue can
+            // no longer prove full-value equality, so it never triggers this.
+            const unambiguous = entries[idx].oldValue == null || entries[idx].oldValue.length < MAX_VALUE_LENGTH;
+            if (unambiguous && entries[idx].oldValue === truncatedNew) {
+              set({ entries: entries.filter((_, i) => i !== idx) });
+              return;
+            }
+            const updated = { ...entries[idx], newValue: truncatedNew, timestamp: new Date().toISOString() };
+            set({ entries: [updated, ...entries.filter((_, i) => i !== idx)].slice(0, MAX_ENTRIES) });
+            return;
+          }
+        }
+
         const entry = {
           id: uuidv4(),
           timestamp: new Date().toISOString(),
           action,
           entity,
           field: field || null,
-          oldValue: oldValue != null ? String(oldValue) : null,
-          newValue: newValue != null ? String(newValue) : null,
-          user: user || 'System'
+          oldValue: truncateValue(oldValue),
+          newValue: truncateValue(newValue),
+          user: actor,
+          targetType: targetType || null,
+          targetId: targetId || null
         };
-        set((state) => ({
-          entries: [entry, ...state.entries].slice(0, 500) // Keep last 500
-        }));
+        set({ entries: [entry, ...entries].slice(0, MAX_ENTRIES) });
+      },
+
+      /**
+       * Diff `before` vs `after` across a named field list and write one
+       * entry per changed field. Only fields PRESENT in `after` are compared
+       * (partial updates never log untouched fields). Returns the number of
+       * entries written.
+       *
+       * fields: array of { key, label?, action?, get? } — `get(obj)` reads a
+       * nested value; label overrides the field name shown in the log.
+       */
+      logFieldChanges: ({ targetType, targetId, entity, before, after, fields, user, defaultAction }) => {
+        let count = 0;
+        fields.forEach((spec) => {
+          const { key, label, action, get: getter } = typeof spec === 'string' ? { key: spec } : spec;
+          const nextRaw = getter ? getter(after) : after?.[key];
+          if (nextRaw === undefined) return; // field not part of this update
+          const prevRaw = getter ? getter(before) : before?.[key];
+          const prev = prevRaw == null ? '' : String(prevRaw);
+          const next = nextRaw == null ? '' : String(nextRaw);
+          if (prev === next) return;
+          get().addEntry({
+            action: action || defaultAction || 'field_changed',
+            entity,
+            field: label || key,
+            oldValue: prevRaw == null ? null : prevRaw,
+            newValue: nextRaw,
+            user,
+            targetType,
+            targetId
+          });
+          count += 1;
+        });
+        return count;
       },
 
       // Get entries with optional filters
@@ -30,6 +134,12 @@ const useAuditLogStore = create(
         if (filters.action) entries = entries.filter(e => e.action === filters.action);
         if (filters.entity) entries = entries.filter(e => e.entity?.includes(filters.entity));
         return entries;
+      },
+
+      // All entries for one record, newest first (store order is newest-first).
+      getEntriesForRecord: (targetType, targetId) => {
+        if (!targetType || !targetId) return [];
+        return get().entries.filter(e => e.targetType === targetType && e.targetId === targetId);
       },
 
       // Clear all entries
@@ -41,7 +151,10 @@ const useAuditLogStore = create(
         const headers = 'Timestamp,Action,Entity,Field,Old Value,New Value,User\n';
         const rows = entries.map(e =>
           [e.timestamp, e.action, e.entity, e.field, e.oldValue, e.newValue, e.user]
-            .map(v => `"${(v || '').replace(/"/g, '""')}"`)
+            // csvFormulaGuard neutralizes leading =+-@ (mention syntax makes
+            // @ routine in these values); the manual wrap below still does
+            // the quoting, which is the split of duties its docstring names.
+            .map(v => `"${csvFormulaGuard(v == null ? '' : v).replace(/"/g, '""')}"`)
             .join(',')
         ).join('\n');
         const blob = new Blob([headers + rows], { type: 'text/csv' });

--- a/src/stores/auditLogStore.js
+++ b/src/stores/auditLogStore.js
@@ -142,6 +142,19 @@ const useAuditLogStore = create(
         return get().entries.filter(e => e.targetType === targetType && e.targetId === targetId);
       },
 
+      // Record-id rename support: history follows the record instead of
+      // orphaning (accountability survives a controlId edit).
+      retargetRecord: (targetType, oldTargetId, newTargetId) => {
+        if (!targetType || !oldTargetId || !newTargetId || oldTargetId === newTargetId) return;
+        set((state) => ({
+          entries: state.entries.map(e =>
+            e.targetType === targetType && e.targetId === oldTargetId
+              ? { ...e, targetId: newTargetId }
+              : e
+          )
+        }));
+      },
+
       // Clear all entries
       clearLog: () => set({ entries: [] }),
 

--- a/src/stores/auditLogStore.js
+++ b/src/stores/auditLogStore.js
@@ -20,6 +20,12 @@ const MAX_VALUE_LENGTH = 120;
 // not one row per character.
 export const COALESCE_WINDOW_MS = 5 * 60 * 1000;
 
+// A change typed straight back to its original value is dropped as a no-op —
+// but ONLY at genuine keystroke/misclick grain. Past this window the trail
+// stays append-only: a deliberate A → B → A sequence keeps the A → B entry
+// and gains a B → A entry, so the log never loses evidence that B existed.
+export const REVERT_DROP_WINDOW_MS = 15 * 1000;
+
 const truncateValue = (v) => {
   if (v == null) return null;
   const s = String(v);
@@ -64,18 +70,24 @@ const useAuditLogStore = create(
           );
           if (idx !== -1 && now - new Date(entries[idx].timestamp).getTime() < COALESCE_WINDOW_MS) {
             const truncatedNew = truncateValue(newValue);
-            // Typed back to the original value — the net change is nothing;
-            // drop the entry entirely rather than logging a no-op. Only when
-            // the comparison is unambiguous: a truncated stored oldValue can
-            // no longer prove full-value equality, so it never triggers this.
+            // Typed back to the original value — at keystroke grain the net
+            // change is nothing, so drop the entry. Only when the comparison
+            // is unambiguous (a truncated stored oldValue can no longer prove
+            // full-value equality) AND within the tight revert window: a
+            // LATER revert falls through to append its own B → A entry, so
+            // the trail stays append-only for deliberate changes.
             const unambiguous = entries[idx].oldValue == null || entries[idx].oldValue.length < MAX_VALUE_LENGTH;
             if (unambiguous && entries[idx].oldValue === truncatedNew) {
-              set({ entries: entries.filter((_, i) => i !== idx) });
+              if (now - new Date(entries[idx].timestamp).getTime() < REVERT_DROP_WINDOW_MS) {
+                set({ entries: entries.filter((_, i) => i !== idx) });
+                return;
+              }
+              // fall through — append a new entry recording the revert
+            } else {
+              const updated = { ...entries[idx], newValue: truncatedNew, timestamp: new Date().toISOString() };
+              set({ entries: [updated, ...entries.filter((_, i) => i !== idx)].slice(0, MAX_ENTRIES) });
               return;
             }
-            const updated = { ...entries[idx], newValue: truncatedNew, timestamp: new Date().toISOString() };
-            set({ entries: [updated, ...entries.filter((_, i) => i !== idx)].slice(0, MAX_ENTRIES) });
-            return;
           }
         }
 

--- a/src/stores/auditLogStore.test.js
+++ b/src/stores/auditLogStore.test.js
@@ -1,0 +1,176 @@
+/**
+ * auditLogStore extension — record scoping, the field-diff helper, keystroke
+ * coalescing, actor attribution (behavioral, via the production path), value
+ * truncation, and CSV formula guarding.
+ */
+import useAuditLogStore, { COALESCE_WINDOW_MS, getActorName } from './auditLogStore';
+import useUserStore from './userStore';
+
+const target = { targetType: 'control', targetId: 'CTL-1' };
+
+beforeEach(() => {
+  window.localStorage.clear();
+  useAuditLogStore.setState({ entries: [] });
+  useUserStore.setState({ users: [{ id: 7, name: 'Nadia.Khan', email: 'n@x.com' }], currentUserId: null });
+});
+
+describe('addEntry + record scoping', () => {
+  test('persists targetType/targetId and scopes getEntriesForRecord', () => {
+    const add = useAuditLogStore.getState().addEntry;
+    add({ action: 'control_updated', entity: 'CTL-1', field: 'status', oldValue: 'a', newValue: 'b', ...target });
+    add({ action: 'control_updated', entity: 'CTL-2', field: 'status', oldValue: 'a', newValue: 'b', targetType: 'control', targetId: 'CTL-2' });
+    expect(useAuditLogStore.getState().getEntriesForRecord('control', 'CTL-1')).toHaveLength(1);
+    expect(useAuditLogStore.getState().getEntriesForRecord('control', 'CTL-2')).toHaveLength(1);
+  });
+
+  test('legacy entries without target fields still return from getEntries', () => {
+    useAuditLogStore.setState({
+      entries: [{ id: 'x', timestamp: new Date().toISOString(), action: 'score_changed', entity: 'legacy', field: 'score', oldValue: '1', newValue: '2', user: 'System' }]
+    });
+    expect(useAuditLogStore.getState().getEntries()).toHaveLength(1);
+    expect(useAuditLogStore.getState().getEntriesForRecord('control', 'CTL-1')).toHaveLength(0);
+  });
+
+  test('attributes to the acting user resolved at write time (production path)', () => {
+    useUserStore.getState().setCurrentUser(7);
+    useAuditLogStore.getState().addEntry({ action: 'control_updated', entity: 'e', field: 'f', oldValue: 'a', newValue: 'b', ...target });
+    expect(useAuditLogStore.getState().entries[0].user).toBe('Nadia.Khan');
+    expect(getActorName()).toBe('Nadia.Khan');
+  });
+
+  test('falls back to System when the acting user id no longer resolves', () => {
+    useUserStore.getState().setCurrentUser(7);
+    useUserStore.getState().deleteUser(7);
+    useAuditLogStore.getState().addEntry({ action: 'control_updated', entity: 'e', field: 'f', oldValue: 'a', newValue: 'b', ...target });
+    expect(useAuditLogStore.getState().entries[0].user).toBe('System');
+  });
+
+  test('truncates stored values to 120 chars with an ellipsis marker', () => {
+    useAuditLogStore.getState().addEntry({ action: 'control_updated', entity: 'e', field: 'f', oldValue: 'x'.repeat(300), newValue: 'y'.repeat(300), ...target });
+    const e = useAuditLogStore.getState().entries[0];
+    expect(e.oldValue.length).toBe(120);
+    expect(e.oldValue.endsWith('…')).toBe(true);
+    expect(e.newValue.length).toBe(120);
+  });
+});
+
+describe('keystroke coalescing', () => {
+  test('same actor+record+field within the window updates the entry in place', () => {
+    const add = useAuditLogStore.getState().addEntry;
+    add({ action: 'control_updated', entity: 'e', field: 'name', oldValue: 'A', newValue: 'Ab', ...target });
+    add({ action: 'control_updated', entity: 'e', field: 'name', oldValue: 'Ab', newValue: 'Abc', ...target });
+    const entries = useAuditLogStore.getState().entries;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].oldValue).toBe('A');
+    expect(entries[0].newValue).toBe('Abc');
+  });
+
+  test('typing back to the original value drops the entry entirely', () => {
+    const add = useAuditLogStore.getState().addEntry;
+    add({ action: 'control_updated', entity: 'e', field: 'name', oldValue: 'A', newValue: 'Ab', ...target });
+    add({ action: 'control_updated', entity: 'e', field: 'name', oldValue: 'Ab', newValue: 'A', ...target });
+    expect(useAuditLogStore.getState().entries).toHaveLength(0);
+  });
+
+  test('a different field or record never coalesces', () => {
+    const add = useAuditLogStore.getState().addEntry;
+    add({ action: 'control_updated', entity: 'e', field: 'name', oldValue: 'A', newValue: 'B', ...target });
+    add({ action: 'control_updated', entity: 'e', field: 'status', oldValue: 'x', newValue: 'y', ...target });
+    add({ action: 'control_updated', entity: 'e', field: 'name', oldValue: 'A', newValue: 'B', targetType: 'control', targetId: 'CTL-9' });
+    expect(useAuditLogStore.getState().entries).toHaveLength(3);
+  });
+
+  test('entries older than the window are never coalesced', () => {
+    const add = useAuditLogStore.getState().addEntry;
+    add({ action: 'control_updated', entity: 'e', field: 'name', oldValue: 'A', newValue: 'B', ...target });
+    const aged = useAuditLogStore.getState().entries.map(e => ({
+      ...e,
+      timestamp: new Date(Date.now() - COALESCE_WINDOW_MS - 1000).toISOString()
+    }));
+    useAuditLogStore.setState({ entries: aged });
+    add({ action: 'control_updated', entity: 'e', field: 'name', oldValue: 'B', newValue: 'C', ...target });
+    expect(useAuditLogStore.getState().entries).toHaveLength(2);
+  });
+});
+
+describe('logFieldChanges', () => {
+  test('one entry per changed field; untouched and absent fields never log', () => {
+    const n = useAuditLogStore.getState().logFieldChanges({
+      ...target,
+      entity: 'CTL-1',
+      before: { name: 'old', status: 'Implemented', tests: 'same' },
+      after: { name: 'new', status: 'Not Implemented', tests: 'same' },
+      defaultAction: 'control_updated',
+      fields: ['name', 'status', 'tests', 'frameworks']
+    });
+    expect(n).toBe(2);
+    const fields = useAuditLogStore.getState().entries.map(e => e.field).sort();
+    expect(fields).toEqual(['name', 'status']);
+  });
+
+  test('a no-op update writes zero entries', () => {
+    const n = useAuditLogStore.getState().logFieldChanges({
+      ...target,
+      entity: 'CTL-1',
+      before: { name: 'same' },
+      after: { name: 'same' },
+      defaultAction: 'control_updated',
+      fields: ['name']
+    });
+    expect(n).toBe(0);
+    expect(useAuditLogStore.getState().entries).toHaveLength(0);
+  });
+
+  test('diffs FULL values even past the truncation cap', () => {
+    const base = 'z'.repeat(150);
+    const n = useAuditLogStore.getState().logFieldChanges({
+      ...target,
+      entity: 'CTL-1',
+      before: { tests: `${base}old` },
+      after: { tests: `${base}new` },
+      defaultAction: 'control_updated',
+      fields: ['tests']
+    });
+    expect(n).toBe(1);
+  });
+
+  test('per-field action override and nested getter work', () => {
+    useAuditLogStore.getState().logFieldChanges({
+      targetType: 'evaluation',
+      targetId: 'ASM-1::PR.DS-01',
+      entity: 'A / PR.DS-01',
+      before: { score: 3, remediation: { actionPlan: 'a' } },
+      after: { score: 5, remediation: { actionPlan: 'b' } },
+      defaultAction: 'observation_updated',
+      fields: [
+        { key: 'score', action: 'score_changed' },
+        { key: 'remediation', label: 'remediation.actionPlan', get: (o) => o?.remediation?.actionPlan }
+      ]
+    });
+    const entries = useAuditLogStore.getState().entries;
+    expect(entries.map(e => e.action).sort()).toEqual(['observation_updated', 'score_changed']);
+    expect(entries.find(e => e.action === 'observation_updated').field).toBe('remediation.actionPlan');
+  });
+});
+
+describe('CSV export formula guard', () => {
+  test('values starting with = + - @ are neutralized in the CSV', () => {
+    const add = useAuditLogStore.getState().addEntry;
+    add({ action: 'comment_added', entity: '@Steve.T mention', field: 'f', oldValue: '=cmd|calc', newValue: '@Steve.T hi', ...target });
+    let csvText = null;
+    const OriginalBlob = global.Blob;
+    global.Blob = class { constructor(parts) { csvText = parts.join(''); } };
+    global.URL.createObjectURL = jest.fn(() => 'blob:x');
+    global.URL.revokeObjectURL = jest.fn();
+    const click = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    try {
+      useAuditLogStore.getState().exportCSV();
+    } finally {
+      global.Blob = OriginalBlob;
+      click.mockRestore();
+    }
+    expect(csvText).toContain(`"'=cmd|calc"`);
+    expect(csvText).toContain(`"'@Steve.T hi"`);
+    expect(csvText).toContain(`"'@Steve.T mention"`);
+  });
+});

--- a/src/stores/auditLogStore.test.js
+++ b/src/stores/auditLogStore.test.js
@@ -3,7 +3,7 @@
  * coalescing, actor attribution (behavioral, via the production path), value
  * truncation, and CSV formula guarding.
  */
-import useAuditLogStore, { COALESCE_WINDOW_MS, getActorName } from './auditLogStore';
+import useAuditLogStore, { COALESCE_WINDOW_MS, REVERT_DROP_WINDOW_MS, getActorName } from './auditLogStore';
 import useUserStore from './userStore';
 
 const target = { targetType: 'control', targetId: 'CTL-1' };
@@ -70,6 +70,25 @@ describe('keystroke coalescing', () => {
     add({ action: 'control_updated', entity: 'e', field: 'name', oldValue: 'A', newValue: 'Ab', ...target });
     add({ action: 'control_updated', entity: 'e', field: 'name', oldValue: 'Ab', newValue: 'A', ...target });
     expect(useAuditLogStore.getState().entries).toHaveLength(0);
+  });
+
+  test('a DELIBERATE revert (outside the drop window) stays append-only', () => {
+    const add = useAuditLogStore.getState().addEntry;
+    add({ action: 'score_changed', entity: 'e', field: 'score', oldValue: '2', newValue: '5', ...target });
+    // age the entry past the revert-drop window but inside the coalesce window
+    const aged = useAuditLogStore.getState().entries.map(e => ({
+      ...e,
+      timestamp: new Date(Date.now() - REVERT_DROP_WINDOW_MS - 1000).toISOString()
+    }));
+    useAuditLogStore.setState({ entries: aged });
+    add({ action: 'score_changed', entity: 'e', field: 'score', oldValue: '5', newValue: '2', ...target });
+    const entries = useAuditLogStore.getState().entries;
+    // both the 2 → 5 and the 5 → 2 rows survive — evidence that 5 existed
+    expect(entries).toHaveLength(2);
+    expect(entries[0].oldValue).toBe('5');
+    expect(entries[0].newValue).toBe('2');
+    expect(entries[1].oldValue).toBe('2');
+    expect(entries[1].newValue).toBe('5');
   });
 
   test('a different field or record never coalesces', () => {

--- a/src/stores/commentsStore.js
+++ b/src/stores/commentsStore.js
@@ -155,6 +155,31 @@ const useCommentsStore = create(
         set({ comments: Array.isArray(comments) ? comments : [] });
       },
 
+      // Called by the record stores' delete paths: a deleted record's
+      // discussion is unreachable in the UI, and — because control ids are
+      // recycled (max+1) — leaving it behind would silently attach the old
+      // thread to a future unrelated record with the same id.
+      deleteCommentsFor: (targetType, targetId) => {
+        if (!targetType || !targetId) return;
+        set((state) => ({
+          comments: state.comments.filter(c => !(c.targetType === targetType && c.targetId === targetId))
+        }));
+      },
+
+      // Assessment deletion sweep: the assessment's own thread plus every
+      // evaluation-record thread under it (targetId `assessmentId::itemId`).
+      deleteCommentsForAssessment: (assessmentId) => {
+        if (!assessmentId) return;
+        const prefix = `${assessmentId}::`;
+        set((state) => ({
+          comments: state.comments.filter(c => {
+            if (c.targetType === 'assessment' && c.targetId === assessmentId) return false;
+            if (c.targetType === 'evaluation' && typeof c.targetId === 'string' && c.targetId.startsWith(prefix)) return false;
+            return true;
+          })
+        }));
+      },
+
       // Record-id rename support (controls key on user-editable controlId):
       // comments follow the record instead of orphaning.
       retargetComments: (targetType, oldTargetId, newTargetId) => {

--- a/src/stores/commentsStore.js
+++ b/src/stores/commentsStore.js
@@ -153,6 +153,19 @@ const useCommentsStore = create(
       // Bulk setter for restore/import lanes (bypasses per-comment logging).
       setComments: (comments) => {
         set({ comments: Array.isArray(comments) ? comments : [] });
+      },
+
+      // Record-id rename support (controls key on user-editable controlId):
+      // comments follow the record instead of orphaning.
+      retargetComments: (targetType, oldTargetId, newTargetId) => {
+        if (!targetType || !oldTargetId || !newTargetId || oldTargetId === newTargetId) return;
+        set((state) => ({
+          comments: state.comments.map(c =>
+            c.targetType === targetType && c.targetId === oldTargetId
+              ? { ...c, targetId: newTargetId }
+              : c
+          )
+        }));
       }
     }),
     {

--- a/src/stores/commentsStore.js
+++ b/src/stores/commentsStore.js
@@ -1,0 +1,139 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { v4 as uuidv4 } from 'uuid';
+import { sanitizeInput } from '../utils/sanitize';
+import useUserStore from './userStore';
+import useAuditLogStore from './auditLogStore';
+
+// Raw input is capped BEFORE sanitize so DOMPurify's entity encoding can
+// never be truncated mid-entity (the sanitized form may run slightly longer).
+export const MAX_COMMENT_LENGTH = 2000;
+
+/**
+ * Split comment text into segments for mention-aware work. This single
+ * function backs BOTH the parse-at-write path (mentions[]) and the
+ * highlight-at-render path, so stored mentions and visible highlights can
+ * never diverge. String scan — no regex built from user names, so names with
+ * regex metacharacters ('.', '(', '+') are safe. Candidates are matched
+ * longest-name-first so '@Steven Mercer' never resolves as '@Steve' + 'n';
+ * on duplicate display names the first user in directory order wins.
+ *
+ * Returns [{ text, userId? }, ...] where segments with userId are mentions
+ * (text includes the leading '@').
+ */
+export const segmentMentions = (text, users) => {
+  const value = typeof text === 'string' ? text : '';
+  if (!value) return [];
+  const candidates = (users || [])
+    .filter(u => typeof u.name === 'string' && u.name.trim())
+    .sort((a, b) => b.name.length - a.name.length);
+  const lower = value.toLowerCase();
+  const segments = [];
+  let plainStart = 0;
+  let i = 0;
+  while (i < value.length) {
+    if (value[i] === '@') {
+      const match = candidates.find(u =>
+        lower.startsWith(u.name.toLowerCase(), i + 1)
+      );
+      if (match) {
+        if (i > plainStart) segments.push({ text: value.slice(plainStart, i) });
+        segments.push({ text: `@${value.slice(i + 1, i + 1 + match.name.length)}`, userId: match.id });
+        i += 1 + match.name.length;
+        plainStart = i;
+        continue;
+      }
+    }
+    i += 1;
+  }
+  if (plainStart < value.length) segments.push({ text: value.slice(plainStart) });
+  return segments;
+};
+
+export const parseMentions = (text, users) => {
+  const ids = segmentMentions(text, users)
+    .filter(s => s.userId !== undefined)
+    .map(s => s.userId);
+  return [...new Set(ids)];
+};
+
+const useCommentsStore = create(
+  persist(
+    (set, get) => ({
+      // Seeds EMPTY by design — no demo comments (standing no-DEFAULT-seeds rule).
+      comments: [],
+
+      /**
+       * Add a comment to a record. targetType: 'evaluation' | 'control' |
+       * 'finding'. Returns the new comment, or null for empty input.
+       * entity is the human-readable record label for the audit log.
+       */
+      addComment: ({ targetType, targetId, text, entity }) => {
+        if (!targetType || !targetId) return null;
+        const raw = typeof text === 'string' ? text.trim() : '';
+        if (!raw) return null;
+        const capped = raw.slice(0, MAX_COMMENT_LENGTH);
+        const clean = sanitizeInput(capped);
+        if (!clean.trim()) return null;
+
+        const userStore = useUserStore.getState();
+        const author = userStore.getCurrentUser();
+        const comment = {
+          id: uuidv4(),
+          targetType,
+          targetId,
+          text: clean,
+          authorId: author?.id ?? null,
+          // Name snapshot so the comment stays attributed even if the user
+          // is later deleted from the directory.
+          authorName: author?.name || 'System',
+          mentions: parseMentions(clean, userStore.users),
+          createdAt: new Date().toISOString()
+        };
+        set((state) => ({ comments: [...state.comments, comment] }));
+
+        useAuditLogStore.getState().addEntry({
+          action: 'comment_added',
+          entity: entity || `${targetType} ${targetId}`,
+          targetType,
+          targetId
+        });
+        return comment;
+      },
+
+      deleteComment: (id, entity) => {
+        const existing = get().comments.find(c => c.id === id);
+        if (!existing) return;
+        set((state) => ({ comments: state.comments.filter(c => c.id !== id) }));
+        // Deletion is logged — silently removing discussion from a record
+        // would defeat the accountability this feature exists for.
+        useAuditLogStore.getState().addEntry({
+          action: 'comment_deleted',
+          entity: entity || `${existing.targetType} ${existing.targetId}`,
+          targetType: existing.targetType,
+          targetId: existing.targetId
+        });
+      },
+
+      // Oldest-first — a conversation reads top-down.
+      getComments: (targetType, targetId) =>
+        get().comments
+          .filter(c => c.targetType === targetType && c.targetId === targetId)
+          .sort((a, b) => (a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0)),
+
+      getCommentCount: (targetType, targetId) =>
+        get().comments.filter(c => c.targetType === targetType && c.targetId === targetId).length,
+
+      // Bulk setter for restore/import lanes (bypasses per-comment logging).
+      setComments: (comments) => {
+        set({ comments: Array.isArray(comments) ? comments : [] });
+      }
+    }),
+    {
+      name: 'csf-comments-storage',
+      version: 1
+    }
+  )
+);
+
+export default useCommentsStore;

--- a/src/stores/commentsStore.js
+++ b/src/stores/commentsStore.js
@@ -33,8 +33,9 @@ export const segmentMentions = (text, users) => {
   let i = 0;
   while (i < value.length) {
     if (value[i] === '@') {
+      const nameStart = i + 1;
       const match = candidates.find(u =>
-        lower.startsWith(u.name.toLowerCase(), i + 1)
+        lower.startsWith(u.name.toLowerCase(), nameStart)
       );
       if (match) {
         if (i > plainStart) segments.push({ text: value.slice(plainStart, i) });

--- a/src/stores/commentsStore.js
+++ b/src/stores/commentsStore.js
@@ -57,6 +57,31 @@ export const parseMentions = (text, users) => {
   return [...new Set(ids)];
 };
 
+/**
+ * Shape repair for the restore/import lane (bulk setters bypass zustand's
+ * load-time migrate). Drops junk-shaped records, coerces mentions to an
+ * array, backfills authorName. Absent-only and idempotent — a well-formed
+ * comment passes through unchanged.
+ */
+export const normalizeCommentFields = (state) => {
+  if (!Array.isArray(state?.comments)) return state;
+  const comments = state.comments
+    .filter(c =>
+      c && typeof c === 'object' &&
+      typeof c.id === 'string' &&
+      typeof c.targetType === 'string' &&
+      typeof c.targetId === 'string' &&
+      typeof c.text === 'string'
+    )
+    .map(c => ({
+      ...c,
+      mentions: Array.isArray(c.mentions) ? c.mentions : [],
+      authorName: typeof c.authorName === 'string' && c.authorName ? c.authorName : 'System',
+      createdAt: typeof c.createdAt === 'string' ? c.createdAt : new Date().toISOString()
+    }));
+  return { ...state, comments };
+};
+
 const useCommentsStore = create(
   persist(
     (set, get) => ({

--- a/src/stores/commentsStore.test.js
+++ b/src/stores/commentsStore.test.js
@@ -1,0 +1,147 @@
+/**
+ * commentsStore — add/sanitize/cap/mention-parse/scoped-get/delete/count,
+ * restore normalization, and audit-log linkage. Attribution tests run the
+ * PRODUCTION path (set acting user → addComment → assert persisted author),
+ * not a grep — the 'System' fallback makes string greps prove nothing.
+ */
+import useCommentsStore, {
+  segmentMentions,
+  parseMentions,
+  normalizeCommentFields,
+  MAX_COMMENT_LENGTH
+} from './commentsStore';
+import useAuditLogStore from './auditLogStore';
+import useUserStore from './userStore';
+
+const USERS = [
+  { id: 1, name: 'Gerry.Callahan', title: 'CISO', email: 'g@example.com' },
+  { id: 2, name: 'Steve.Mercer', title: 'Director', email: 's@example.com' },
+  // Regex metacharacters and a prefix collision with user 2 on purpose:
+  { id: 3, name: 'Steve.Mercer (Contractor)', title: 'Advisor', email: 'sc@example.com' },
+  { id: 4, name: 'Jane Alvarez', title: 'Engineer', email: 'j@example.com' }
+];
+
+beforeEach(() => {
+  window.localStorage.clear();
+  useCommentsStore.setState({ comments: [] });
+  useAuditLogStore.setState({ entries: [] });
+  useUserStore.setState({ users: USERS, currentUserId: null });
+});
+
+describe('segmentMentions / parseMentions', () => {
+  test('parses a simple mention and resolves the user id', () => {
+    expect(parseMentions('ping @Gerry.Callahan please', USERS)).toEqual([1]);
+  });
+
+  test('longest name wins on prefix collisions', () => {
+    expect(parseMentions('cc @Steve.Mercer (Contractor) too', USERS)).toEqual([3]);
+  });
+
+  test('names with spaces and regex metacharacters are safe', () => {
+    expect(parseMentions('for @Jane Alvarez to review', USERS)).toEqual([4]);
+    expect(() => parseMentions('@(((', USERS)).not.toThrow();
+  });
+
+  test('unknown @tokens are not mentions', () => {
+    expect(parseMentions('@nobody.here hello', USERS)).toEqual([]);
+  });
+
+  test('duplicate mentions dedupe; case-insensitive match', () => {
+    expect(parseMentions('@steve.mercer and @Steve.Mercer', USERS)).toEqual([2]);
+  });
+
+  test('segments reconstruct the full text (render path = parse path)', () => {
+    const text = 'a @Gerry.Callahan b @Jane Alvarez c';
+    const joined = segmentMentions(text, USERS).map(s => s.text).join('');
+    expect(joined).toBe(text);
+  });
+});
+
+describe('addComment', () => {
+  const target = { targetType: 'finding', targetId: 'FND-1', entity: 'FND-1 — test' };
+
+  test('adds a comment with ISO timestamp and parsed mentions', () => {
+    const c = useCommentsStore.getState().addComment({ ...target, text: 'look @Steve.Mercer' });
+    expect(c).not.toBeNull();
+    expect(c.mentions).toEqual([2]);
+    expect(new Date(c.createdAt).toISOString()).toBe(c.createdAt);
+  });
+
+  test('rejects empty and whitespace-only text', () => {
+    expect(useCommentsStore.getState().addComment({ ...target, text: '   ' })).toBeNull();
+    expect(useCommentsStore.getState().addComment({ ...target, text: '' })).toBeNull();
+    expect(useCommentsStore.getState().comments).toHaveLength(0);
+  });
+
+  test('strips markup at the producer — no <script> is ever persisted', () => {
+    const c = useCommentsStore.getState().addComment({ ...target, text: 'hi <script>alert(1)</script>' });
+    expect(c.text).not.toMatch(/<script/i);
+    expect(useCommentsStore.getState().comments[0].text).not.toMatch(/</);
+  });
+
+  test('caps raw input length before sanitize', () => {
+    const c = useCommentsStore.getState().addComment({ ...target, text: 'x'.repeat(MAX_COMMENT_LENGTH + 500) });
+    expect(c.text.length).toBeLessThanOrEqual(MAX_COMMENT_LENGTH);
+  });
+
+  test('attributes to the acting user via the production path', () => {
+    useUserStore.getState().setCurrentUser(2);
+    const c = useCommentsStore.getState().addComment({ ...target, text: 'attributed' });
+    expect(c.authorId).toBe(2);
+    expect(c.authorName).toBe('Steve.Mercer');
+  });
+
+  test('falls back to System when no acting user is selected', () => {
+    const c = useCommentsStore.getState().addComment({ ...target, text: 'anon' });
+    expect(c.authorId).toBeNull();
+    expect(c.authorName).toBe('System');
+  });
+
+  test('writes a comment_added audit entry scoped to the record', () => {
+    useCommentsStore.getState().addComment({ ...target, text: 'logged' });
+    const entries = useAuditLogStore.getState().getEntriesForRecord('finding', 'FND-1');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].action).toBe('comment_added');
+  });
+});
+
+describe('scoped reads and delete', () => {
+  test('getComments returns only the record, oldest-first; count matches', () => {
+    const add = useCommentsStore.getState().addComment;
+    add({ targetType: 'control', targetId: 'CTL-1', text: 'first' });
+    add({ targetType: 'control', targetId: 'CTL-1', text: 'second' });
+    add({ targetType: 'control', targetId: 'CTL-2', text: 'other record' });
+    const list = useCommentsStore.getState().getComments('control', 'CTL-1');
+    expect(list.map(c => c.text)).toEqual(['first', 'second']);
+    expect(useCommentsStore.getState().getCommentCount('control', 'CTL-1')).toBe(2);
+  });
+
+  test('deleteComment removes exactly one and logs comment_deleted', () => {
+    const c = useCommentsStore.getState().addComment({ targetType: 'finding', targetId: 'FND-9', text: 'bye' });
+    useCommentsStore.getState().deleteComment(c.id);
+    expect(useCommentsStore.getState().comments).toHaveLength(0);
+    const actions = useAuditLogStore.getState().getEntriesForRecord('finding', 'FND-9').map(e => e.action);
+    expect(actions).toContain('comment_deleted');
+  });
+});
+
+describe('normalizeCommentFields (restore lane)', () => {
+  test('drops junk-shaped records, keeps well-formed ones unchanged', () => {
+    const good = {
+      id: 'a', targetType: 'finding', targetId: 'FND-1', text: 'ok',
+      authorId: 1, authorName: 'G', mentions: [1], createdAt: '2026-01-01T00:00:00.000Z'
+    };
+    const { comments } = normalizeCommentFields({
+      comments: [good, null, 'junk', { id: 'b' }, { ...good, id: 'c', mentions: 'not-an-array', authorName: '' }]
+    });
+    expect(comments).toHaveLength(2);
+    expect(comments[0]).toEqual(good);
+    expect(comments[1].mentions).toEqual([]);
+    expect(comments[1].authorName).toBe('System');
+  });
+
+  test('non-array state passes through untouched', () => {
+    const state = { comments: undefined };
+    expect(normalizeCommentFields(state)).toBe(state);
+  });
+});

--- a/src/stores/controlsStore.js
+++ b/src/stores/controlsStore.js
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware';
 import Papa from 'papaparse';
 import { sanitizeInput, csvFormulaGuard } from '../utils/sanitize';
 import useAuditLogStore from './auditLogStore';
+import useCommentsStore from './commentsStore';
 import { DEFAULT_CONTROLS } from './defaultControlsData';
 import { COMPREHENSIVE_ASSESSMENT_ID } from './comprehensiveAssessmentData';
 import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
@@ -215,13 +216,33 @@ const useControlsStore = create(
         );
         get().setControls(updatedControls);
 
+        // Controls are keyed by the user-EDITABLE controlId. On rename,
+        // comments and history retarget to the new id so neither orphans —
+        // then the rename itself is logged (under the new id, so the
+        // record's history shows it).
+        const renamedTo = typeof sanitizedUpdates.controlId === 'string' &&
+          sanitizedUpdates.controlId !== controlId ? sanitizedUpdates.controlId : null;
+        if (renamedTo) {
+          useCommentsStore.getState().retargetComments('control', controlId, renamedTo);
+          useAuditLogStore.getState().retargetRecord('control', controlId, renamedTo);
+          useAuditLogStore.getState().addEntry({
+            action: 'control_updated',
+            entity: before?.name ? `${renamedTo} ${before.name}` : renamedTo,
+            field: 'controlId',
+            oldValue: controlId,
+            newValue: renamedTo,
+            targetType: 'control',
+            targetId: renamedTo
+          });
+        }
+
         // Field-level change log. The detail panel writes per keystroke; the
         // audit store coalesces those into one entry per field per session.
         if (before) {
           useAuditLogStore.getState().logFieldChanges({
             targetType: 'control',
-            targetId: controlId,
-            entity: before.name ? `${controlId} ${before.name}` : controlId,
+            targetId: renamedTo || controlId,
+            entity: before.name ? `${renamedTo || controlId} ${before.name}` : (renamedTo || controlId),
             before,
             after: sanitizedUpdates,
             defaultAction: 'control_updated',

--- a/src/stores/controlsStore.js
+++ b/src/stores/controlsStore.js
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import Papa from 'papaparse';
 import { sanitizeInput, csvFormulaGuard } from '../utils/sanitize';
+import useAuditLogStore from './auditLogStore';
 import { DEFAULT_CONTROLS } from './defaultControlsData';
 import { COMPREHENSIVE_ASSESSMENT_ID } from './comprehensiveAssessmentData';
 import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
@@ -106,8 +107,10 @@ const useControlsStore = create(
         );
       },
 
-      // Create new control
-      createControl: (controlData) => {
+      // Create new control. options.log defaults true for user-initiated
+      // creates; programmatic bulk lanes (getOrCreateControlForRequirement,
+      // CSV import via setControls) must not flood the audit log.
+      createControl: (controlData, options = {}) => {
         const newControl = {
           controlId: controlData.controlId || `CTL-${String(get().controls.length + 1).padStart(3, '0')}`,
           // Human-readable control name, distinct from the control ID (issue #306).
@@ -145,6 +148,14 @@ const useControlsStore = create(
 
         const updatedControls = [...get().controls, newControl];
         get().setControls(updatedControls);
+        if (options.log !== false) {
+          useAuditLogStore.getState().addEntry({
+            action: 'control_created',
+            entity: newControl.name ? `${newControl.controlId} ${newControl.name}` : newControl.controlId,
+            targetType: 'control',
+            targetId: newControl.controlId
+          });
+        }
         return newControl;
       },
 
@@ -158,12 +169,13 @@ const useControlsStore = create(
           return existingControl;
         }
 
-        // Auto-create control linked to this requirement
+        // Auto-create control linked to this requirement (programmatic —
+        // never audit-logged, this lane runs in bulk per scoped requirement)
         return get().createControl({
           controlId,
           linkedRequirementIds: [requirement.id],
           status: 'Not Implemented'
-        });
+        }, { log: false });
       },
 
       // Bulk get or create controls for multiple requirements
@@ -197,16 +209,40 @@ const useControlsStore = create(
           sanitizedUpdates.implementationDescription = sanitizeInput(updates.implementationDescription);
         }
 
+        const before = get().getControl(controlId);
         const updatedControls = get().controls.map(c =>
           c.controlId === controlId ? { ...c, ...sanitizedUpdates } : c
         );
         get().setControls(updatedControls);
+
+        // Field-level change log. The detail panel writes per keystroke; the
+        // audit store coalesces those into one entry per field per session.
+        if (before) {
+          useAuditLogStore.getState().logFieldChanges({
+            targetType: 'control',
+            targetId: controlId,
+            entity: before.name ? `${controlId} ${before.name}` : controlId,
+            before,
+            after: sanitizedUpdates,
+            defaultAction: 'control_updated',
+            fields: ['name', 'implementationDescription', 'status', 'tests', 'frameworks', 'ownerId', 'externalUrl']
+          });
+        }
       },
 
       // Delete control
       deleteControl: (controlId) => {
+        const existing = get().getControl(controlId);
         const updatedControls = get().controls.filter(c => c.controlId !== controlId);
         get().setControls(updatedControls);
+        if (existing) {
+          useAuditLogStore.getState().addEntry({
+            action: 'control_deleted',
+            entity: existing.name ? `${controlId} ${existing.name}` : controlId,
+            targetType: 'control',
+            targetId: controlId
+          });
+        }
       },
 
       // Link requirement to control

--- a/src/stores/controlsStore.js
+++ b/src/stores/controlsStore.js
@@ -210,14 +210,29 @@ const useControlsStore = create(
           sanitizedUpdates.implementationDescription = sanitizeInput(updates.implementationDescription);
         }
 
+        // controlId is the record's KEY. A rename is honored only when the
+        // new id is non-empty and not already taken — an empty id would
+        // orphan the record, and a collision would silently merge two
+        // records' comment threads and histories. (The UI currently disables
+        // the field outside create mode; this guard is producer-side defense
+        // for when that changes or a programmatic caller passes one.)
+        if ('controlId' in sanitizedUpdates) {
+          const nextId = typeof sanitizedUpdates.controlId === 'string' ? sanitizedUpdates.controlId.trim() : '';
+          if (!nextId || nextId === controlId || get().getControl(nextId)) {
+            delete sanitizedUpdates.controlId;
+          } else {
+            sanitizedUpdates.controlId = nextId;
+          }
+        }
+
         const before = get().getControl(controlId);
         const updatedControls = get().controls.map(c =>
           c.controlId === controlId ? { ...c, ...sanitizedUpdates } : c
         );
         get().setControls(updatedControls);
 
-        // Controls are keyed by the user-EDITABLE controlId. On rename,
-        // comments and history retarget to the new id so neither orphans —
+        // Controls are keyed by controlId, so a (guarded, see above) rename
+        // retargets comments and history to the new id so neither orphans —
         // then the rename itself is logged (under the new id, so the
         // record's history shows it).
         const renamedTo = typeof sanitizedUpdates.controlId === 'string' &&
@@ -257,6 +272,10 @@ const useControlsStore = create(
         const updatedControls = get().controls.filter(c => c.controlId !== controlId);
         get().setControls(updatedControls);
         if (existing) {
+          // Remove the record's discussion: control ids are recycled (max+1),
+          // so an orphaned thread would re-attach to a future unrelated
+          // control. The audit trail itself is retained (accountability).
+          useCommentsStore.getState().deleteCommentsFor('control', controlId);
           useAuditLogStore.getState().addEntry({
             action: 'control_deleted',
             entity: existing.name ? `${controlId} ${existing.name}` : controlId,

--- a/src/stores/findingsStore.js
+++ b/src/stores/findingsStore.js
@@ -4,6 +4,7 @@ import Papa from 'papaparse';
 import { v4 as uuidv4 } from 'uuid';
 import { sanitizeInput, escapeCSVValue } from '../utils/sanitize';
 import useAuditLogStore from './auditLogStore';
+import useCommentsStore from './commentsStore';
 import { COMPREHENSIVE_FINDINGS, COMPREHENSIVE_ASSESSMENT_ID } from './comprehensiveAssessmentData';
 import { LEGACY_EXAMPLE_ASSESSMENT_IDS } from './assessmentsStore';
 import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
@@ -169,6 +170,9 @@ const useFindingsStore = create(
           findings: state.findings.filter(f => f.id !== findingId)
         }));
         if (existing) {
+          // Discussion goes with the record (unreachable once deleted);
+          // the audit trail is retained.
+          useCommentsStore.getState().deleteCommentsFor('finding', findingId);
           useAuditLogStore.getState().addEntry({
             action: 'finding_deleted',
             entity: findingLabel(existing),

--- a/src/stores/findingsStore.js
+++ b/src/stores/findingsStore.js
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware';
 import Papa from 'papaparse';
 import { v4 as uuidv4 } from 'uuid';
 import { sanitizeInput, escapeCSVValue } from '../utils/sanitize';
+import useAuditLogStore from './auditLogStore';
 import { COMPREHENSIVE_FINDINGS, COMPREHENSIVE_ASSESSMENT_ID } from './comprehensiveAssessmentData';
 import { LEGACY_EXAMPLE_ASSESSMENT_IDS } from './assessmentsStore';
 import { DEMO_SEED_SOURCE } from '../utils/assessmentScope';
@@ -17,6 +18,12 @@ export const SEEDED_FINDINGS = COMPREHENSIVE_FINDINGS.map(f => ({
   assessmentId: f.assessmentId || COMPREHENSIVE_ASSESSMENT_ID,
   seedSource: DEMO_SEED_SOURCE
 }));
+
+// Human-readable audit-log label: short id + truncated summary.
+const findingLabel = (finding) => {
+  const summary = (finding.summary || '').slice(0, 60);
+  return summary ? `${finding.id} — ${summary}` : finding.id;
+};
 
 const LEGACY_DEMO_FINDING_IDS = new Set(['FND-1', 'FND-2', 'FND-3', 'FND-4']);
 
@@ -108,6 +115,13 @@ const useFindingsStore = create(
           findings: [...state.findings, newFinding]
         }));
 
+        useAuditLogStore.getState().addEntry({
+          action: 'finding_created',
+          entity: findingLabel(newFinding),
+          targetType: 'finding',
+          targetId: newFinding.id
+        });
+
         return newFinding;
       },
 
@@ -128,18 +142,40 @@ const useFindingsStore = create(
           sanitizedUpdates.remediationActionPlan = sanitizeInput(updates.remediationActionPlan);
         }
 
+        const before = get().findings.find(f => f.id === findingId);
         set((state) => ({
           findings: state.findings.map(f =>
             f.id === findingId ? { ...f, ...sanitizedUpdates } : f
           )
         }));
+
+        if (before) {
+          useAuditLogStore.getState().logFieldChanges({
+            targetType: 'finding',
+            targetId: findingId,
+            entity: findingLabel(before),
+            before,
+            after: sanitizedUpdates,
+            defaultAction: 'finding_updated',
+            fields: ['summary', 'status', 'priority', 'rootCause', 'remediationActionPlan', 'remediationOwner', 'dueDate', 'externalUrl']
+          });
+        }
       },
 
       // Delete finding
       deleteFinding: (findingId) => {
+        const existing = get().findings.find(f => f.id === findingId);
         set((state) => ({
           findings: state.findings.filter(f => f.id !== findingId)
         }));
+        if (existing) {
+          useAuditLogStore.getState().addEntry({
+            action: 'finding_deleted',
+            entity: findingLabel(existing),
+            targetType: 'finding',
+            targetId: findingId
+          });
+        }
       },
 
       // Link artifact to finding

--- a/src/stores/recordAudit.wiring.test.js
+++ b/src/stores/recordAudit.wiring.test.js
@@ -6,6 +6,7 @@
  */
 import useAuditLogStore from './auditLogStore';
 import useUserStore from './userStore';
+import useCommentsStore from './commentsStore';
 import useControlsStore from './controlsStore';
 import useFindingsStore from './findingsStore';
 import useAssessmentsStore, { evaluationTargetId } from './assessmentsStore';
@@ -41,6 +42,25 @@ describe('controlsStore wiring', () => {
     const before = entriesFor('control', control.controlId).length;
     useControlsStore.getState().updateControl(control.controlId, { name: 'N' });
     expect(entriesFor('control', control.controlId).length).toBe(before);
+  });
+
+  test('controlId rename retargets comments and history, and is itself logged', () => {
+    useCommentsStore.setState({ comments: [] });
+    const control = useControlsStore.getState().createControl({ controlId: 'CTL-OLD', name: 'Renamable' });
+    useCommentsStore.getState().addComment({ targetType: 'control', targetId: 'CTL-OLD', text: 'keep me' });
+    useControlsStore.getState().updateControl(control.controlId, { controlId: 'CTL-NEW' });
+
+    // comments and history both follow the record to the new id
+    expect(useCommentsStore.getState().getComments('control', 'CTL-NEW')).toHaveLength(1);
+    expect(useCommentsStore.getState().getComments('control', 'CTL-OLD')).toHaveLength(0);
+    const newEntries = entriesFor('control', 'CTL-NEW');
+    expect(entriesFor('control', 'CTL-OLD')).toHaveLength(0);
+    const rename = newEntries.find(e => e.field === 'controlId');
+    expect(rename.oldValue).toBe('CTL-OLD');
+    expect(rename.newValue).toBe('CTL-NEW');
+    // the record itself was renamed
+    expect(useControlsStore.getState().getControl('CTL-NEW')).toBeTruthy();
+    expect(useControlsStore.getState().getControl('CTL-OLD')).toBeUndefined();
   });
 
   test('programmatic bulk auto-create does not flood the log', () => {
@@ -106,6 +126,17 @@ describe('assessmentsStore wiring', () => {
     const rename = entriesFor('assessment', assessment.id).find(e => e.action === 'assessment_updated');
     expect(rename.oldValue).toBe('Lifecycle A');
     expect(rename.newValue).toBe('Lifecycle B');
+  });
+
+  test('bulk lanes pass log:false and write nothing (wizard attach / migration)', () => {
+    const assessment = useAssessmentsStore.getState().createAssessment({
+      name: 'Bulk', scopeIds: ['GV.OC-01'], scopeType: 'requirements'
+    });
+    useAuditLogStore.setState({ entries: [] });
+    useAssessmentsStore.getState().updateObservation(assessment.id, 'GV.OC-01', {
+      testProcedures: 'attached bank text', testingStatus: 'Not Started'
+    }, { log: false });
+    expect(useAuditLogStore.getState().entries).toHaveLength(0);
   });
 
   test('an observations-payload updateAssessment call does not double-log', () => {

--- a/src/stores/recordAudit.wiring.test.js
+++ b/src/stores/recordAudit.wiring.test.js
@@ -63,6 +63,43 @@ describe('controlsStore wiring', () => {
     expect(useControlsStore.getState().getControl('CTL-OLD')).toBeUndefined();
   });
 
+  test('empty or colliding controlId renames are refused at the producer', () => {
+    useControlsStore.getState().createControl({ controlId: 'CTL-KEEP-A', name: 'A' });
+    useControlsStore.getState().createControl({ controlId: 'CTL-KEEP-B', name: 'B' });
+    useControlsStore.getState().updateControl('CTL-KEEP-A', { controlId: '' });
+    useControlsStore.getState().updateControl('CTL-KEEP-A', { controlId: 'CTL-KEEP-B' });
+    // record keeps its id in both cases — no orphaning, no silent merge
+    expect(useControlsStore.getState().getControl('CTL-KEEP-A')).toBeTruthy();
+    expect(useControlsStore.getState().controls.filter(c => c.controlId === 'CTL-KEEP-B')).toHaveLength(1);
+  });
+
+  test('deleting a record removes its comments but keeps its audit trail', () => {
+    useCommentsStore.setState({ comments: [] });
+    const control = useControlsStore.getState().createControl({ controlId: 'CTL-GONE', name: 'G' });
+    useCommentsStore.getState().addComment({ targetType: 'control', targetId: 'CTL-GONE', text: 'orphan me not' });
+    useControlsStore.getState().deleteControl(control.controlId);
+    // comments gone (id recycling would re-attach them to a future control)
+    expect(useCommentsStore.getState().getComments('control', 'CTL-GONE')).toHaveLength(0);
+    // audit trail retained
+    const actions = entriesFor('control', 'CTL-GONE').map(e => e.action);
+    expect(actions).toContain('control_deleted');
+    expect(actions).toContain('control_created');
+  });
+
+  test('deleting an assessment sweeps its evaluation comment threads', () => {
+    useCommentsStore.setState({ comments: [] });
+    const assessment = useAssessmentsStore.getState().createAssessment({
+      name: 'Sweep', scopeIds: ['PR.DS-09'], scopeType: 'requirements'
+    });
+    useCommentsStore.getState().addComment({
+      targetType: 'evaluation', targetId: evaluationTargetId(assessment.id, 'PR.DS-09'), text: 'eval note'
+    });
+    useCommentsStore.getState().addComment({ targetType: 'control', targetId: 'CTL-UNRELATED', text: 'stays' });
+    useAssessmentsStore.getState().deleteAssessment(assessment.id);
+    expect(useCommentsStore.getState().getComments('evaluation', evaluationTargetId(assessment.id, 'PR.DS-09'))).toHaveLength(0);
+    expect(useCommentsStore.getState().getComments('control', 'CTL-UNRELATED')).toHaveLength(1);
+  });
+
   test('programmatic bulk auto-create does not flood the log', () => {
     useControlsStore.getState().ensureControlsForRequirements([
       { id: 'GV.OC-01' }, { id: 'GV.OC-02' }, { id: 'GV.OC-03' }

--- a/src/stores/recordAudit.wiring.test.js
+++ b/src/stores/recordAudit.wiring.test.js
@@ -1,0 +1,121 @@
+/**
+ * Store wiring — the PRODUCTION update/create/delete paths of the three real
+ * stores must write scoped, attributed audit entries; bulk lanes must not
+ * flood the log. Attribution asserts run with an acting user selected, per
+ * the behavioral-not-grep rule (the 'System' fallback makes greps useless).
+ */
+import useAuditLogStore from './auditLogStore';
+import useUserStore from './userStore';
+import useControlsStore from './controlsStore';
+import useFindingsStore from './findingsStore';
+import useAssessmentsStore, { evaluationTargetId } from './assessmentsStore';
+
+const entriesFor = (t, id) => useAuditLogStore.getState().getEntriesForRecord(t, id);
+
+beforeEach(() => {
+  window.localStorage.clear();
+  useAuditLogStore.setState({ entries: [] });
+  useUserStore.setState({
+    users: [{ id: 42, name: 'Omar.Garza', email: 'o@x.com' }],
+    currentUserId: 42
+  });
+});
+
+describe('controlsStore wiring', () => {
+  test('create → update → delete logs scoped, attributed entries', () => {
+    const control = useControlsStore.getState().createControl({ controlId: 'CTL-AUD-1', name: 'Audit control' });
+    expect(entriesFor('control', control.controlId).map(e => e.action)).toEqual(['control_created']);
+
+    useControlsStore.getState().updateControl(control.controlId, { status: 'Implemented' });
+    const afterUpdate = entriesFor('control', control.controlId);
+    expect(afterUpdate[0].action).toBe('control_updated');
+    expect(afterUpdate[0].field).toBe('status');
+    expect(afterUpdate[0].user).toBe('Omar.Garza');
+
+    useControlsStore.getState().deleteControl(control.controlId);
+    expect(entriesFor('control', control.controlId)[0].action).toBe('control_deleted');
+  });
+
+  test('a no-op update writes nothing', () => {
+    const control = useControlsStore.getState().createControl({ controlId: 'CTL-AUD-2', name: 'N' });
+    const before = entriesFor('control', control.controlId).length;
+    useControlsStore.getState().updateControl(control.controlId, { name: 'N' });
+    expect(entriesFor('control', control.controlId).length).toBe(before);
+  });
+
+  test('programmatic bulk auto-create does not flood the log', () => {
+    useControlsStore.getState().ensureControlsForRequirements([
+      { id: 'GV.OC-01' }, { id: 'GV.OC-02' }, { id: 'GV.OC-03' }
+    ]);
+    const created = useAuditLogStore.getState().getEntries({ action: 'control_created' });
+    expect(created).toHaveLength(0);
+  });
+});
+
+describe('findingsStore wiring', () => {
+  test('create → update → delete logs scoped, attributed entries', () => {
+    const finding = useFindingsStore.getState().createFinding({ summary: 'MFA gap on payroll' });
+    expect(entriesFor('finding', finding.id).map(e => e.action)).toEqual(['finding_created']);
+
+    useFindingsStore.getState().updateFinding(finding.id, { status: 'In Progress', priority: 'High' });
+    const actions = entriesFor('finding', finding.id).map(e => e.action);
+    expect(actions.filter(a => a === 'finding_updated')).toHaveLength(2);
+    expect(entriesFor('finding', finding.id)[0].user).toBe('Omar.Garza');
+
+    useFindingsStore.getState().deleteFinding(finding.id);
+    expect(entriesFor('finding', finding.id)[0].action).toBe('finding_deleted');
+    // History survives the record's deletion — that is the point of the log.
+    expect(entriesFor('finding', finding.id).length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('assessmentsStore wiring', () => {
+  test('observation edits log per changed field with evaluation scoping', () => {
+    const assessment = useAssessmentsStore.getState().createAssessment({
+      name: 'Wiring Test', scopeIds: ['PR.DS-01'], scopeType: 'requirements'
+    });
+    useAuditLogStore.setState({ entries: [] });
+
+    useAssessmentsStore.getState().updateObservation(assessment.id, 'PR.DS-01', {
+      score: 4, testingStatus: 'In Progress'
+    });
+    const tid = evaluationTargetId(assessment.id, 'PR.DS-01');
+    const actions = entriesFor('evaluation', tid).map(e => e.action).sort();
+    expect(actions).toEqual(['score_changed', 'status_changed']);
+    expect(entriesFor('evaluation', tid)[0].user).toBe('Omar.Garza');
+  });
+
+  test('quarterly edits log with the quarter named in the field', () => {
+    const assessment = useAssessmentsStore.getState().createAssessment({
+      name: 'Quarterly Test', scopeIds: ['PR.DS-02'], scopeType: 'requirements'
+    });
+    useAssessmentsStore.getState().updateQuarterlyObservation(assessment.id, 'PR.DS-02', 'Q2', {
+      score: 7, observations: 'Improved coverage'
+    });
+    const tid = evaluationTargetId(assessment.id, 'PR.DS-02');
+    const fields = entriesFor('evaluation', tid).map(e => e.field);
+    expect(fields).toEqual(expect.arrayContaining(['Q2 score', 'Q2 observations']));
+  });
+
+  test('assessment create, rename, delete are logged', () => {
+    const assessment = useAssessmentsStore.getState().createAssessment({ name: 'Lifecycle A' });
+    useAssessmentsStore.getState().updateAssessment(assessment.id, { name: 'Lifecycle B' });
+    useAssessmentsStore.getState().deleteAssessment(assessment.id);
+    const actions = entriesFor('assessment', assessment.id).map(e => e.action);
+    expect(actions).toEqual(['assessment_deleted', 'assessment_updated', 'assessment_created']);
+    const rename = entriesFor('assessment', assessment.id).find(e => e.action === 'assessment_updated');
+    expect(rename.oldValue).toBe('Lifecycle A');
+    expect(rename.newValue).toBe('Lifecycle B');
+  });
+
+  test('an observations-payload updateAssessment call does not double-log', () => {
+    const assessment = useAssessmentsStore.getState().createAssessment({
+      name: 'NoDouble', scopeIds: ['PR.DS-03'], scopeType: 'requirements'
+    });
+    useAuditLogStore.setState({ entries: [] });
+    useAssessmentsStore.getState().updateObservation(assessment.id, 'PR.DS-03', { score: 2 });
+    // Exactly the one score entry — updateAssessment's internal call with the
+    // observations payload must not add assessment_updated noise.
+    expect(useAuditLogStore.getState().entries).toHaveLength(1);
+  });
+});

--- a/src/stores/recordAudit.wiring.test.js
+++ b/src/stores/recordAudit.wiring.test.js
@@ -90,11 +90,11 @@ describe('assessmentsStore wiring', () => {
       name: 'Quarterly Test', scopeIds: ['PR.DS-02'], scopeType: 'requirements'
     });
     useAssessmentsStore.getState().updateQuarterlyObservation(assessment.id, 'PR.DS-02', 'Q2', {
-      score: 7, observations: 'Improved coverage'
+      actualScore: 7, observations: 'Improved coverage'
     });
     const tid = evaluationTargetId(assessment.id, 'PR.DS-02');
     const fields = entriesFor('evaluation', tid).map(e => e.field);
-    expect(fields).toEqual(expect.arrayContaining(['Q2 score', 'Q2 observations']));
+    expect(fields).toEqual(expect.arrayContaining(['Q2 actualScore', 'Q2 observations']));
   });
 
   test('assessment create, rename, delete are logged', () => {

--- a/src/stores/userStore.js
+++ b/src/stores/userStore.js
@@ -86,6 +86,31 @@ const useUserStore = create(
     (set, get) => ({
       users: DEFAULT_USERS,
 
+      // Acting user (comments/audit attribution). Honor-system by design —
+      // there is no authentication anywhere in this app; this is the same
+      // trust model as every other store. null = no selection → 'System'.
+      currentUserId: null,
+
+      setCurrentUser: (id) => {
+        // Positive resolution: only a truthy directory lookup may be stored,
+        // so a stale/garbage id can never brand writes (null clears).
+        if (id !== null && !get().getUserById(id)) return;
+        set({ currentUserId: id });
+      },
+
+      getCurrentUser: () => {
+        const id = get().currentUserId;
+        if (id == null) return null;
+        // Resolve positively on every read — a persisted id whose user was
+        // deleted (or arrived via restore) must not resolve to a ghost.
+        return get().getUserById(id) || null;
+      },
+
+      getCurrentUserName: () => {
+        const user = get().getCurrentUser();
+        return user?.name || 'System';
+      },
+
       // Add a single user
       addUser: (user) => {
         const newUser = {
@@ -110,7 +135,9 @@ const useUserStore = create(
       // Delete a user
       deleteUser: (id) => {
         set((state) => ({
-          users: state.users.filter(user => user.id !== id)
+          users: state.users.filter(user => user.id !== id),
+          // Deleting the acting user resets attribution to the fallback.
+          ...(state.currentUserId === id ? { currentUserId: null } : {})
         }));
       },
 

--- a/src/utils/__snapshots__/dataExportGolden.test.js.snap
+++ b/src/utils/__snapshots__/dataExportGolden.test.js.snap
@@ -209,6 +209,7 @@ Object {
         "status": "Not Started",
       },
     ],
+    "comments": Array [],
     "controls": Array [
       Object {
         "artifacts": "",
@@ -507,7 +508,7 @@ Object {
   },
   "dataType": "Complete Assessment Database",
   "exportDate": "<stripped>",
-  "formatVersion": 6,
+  "formatVersion": 7,
   "metadata": Object {
     "applicationName": "CSF Profile Assessment Tool",
     "assessmentCount": 3,
@@ -521,6 +522,7 @@ Object {
   "storeVersions": Object {
     "artifacts": 9,
     "assessments": 16,
+    "comments": null,
     "findings": 6,
     "frameworks": 6,
     "metrics": 1,
@@ -830,7 +832,7 @@ Alma's position as a continuous authentication SaaS company creates a unique dyn
   },
   "dataType": "Shareable Assessment Database (private pack data excluded)",
   "exportDate": "<stripped>",
-  "formatVersion": 6,
+  "formatVersion": 7,
   "metadata": Object {
     "applicationName": "CSF Profile Assessment Tool",
     "assessmentCount": 2,
@@ -844,6 +846,7 @@ Alma's position as a continuous authentication SaaS company creates a unique dyn
   "storeVersions": Object {
     "artifacts": 9,
     "assessments": 16,
+    "comments": null,
     "findings": 6,
     "frameworks": 6,
     "metrics": 1,
@@ -1063,6 +1066,7 @@ Object {
         "status": "Not Started",
       },
     ],
+    "comments": Array [],
     "controls": Array [
       Object {
         "artifacts": "",
@@ -1322,7 +1326,7 @@ Object {
   },
   "dataType": "Complete Assessment Database (private pack data INCLUDED; restricted-license metrics still excluded)",
   "exportDate": "<stripped>",
-  "formatVersion": 6,
+  "formatVersion": 7,
   "metadata": Object {
     "applicationName": "CSF Profile Assessment Tool",
     "assessmentCount": 3,
@@ -1336,6 +1340,7 @@ Object {
   "storeVersions": Object {
     "artifacts": 9,
     "assessments": 16,
+    "comments": null,
     "findings": 6,
     "frameworks": 6,
     "metrics": 1,

--- a/src/utils/assessmentSelection.js
+++ b/src/utils/assessmentSelection.js
@@ -50,7 +50,12 @@ export const SECTION_DISPOSITION = {
   frameworks: 'keep-whole',
   metrics: 'keep-whole',
   systems: 'keep-whole',
-  orgProfile: 'keep-whole'
+  orgProfile: 'keep-whole',
+  // Comments cascade with their records: evaluation comments carry the
+  // assessment id inside targetId, finding comments follow their finding
+  // (see the comments block in filterExportByAssessments); control comments
+  // ride whole with the control catalogue.
+  comments: 'cascade'
 };
 
 /**

--- a/src/utils/assessmentSelection.js
+++ b/src/utils/assessmentSelection.js
@@ -133,6 +133,25 @@ export const filterExportByAssessments = (envelope, assessmentIds = null) => {
   cascade('findings');
   cascade('artifacts');
 
+  // Comments cascade with their records: evaluation comments follow the kept
+  // assessments (targetId is `assessmentId::itemId`), finding comments follow
+  // the findings that survived above, control comments ride wholesale because
+  // the control catalogue itself rides wholesale.
+  if (Array.isArray(data.comments)) {
+    const keptFindingIds = new Set(
+      (Array.isArray(next.data.findings) ? next.data.findings : []).map((f) => f?.id)
+    );
+    next.data.comments = data.comments.filter((c) => {
+      if (!c || typeof c !== 'object') return false;
+      if (c.targetType === 'evaluation') {
+        const idx = typeof c.targetId === 'string' ? c.targetId.indexOf('::') : -1;
+        return idx > 0 && wanted.has(c.targetId.slice(0, idx));
+      }
+      if (c.targetType === 'finding') return keptFindingIds.has(c.targetId);
+      return true;
+    });
+  }
+
   next.metadata = {
     ...(envelope.metadata || {}),
     assessmentCount: assessments.length,

--- a/src/utils/auditActions.js
+++ b/src/utils/auditActions.js
@@ -1,0 +1,42 @@
+/**
+ * Audit-log action metadata shared by the global Audit Log page and the
+ * per-record History tab (RecordPanel). One home so a new action type can't
+ * render labeled in one surface and raw in the other.
+ */
+export const ACTION_META = {
+  score_changed: { label: 'Score Changed', color: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200' },
+  status_changed: { label: 'Status Changed', color: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200' },
+  finding_created: { label: 'Finding Created', color: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' },
+  finding_updated: { label: 'Finding Updated', color: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200' },
+  finding_deleted: { label: 'Finding Deleted', color: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' },
+  observation_updated: { label: 'Observation Updated', color: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200' },
+  control_created: { label: 'Control Created', color: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' },
+  control_updated: { label: 'Control Updated', color: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200' },
+  control_deleted: { label: 'Control Deleted', color: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' },
+  assessment_created: { label: 'Assessment Created', color: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' },
+  assessment_updated: { label: 'Assessment Updated', color: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200' },
+  assessment_deleted: { label: 'Assessment Deleted', color: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' },
+  comment_added: { label: 'Comment Added', color: 'bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200' },
+  comment_deleted: { label: 'Comment Deleted', color: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' }
+};
+
+export const ACTION_OPTIONS = [
+  { value: '', label: 'All Actions' },
+  ...Object.entries(ACTION_META).map(([value, meta]) => ({ value, label: meta.label }))
+];
+
+export const formatAuditTimestamp = (isoString) => {
+  if (!isoString) return '—';
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    }).format(new Date(isoString));
+  } catch {
+    return isoString;
+  }
+};

--- a/src/utils/dataExport.js
+++ b/src/utils/dataExport.js
@@ -29,8 +29,12 @@ import { filterExportByAssessments } from './assessmentSelection';
  *   backups carry it wholesale; share exports OMIT it by default and carry
  *   it only under the include-private opt-in (see shareRegistry.js — a
  *   populated inventory reads as a target list).
+ * Format 7: adds the comments section (per-record discussion threads on
+ *   evaluations/controls/findings). Complete backups carry it wholesale;
+ *   share exports OMIT it by default (author names + free discussion text —
+ *   the users-directory pattern) and carry it only under include-private.
  */
-export const EXPORT_FORMAT_VERSION = 6;
+export const EXPORT_FORMAT_VERSION = 7;
 
 // zustand persist keys whose schema versions travel with the export so a
 // restore can detect version drift between the exporting and importing app.
@@ -45,7 +49,8 @@ export const PERSIST_KEYS = {
   // can version-gate instead of relying on the unconditional stamp passes
   artifacts: 'csf-artifacts-storage',
   users: 'csf-users-storage',
-  systems: 'csf-inventory-storage'
+  systems: 'csf-inventory-storage',
+  comments: 'csf-comments-storage'
 };
 
 /**
@@ -87,7 +92,8 @@ export const exportAllDataJSON = (stores) => {
     findingsStore,
     metricsStore,
     orgProfileStore,
-    inventoryStore
+    inventoryStore,
+    commentsStore
   } = stores;
 
   const orgProfileState = orgProfileStore?.getState?.();
@@ -117,6 +123,7 @@ export const exportAllDataJSON = (stores) => {
       findings: findingsStore?.getState?.()?.findings || [],
       metrics: metricsStore?.getState?.()?.metrics || [],
       systems: inventoryStore?.getState?.()?.systems || [],
+      comments: commentsStore?.getState?.()?.comments || [],
       // Object section (not an array): the org profile rides COMPLETE
       // backups only; buildShareableExport strips it unconditionally.
       orgProfile: orgProfileState

--- a/src/utils/dataImport.js
+++ b/src/utils/dataImport.js
@@ -39,6 +39,7 @@ import { stampSeededDemoFindings } from '../stores/findingsStore';
 import { stampSeededDemoUsers } from '../stores/userStore';
 import { stampSeededDemoControls, normalizeControlFields } from '../stores/controlsStore';
 import { normalizeSystemFields } from '../stores/inventoryStore';
+import { normalizeCommentFields } from '../stores/commentsStore';
 
 // Sections a restore knows how to apply, with the store + bulk setter each uses.
 // Format-2 exports carry no metrics section — it is simply skipped (untouched),
@@ -52,7 +53,11 @@ const SECTIONS = [
   { key: 'artifacts', store: 'artifactStore', setter: 'setArtifacts' },
   { key: 'findings', store: 'findingsStore', setter: 'setFindings' },
   { key: 'metrics', store: 'metricsStore', setter: 'setMetrics' },
-  { key: 'systems', store: 'inventoryStore', setter: 'setSystems' }
+  { key: 'systems', store: 'inventoryStore', setter: 'setSystems' },
+  // Format 7. Absent in older files → skipped, so a pre-comments backup (or a
+  // share export, which OMITS the section) leaves the receiver's comments
+  // untouched rather than wiping them.
+  { key: 'comments', store: 'commentsStore', setter: 'setComments' }
 ];
 
 /**
@@ -277,6 +282,13 @@ export const importCompleteDatabase = (parsed, stores, { backupFirst = true } = 
   // absent-only, idempotent (normalizeSystemFields).
   if (Array.isArray(data.systems)) {
     data.systems = normalizeSystemFields({ systems: data.systems }).systems;
+  }
+
+  // Comments (format 7) get the same unconditional shape pass — junk-shaped
+  // or truncated records from a hand-edited file are dropped, well-formed
+  // ones ride verbatim.
+  if (Array.isArray(data.comments)) {
+    data.comments = normalizeCommentFields({ comments: data.comments }).comments;
   }
 
   // Resolve every write BEFORE applying any, so a missing setter can never

--- a/src/utils/dataImport.test.js
+++ b/src/utils/dataImport.test.js
@@ -31,6 +31,7 @@ const makeStores = (data = SAMPLE) => {
     setFindings: jest.fn(),
     setMetrics: jest.fn(),
     setSystems: jest.fn(),
+    setComments: jest.fn(),
     setProfileState: jest.fn()
   };
   const stores = {
@@ -43,6 +44,7 @@ const makeStores = (data = SAMPLE) => {
     findingsStore: { getState: () => ({ findings: data.findings, setFindings: setters.setFindings }) },
     metricsStore: { getState: () => ({ metrics: data.metrics, setMetrics: setters.setMetrics }) },
     inventoryStore: { getState: () => ({ systems: data.systems || [], setSystems: setters.setSystems }) },
+    commentsStore: { getState: () => ({ comments: data.comments || [], setComments: setters.setComments }) },
     orgProfileStore: { getState: () => ({ profile: null, cloudConsent: false, setProfileState: setters.setProfileState }) }
   };
   return { stores, setters };
@@ -50,6 +52,41 @@ const makeStores = (data = SAMPLE) => {
 
 afterEach(() => {
   window.localStorage.clear();
+});
+
+describe('comments restore semantics (format 7)', () => {
+  const COMMENT = {
+    id: 'c-1', targetType: 'finding', targetId: 'FND-1', text: 'note',
+    authorId: 1, authorName: 'A', mentions: [], createdAt: '2026-01-01T00:00:00.000Z'
+  };
+
+  test('comments round-trip through the bulk setter', () => {
+    const { stores } = makeStores({ ...SAMPLE, comments: [COMMENT] });
+    const parsed = JSON.parse(JSON.stringify(exportAllDataJSON(stores)));
+    const { stores: targetStores, setters } = makeStores();
+    const result = importCompleteDatabase(parsed, targetStores, { backupFirst: false });
+    expect(result.applied).toContain('comments');
+    expect(setters.setComments).toHaveBeenCalledWith([COMMENT]);
+  });
+
+  test('a file without a comments section leaves the receiver comments untouched', () => {
+    const { stores } = makeStores();
+    const parsed = JSON.parse(JSON.stringify(exportAllDataJSON(stores)));
+    delete parsed.data.comments; // pre-format-7 backup or a share export (OMIT)
+    const { stores: targetStores, setters } = makeStores();
+    const result = importCompleteDatabase(parsed, targetStores, { backupFirst: false });
+    expect(result.skipped).toContain('comments');
+    expect(setters.setComments).not.toHaveBeenCalled();
+  });
+
+  test('junk-shaped comment records are dropped on the way in', () => {
+    const { stores } = makeStores({ ...SAMPLE, comments: [COMMENT] });
+    const parsed = JSON.parse(JSON.stringify(exportAllDataJSON(stores)));
+    parsed.data.comments = [COMMENT, null, { id: 'no-target' }, 'junk'];
+    const { stores: targetStores, setters } = makeStores();
+    importCompleteDatabase(parsed, targetStores, { backupFirst: false });
+    expect(setters.setComments).toHaveBeenCalledWith([COMMENT]);
+  });
 });
 
 describe('export → restore round-trip', () => {
@@ -581,8 +618,8 @@ describe('PR-5: platform references on the restore path (format 5)', () => {
     ]
   });
 
-  test('the export format is 6 — systems section joins the envelope', () => {
-    expect(EXPORT_FORMAT_VERSION).toBe(6);
+  test('the export format is 7 — comments section joins the envelope', () => {
+    expect(EXPORT_FORMAT_VERSION).toBe(7);
   });
 
   test('a format-5 backup carrying references restores them VERBATIM (never dropped, never crashes)', () => {
@@ -614,8 +651,8 @@ describe('PR-5: platform references on the restore path (format 5)', () => {
     expect(out).toContain(REF.contentHash);
   });
 
-  test('a file from a newer format (7) is still rejected with the newer-version message', () => {
-    const result = validateDatabaseExport({ formatVersion: 7, data: { users: [] } });
+  test('a file from a newer format (8) is still rejected with the newer-version message', () => {
+    const result = validateDatabaseExport({ formatVersion: 8, data: { users: [] } });
     expect(result.ok).toBe(false);
     expect(result.errors.join(' ')).toMatch(/newer version/i);
   });

--- a/src/utils/dataMigration.js
+++ b/src/utils/dataMigration.js
@@ -161,7 +161,8 @@ export const migrateLegacyData = () => {
                 actionPlan: item['Action Plan'] || '',
                 dueDate: item['Remediation Due Date'] || ''
               }
-            });
+            // migration seeding — never audit-logged (bulk lane)
+            }, { log: false });
           });
         }
       });

--- a/src/utils/inventoryShare.test.js
+++ b/src/utils/inventoryShare.test.js
@@ -17,6 +17,7 @@ import useFindingsStore from '../stores/findingsStore';
 import useMetricsStore from '../stores/metricsStore';
 import useOrgProfileStore from '../stores/orgProfileStore';
 import useInventoryStore from '../stores/inventoryStore';
+import useCommentsStore from '../stores/commentsStore';
 
 const stores = () => ({
   controlsStore: useControlsStore,
@@ -28,7 +29,8 @@ const stores = () => ({
   findingsStore: useFindingsStore,
   metricsStore: useMetricsStore,
   orgProfileStore: useOrgProfileStore,
-  inventoryStore: useInventoryStore
+  inventoryStore: useInventoryStore,
+  commentsStore: useCommentsStore
 });
 
 // Canary strings: a system identity, an internal admin URL, an external
@@ -60,8 +62,9 @@ describe('complete backup (format 6)', () => {
   test('carries the systems section, count, and schema version slot', () => {
     seedCanarySystem();
     const envelope = exportAllDataJSON(stores());
-    expect(EXPORT_FORMAT_VERSION).toBe(6);
-    expect(envelope.formatVersion).toBe(6);
+    // ≥6: the systems section landed in format 6; later formats keep it.
+    expect(EXPORT_FORMAT_VERSION).toBeGreaterThanOrEqual(6);
+    expect(envelope.formatVersion).toBe(EXPORT_FORMAT_VERSION);
     expect(envelope.data.systems).toHaveLength(1);
     expect(envelope.data.systems[0].name).toBe(CANARY_NAME);
     expect(envelope.metadata.systemCount).toBe(1);

--- a/src/utils/metricsImport.test.js
+++ b/src/utils/metricsImport.test.js
@@ -65,6 +65,7 @@ const makeStores = ({ metrics = [], assessments = [], findings = [] } = {}) => (
   artifactStore: { getState: () => ({ artifacts: [], setArtifacts: jest.fn() }) },
   userStore: { getState: () => ({ users: [], setUsers: jest.fn() }) },
   inventoryStore: { getState: () => ({ systems: [], setSystems: jest.fn() }) },
+  commentsStore: { getState: () => ({ comments: [], setComments: jest.fn() }) },
   orgProfileStore: { getState: () => ({ profile: null, cloudConsent: false, setProfileState: jest.fn() }) }
 });
 

--- a/src/utils/shareRegistry.js
+++ b/src/utils/shareRegistry.js
@@ -234,6 +234,20 @@ const USER = struct({
   seedSource: SHARE
 });
 
+// Per-record discussion comments (evaluations/controls/findings). Author
+// names + free discussion text — private by the same reasoning as the user
+// directory; the section rides only under the include-private opt-in.
+const COMMENT = struct({
+  id: SHARE,
+  targetType: SHARE,
+  targetId: SHARE,
+  text: SHARE,
+  authorId: SHARE,
+  authorName: SHARE,
+  mentions: SHARE,
+  createdAt: SHARE
+});
+
 const CONTROL = struct({
   controlId: SHARE,
   name: SHARE,
@@ -486,6 +500,12 @@ export const SHARE_SECTIONS = {
   systems: {
     disposition: { default: OMIT, includePrivate: 'fold' },
     record: SYSTEM
+  },
+  // Record comments: the users-directory pattern — OMIT by default (deleted,
+  // never emptied), include-private opt-in rides them whole.
+  comments: {
+    disposition: { default: OMIT, includePrivate: 'fold' },
+    record: COMMENT
   },
   // The org profile (crown jewels + tooling) is never share material —
   // unconditionally, opt-in or not.


### PR DESCRIPTION
## Per-record comments + change audit log

Adds collaboration and accountability to the three record types:

**Comments** — a 💬 button in the top-right of every Assessment Evaluation record, Control detail, and Finding opens a right-docked panel. Flat, date-stamped comments with `@` mention autocomplete from the user directory (mentions render highlighted and are stored as user ids). Two-step delete, and every add/delete is audit-logged.

**Change log** — field-level audit entries (actor, timestamp, field, old → new) on every create/update/delete across evaluations (incl. quarterly scores/status/observations), controls, findings, and assessment create/rename/delete. Each record's panel has a History tab scoped to that record; the global `/history` page gains the new action types. Keystroke-grain edits coalesce (5-min window per actor+record+field) so the Controls panel's write-per-keystroke doesn't flood; typing back to the original value drops the entry.

**Acting user** — an "Acting as" selector in the sidebar (honor-system, no auth — same trust model as the rest of the app) attributes comments and audit entries; unset = `System`. Deleting the acting user resets attribution; historical entries keep their name snapshot.

### Data lifecycle

- Complete backups: `EXPORT_FORMAT_VERSION` 6 → 7, `comments` section rides wholesale; restore applies it only when present (older files / share exports leave receiver comments untouched) with unconditional shape repair.
- Share exports: `comments` declared in the registry as OMIT-by-default (deleted, not emptied — users-directory precedent), rides only under include-private. Golden snapshots diff-audited and updated.
- Subset exports: comments cascade with their records (evaluation comments by assessment, finding comments by surviving finding).
- Audit log stays device-local (existing posture); cap 500 → 1000; values truncated at 120 chars; CSV export formula-guarded (`@`/`=` prefixes — mention syntax made `@` routine).
- controlId rename: comments + history retarget to the new id, the rename is logged, and the page follows it (fixes pre-existing stale-panel-on-rename).

### Ratification items

1. Honor-system attribution (no auth) — deliberate.
2. Comments in complete backups but OMITted from default shares.
3. Comment deletion allowed + logged (`comment_deleted`).
4. Bulk lanes (wizard bank-attach, migration, CSV import, restore) exempt from per-field logging.
5. Comment volume: 2000 chars/comment, count uncapped (documented ceiling).

### Verification

- 76 suites / 1361 tests green (`CI=true`), incl. new suites: `commentsStore.test.js`, `auditLogStore.test.js`, `recordAudit.wiring.test.js`, `RecordPanel.test.js`, comments restore semantics in `dataImport.test.js`; golden export snapshots updated intentionally (default share carries no comments key).
- ESLint: zero new warnings (3 pre-existing baseline).
- Live click-through (real Chrome): all three surfaces, mention autocomplete, per-record History (score 3 → 4 with actor), global /history, dark mode, Escape closes only the panel (capture-phase + stopPropagation over the Findings slide-over).
