### PR TITLE
Make Assessments-list evaluations right-clickable into a new window

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1872,3 +1872,47 @@ nav a:active { text-decoration: none !important; }
   border: 1px solid var(--border-color);
   border-radius: 4px;
 }
+
+/* ==========================================================================
+   Evaluation cards — whole-card link target (Assessments list)
+   Each evaluation is addressable at /assessments?selected=<id>. Its title is
+   a real anchor, so the browser's own context menu supplies "Open Link in New
+   Window" / "New Tab", and the ::after overlay stretches that hit area across
+   the whole card. The card's own buttons are lifted above the overlay so they
+   keep taking clicks. Named rules rather than utilities: the utility layer
+   here is a partial hand-written subset with no z-10/z-0.
+   ========================================================================== */
+
+.evaluation-card { position: relative; }
+
+.evaluation-card__link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.evaluation-card__link::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+.evaluation-card__actions,
+.evaluation-card__status {
+  position: relative;
+  z-index: 2;
+}
+
+/* The hit area is the whole card, so the focus ring is drawn on the overlay
+   rather than around the title text — otherwise keyboard users see a ring
+   that describes a much smaller target than the one they are about to
+   activate. */
+.evaluation-card__link:focus-visible {
+  outline: none;
+}
+
+.evaluation-card__link:focus-visible::after {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: var(--radius-lg);
+}

--- a/src/pages/Assessments.js
+++ b/src/pages/Assessments.js
@@ -1,4 +1,5 @@
-import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
 import {
   Plus, Edit, Save, Trash2, X, CheckCircle, XCircle,
   Download, Upload, ClipboardList, FileSearch, ChevronRight, Copy,
@@ -103,6 +104,10 @@ const Assessments = () => {
 
   // AI Store for test procedure generation
   const { llmProvider, generateWithOllama, generateWithClaude, ollamaStatus, claudeStatus, checkClaude, checkOllama } = useAIStore();
+
+  // Deep linking: /assessments?selected=<assessmentId> — same convention the
+  // Findings and Controls pages already honor.
+  const [searchParams, setSearchParams] = useSearchParams();
 
   // Local state
   const [view, setView] = useState('list'); // 'list', 'scope', 'assess'
@@ -784,6 +789,22 @@ Format as a numbered list. Be specific and actionable.`;
     setSelectedItemId(null);
   }, [setCurrentAssessmentId]);
 
+  // Honor ?selected=<assessmentId> so an evaluation opened in a new window or
+  // tab lands on that evaluation instead of the generic list. useLayoutEffect
+  // rather than useEffect: this runs before paint, so a freshly opened window
+  // shows the evaluation without flashing the list first. Persisted
+  // assessments rehydrate synchronously; a seed-CSV first visit lands on the
+  // re-run once `assessments` populates.
+  useLayoutEffect(() => {
+    const selectedParam = searchParams.get('selected');
+    if (!selectedParam) return;
+    const assessment = assessments.find(a => a.id === selectedParam);
+    if (!assessment) return;
+    handleSelectAssessment(assessment);
+    // Clear the URL parameter after selection
+    setSearchParams({}, { replace: true });
+  }, [searchParams, assessments, handleSelectAssessment, setSearchParams]);
+
   const handleDeleteAssessment = useCallback((assessmentId) => {
     const assessment = assessments.find(a => a.id === assessmentId);
     if (window.confirm(`Delete assessment "${assessment?.name}"?`)) {
@@ -1198,12 +1219,37 @@ Format as a numbered list. Be specific and actionable.`;
               return (
                 <div
                   key={assessment.id}
-                  className="bg-white border rounded-lg p-4 hover:shadow-md cursor-pointer transition-shadow"
-                  onClick={() => handleSelectAssessment(assessment)}
+                  className="evaluation-card bg-white border rounded-lg p-4 hover:shadow-md cursor-pointer transition-shadow"
                 >
                   <div className="flex items-start justify-between">
                     <div>
-                      <h3 className="font-bold text-lg">{assessment.name}</h3>
+                      {/* A real anchor, not a div+onClick: the browser then
+                          supplies "Open Link in New Window"/"New Tab" on
+                          right-click, plus Cmd-click, middle-click and
+                          keyboard focus. Its ::after overlay stretches the hit
+                          area over the whole card. */}
+                      <h3 className="font-bold text-lg">
+                        <Link
+                          to={`/assessments?selected=${encodeURIComponent(assessment.id)}`}
+                          className="evaluation-card__link"
+                          onClick={(e) => {
+                            // A plain left-click selects in place, exactly as
+                            // the old card onClick did — routing through the
+                            // URL would push a history entry that the
+                            // ?selected= handler immediately replaces, leaving
+                            // a Back stack of identical no-op /assessments
+                            // entries. Modified clicks and the context menu
+                            // fall through untouched, which is what makes
+                            // "Open Link in New Window", Cmd-click and
+                            // middle-click work.
+                            if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                            e.preventDefault();
+                            handleSelectAssessment(assessment);
+                          }}
+                        >
+                          {assessment.name}
+                        </Link>
+                      </h3>
                       {assessment.description && (
                         <p className="text-gray-600 text-sm mt-1">{assessment.description}</p>
                       )}
@@ -1211,7 +1257,7 @@ Format as a numbered list. Be specific and actionable.`;
                         <span>Scope: {assessment.scopeType === 'controls' ? 'Controls' : 'Requirements'}</span>
                         <span>{prog.total} items</span>
                         <button
-                          className={`${getStatusColor(assessment.status)} hover:opacity-80 transition-opacity`}
+                          className={`evaluation-card__status ${getStatusColor(assessment.status)} hover:opacity-80 transition-opacity`}
                           onClick={(e) => {
                             e.stopPropagation();
                             setCurrentAssessmentId(assessment.id);
@@ -1230,7 +1276,7 @@ Format as a numbered list. Be specific and actionable.`;
                         </button>
                       </div>
                     </div>
-                    <div className="flex items-center gap-2" onClick={e => e.stopPropagation()}>
+                    <div className="evaluation-card__actions flex items-center gap-2" onClick={e => e.stopPropagation()}>
                       <button
                         className="p-2 rounded"
                         style={{ backgroundColor: '#e5e7eb', color: '#000000' }}

--- a/src/pages/assessmentDeepLink.test.js
+++ b/src/pages/assessmentDeepLink.test.js
@@ -1,0 +1,129 @@
+/**
+ * Assessments list — every evaluation is a real link.
+ *
+ * The cards used to be `div`s with an onClick, so the browser had no link to
+ * offer a context menu for: no "Open Link in New Window", no Cmd-click, no
+ * keyboard focus. These tests pin the two halves of the fix — the anchor that
+ * produces the URL, and the `?selected=` handler that consumes it.
+ */
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Assessments from './Assessments';
+import useAssessmentsStore from '../stores/assessmentsStore';
+
+// react-markdown and remark-gfm are ESM and CRA's Jest does not transform
+// them; the repo mocks them at the test-file level (see App.test.js).
+jest.mock('react-markdown', () => {
+  return function ReactMarkdown({ children }) {
+    return <div>{children}</div>;
+  };
+});
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => {} }));
+
+const EVAL_ID = 'ASM-1001';
+const EVAL_NAME = 'Q3 CSF Baseline';
+
+const seedAssessment = (overrides = {}) => ({
+  id: EVAL_ID,
+  name: EVAL_NAME,
+  description: 'Baseline evaluation',
+  scopeType: 'requirements',
+  scoringScale: 10,
+  externalTracking: null,
+  year: 2026,
+  users: [],
+  platforms: [],
+  scopeIds: [],
+  frameworkFilter: null,
+  status: 'Not Started',
+  createdDate: '2026-01-01T00:00:00.000Z',
+  lastModified: '2026-01-01T00:00:00.000Z',
+  observations: {},
+  ...overrides
+});
+
+const renderAt = (route) =>
+  render(
+    <MemoryRouter initialEntries={[route]}>
+      <Assessments />
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  window.localStorage.clear();
+  useAssessmentsStore.setState({
+    assessments: [seedAssessment()],
+    currentAssessmentId: null
+  });
+});
+
+describe('Assessments list — evaluation cards are links', () => {
+  test('each evaluation renders an anchor addressing itself', () => {
+    renderAt('/assessments');
+
+    const link = screen.getByRole('link', { name: EVAL_NAME });
+    expect(link).toHaveAttribute('href', `/assessments?selected=${EVAL_ID}`);
+  });
+
+  test('the anchor carries no target — the context menu decides window vs tab', () => {
+    renderAt('/assessments');
+
+    const link = screen.getByRole('link', { name: EVAL_NAME });
+    expect(link.getAttribute('target')).toBeNull();
+  });
+
+  test('clicking the card link opens that evaluation', () => {
+    renderAt('/assessments');
+
+    fireEvent.click(screen.getByRole('link', { name: EVAL_NAME }));
+
+    expect(useAssessmentsStore.getState().currentAssessmentId).toBe(EVAL_ID);
+    expect(screen.getByText(/Define scope/i)).toBeInTheDocument();
+  });
+
+  test('the link is keyboard reachable — Enter opens the evaluation', () => {
+    renderAt('/assessments');
+
+    const link = screen.getByRole('link', { name: EVAL_NAME });
+    act(() => link.focus());
+    expect(link).toHaveFocus();
+
+    fireEvent.keyDown(link, { key: 'Enter', code: 'Enter' });
+    fireEvent.click(link); // Enter on an anchor dispatches a click in a real browser
+
+    expect(useAssessmentsStore.getState().currentAssessmentId).toBe(EVAL_ID);
+  });
+});
+
+describe('Assessments deep link — ?selected=<id>', () => {
+  test('a window opened at ?selected=<id> lands on that evaluation, not the list', () => {
+    renderAt(`/assessments?selected=${EVAL_ID}`);
+
+    expect(useAssessmentsStore.getState().currentAssessmentId).toBe(EVAL_ID);
+    expect(screen.getByText(/Define scope/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Control Evaluations/i)).not.toBeInTheDocument();
+  });
+
+  test('an unknown id leaves the list intact and throws nothing', () => {
+    expect(() => renderAt('/assessments?selected=ASM-does-not-exist')).not.toThrow();
+
+    expect(screen.getByText(/Control Evaluations/i)).toBeInTheDocument();
+    expect(useAssessmentsStore.getState().currentAssessmentId).toBeNull();
+  });
+
+  test('the clone and delete buttons do not navigate to the evaluation', () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+    const promptSpy = jest.spyOn(window, 'prompt').mockReturnValue(null);
+    renderAt('/assessments');
+
+    fireEvent.click(screen.getByTitle('Clone assessment'));
+    fireEvent.click(screen.getByTitle('Delete assessment'));
+
+    expect(screen.getByText(/Control Evaluations/i)).toBeInTheDocument();
+    expect(useAssessmentsStore.getState().currentAssessmentId).toBeNull();
+
+    confirmSpy.mockRestore();
+    promptSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Each evaluation card was a div with an onClick, so the browser had no link to build a context menu around: no "Open Link in New Window", no Cmd-click, no middle-click, and no keyboard focus. There was also no URL addressing a single evaluation.

Each card title is now a react-router Link to /assessments?selected=<id>, with a stretched ::after overlay so the whole card is the hit area and the clone/delete/status buttons raised above it. The page honors ?selected= in a pre-paint layout effect, reusing handleSelectAssessment and clearing the param -- the same convention Findings and Controls already use.

A plain left-click is intercepted and selects in place, so it adds no history entry; modified clicks and right-click fall through to the browser untouched, which is what makes the new-window affordance work.

Known cost: the overlay owns the hit test, so card text is no longer drag-selectable in the list.