### PR TITLE
Add Claude diff security review and document the AI review layers

### DIFF
--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -1,0 +1,51 @@
+name: Security Review
+
+# AI-assisted diff review of pull requests using Anthropic's
+# claude-code-security-review action. The action analyzes only the files
+# changed in the PR, filters false positives, and leaves inline review
+# comments. It is one layer of the review process, not a gate: findings
+# are advisory and require human verification (see SECURITY.md,
+# "AI-Assisted Security Review").
+#
+# Both actions are pinned to full commit SHAs, not tags or branches.
+# The upstream README says @main; a reviewer with pull-requests: write
+# and an API key is itself a third-party dependency, and mutable refs
+# are how action supply-chain compromises happen. Bump the pins
+# deliberately, via PR.
+
+permissions:
+  pull-requests: write # inline review comments on findings
+  contents: read
+
+on:
+  pull_request:
+
+# One run per PR at a time; force-pushes cancel the superseded run so
+# API spend tracks the newest diff only (tokens already spent are not
+# refunded, but the runner stops).
+concurrency:
+  group: security-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  security-review:
+    name: Claude diff security review
+    # GitHub strips repo secrets from pull_request runs triggered by fork
+    # PRs, so the API key would be empty and every external PR would fail
+    # red. Dependabot runs also cannot read regular Actions secrets. Both
+    # are skipped here; maintainers review external PRs locally with
+    # /security-review instead. Deliberately NOT path-filtered: skills
+    # and prompts are markdown, so markdown stays in scope.
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25 # backstop above the action's internal 20-minute default
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 2
+
+      - uses: anthropics/claude-code-security-review@0c6a49f1fa56a1d472575da86a94dbc1edb78eda # main, 2026-07-26
+        with:
+          comment-pr: true
+          claude-api-key: ${{ secrets.CLAUDE_API_KEY }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,6 +78,31 @@ Sanitize input using DOMPurify before rendering...
 - Browser security policies apply
 - Local storage accessible only from the same origin
 
+## AI-Assisted Security Review
+
+This project uses AI-assisted review in two layers, mapped to NIST CSF 2.0 functions the same way the app itself maps assessments:
+
+### Layer 1: PR-time diff review (continuous — CSF DE.CM)
+
+Every same-repo pull request is analyzed by [Anthropic's claude-code-security-review](https://github.com/anthropics/claude-code-security-review) GitHub Action (MIT license). It reviews only the changed files, filters false positives, and leaves inline comments. See `.github/workflows/security-review.yml`.
+
+Operating notes:
+
+- **Findings are advisory, never auto-filed.** A human maintainer verifies every finding before it becomes an issue or a fix. Unverified AI findings are noise at best and a disclosure problem at worst.
+- **Fork PRs are skipped by design.** GitHub strips repo secrets from `pull_request` runs triggered from forks, so the workflow guards on `head.repo.full_name == github.repository`. Maintainers review external PRs locally with the `/security-review` slash command that ships with Claude Code.
+- **The action itself is a prompt-injection surface.** Per Anthropic's own documentation, the reviewer is not hardened against adversarial PR content. The repository uses GitHub's "require approval for outside contributors" workflow setting, and this check stays out of required branch protection until a maintainer has verified a green run.
+- **Setup (maintainers):** add a `CLAUDE_API_KEY` repository secret (a dedicated Anthropic API key with a spend cap, enabled for the Claude API and Claude Code). Runs are billed API usage with a 20-minute default timeout.
+- **The reviewer is a third-party dependency too.** Both actions in the workflow are pinned to full commit SHAs rather than tags or `@main`, and both belong in the same supply-chain inventory (GV.SC) this section describes. Pin bumps happen deliberately, via PR.
+- **Coverage is honest, not total.** Because fork PRs and Dependabot runs are skipped, the automated layer only sees maintainer branches. External contributions, the population that most needs review, get human review plus a local `/security-review` pass instead.
+
+### Layer 2: point-in-time deep review (periodic — CSF ID.RA)
+
+Scheduled deep assessments use [Google's Mantis](https://github.com/google/mantis) (Apache-2.0), a toolkit of security-review skills for AI coding agents covering threat modeling through finding calibration. Mantis is demonstration-grade by Google's own statement and is deliberately **not** wired into CI: it has no CLI, its output is non-deterministic, and running it requires an isolated environment. Assessments run offline on a scoped copy of the repository, findings are human-verified, and confirmed issues enter the normal vulnerability response process above.
+
+### Why two layers
+
+Diff review catches what a change introduces; it cannot see what the codebase already carries. Deep review sees the whole system but is too slow and expensive to run per-PR. Together they cover continuous monitoring (DE.CM) and periodic risk assessment (ID.RA) without pretending either tool replaces the supply-chain and access controls (GV.SC, PR.AA) that bound what any code change can reach.
+
 ## Vulnerability Response Process
 
 1. **Report Received**: We'll acknowledge receipt within 48 hours


### PR DESCRIPTION
Layer 1: anthropics/claude-code-security-review runs on same-repo PRs (fork PRs are skipped because secrets are stripped; maintainers use /security-review locally). Layer 2: Google Mantis positioned as the periodic offline deep review, never CI. SECURITY.md maps the layers to CSF DE.CM and ID.RA and records the operating rules: findings are advisory, humans verify, the reviewer itself is a prompt-injection surface so external-contributor approval gating stays on.

Maintainer setup: add a CLAUDE_API_KEY repo secret; leave the check out of required branch protection until the first green run.