### PR TITLE
Give the CSV-only findings columns a panel surface

### DIFF
--- a/src/pages/Findings.js
+++ b/src/pages/Findings.js
@@ -227,7 +227,7 @@ const Findings = () => {
       'Last Modified': '',
       'Control ID': 'PR.AA-05 Ex1',
       'Linked Artifacts': 'Access Review Report; IAM Policy',
-      'Jira Key': ''
+      'Ticket ID': 'SEC-123'
     };
 
     const csv = [
@@ -328,7 +328,10 @@ const Findings = () => {
       dueDate: '',
       status: 'Not Started',
       priority: 'Medium',
-      externalUrl: ''
+      externalUrl: '',
+      controlId: '',
+      linkedArtifacts: [],
+      jiraKey: ''
     });
     setEditMode(false);
     setErrors({});
@@ -901,9 +904,11 @@ const Findings = () => {
                     )}
                   </div>
 
-                  {/* CSF Compliance Requirement */}
+                  {/* CSF Compliance Requirement — labelled to match the CSV
+                      column of the same name so the panel and the sheet cannot
+                      drift apart again. */}
                   <div className="flex items-center justify-between">
-                    <span className="text-sm text-gray-500 dark:text-gray-400">CSF Reference</span>
+                    <span className="text-sm text-gray-500 dark:text-gray-400">Compliance Requirement</span>
                     {editMode ? (
                       <input
                         type="text"
@@ -1008,6 +1013,73 @@ const Findings = () => {
                       </span>
                     </div>
                   )}
+
+                  {/* Control ID, Linked Artifacts and Ticket ID were exported
+                      to CSV but had no panel surface, so the sheet carried
+                      state the UI could neither show nor correct. Order here
+                      matches the tail of FINDING_CSV_HEADERS. */}
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-gray-500 dark:text-gray-400">Control ID</span>
+                    {editMode ? (
+                      <input
+                        type="text"
+                        name="controlId"
+                        value={formData.controlId || ''}
+                        onChange={handleChange}
+                        className="p-1 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white w-32"
+                        placeholder="e.g., DE.AE-03 Ex1"
+                      />
+                    ) : (
+                      <span className="text-sm text-gray-700 dark:text-gray-300">
+                        {selectedFinding?.controlId || '-'}
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Stored as an array; the CSV joins on '; ' and the importer
+                      splits on ';', so the input round-trips through the same
+                      separator rather than inventing a third representation. */}
+                  <div className="flex items-start justify-between">
+                    <span className="text-sm text-gray-500 dark:text-gray-400">Linked Artifacts</span>
+                    {editMode ? (
+                      <input
+                        type="text"
+                        name="linkedArtifacts"
+                        value={(formData.linkedArtifacts || []).join('; ')}
+                        onChange={(e) => setFormData({
+                          ...formData,
+                          linkedArtifacts: e.target.value
+                            .split(';').map(s => s.trim()).filter(Boolean)
+                        })}
+                        className="p-1 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white max-w-[200px]"
+                        placeholder="Report A; Policy B"
+                      />
+                    ) : (
+                      <span className="text-sm text-gray-700 dark:text-gray-300 text-right max-w-[200px] break-words">
+                        {(selectedFinding?.linkedArtifacts || []).length > 0
+                          ? selectedFinding.linkedArtifacts.join('; ')
+                          : 'None'}
+                      </span>
+                    )}
+                  </div>
+
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-gray-500 dark:text-gray-400">Ticket ID</span>
+                    {editMode ? (
+                      <input
+                        type="text"
+                        name="jiraKey"
+                        value={formData.jiraKey || ''}
+                        onChange={handleChange}
+                        className="p-1 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white w-32"
+                        placeholder="e.g., FND-1001"
+                      />
+                    ) : (
+                      <span className="text-sm text-gray-700 dark:text-gray-300">
+                        {selectedFinding?.jiraKey || '-'}
+                      </span>
+                    )}
+                  </div>
                 </div>
               </div>
 

--- a/src/pages/findingsPanelParity.test.js
+++ b/src/pages/findingsPanelParity.test.js
@@ -1,0 +1,90 @@
+/**
+ * Findings detail panel — render probe for the CSV-parity fields (2026-08-05).
+ *
+ * `findingsCsvUiParity.test.js` proves the column list and the panel source
+ * agree. That is a source-level check: it would still pass if a label sat
+ * inside a branch that never renders. This suite mounts the real panel and
+ * asserts the fields reach the DOM with their real values, which is the claim
+ * the source check cannot make on its own.
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Findings from './Findings';
+import useFindingsStore from '../stores/findingsStore';
+import useAssessmentsStore from '../stores/assessmentsStore';
+
+jest.mock('react-markdown', () => {
+  return function ReactMarkdown({ children }) {
+    return <div>{children}</div>;
+  };
+});
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => {} }));
+
+const FINDING = {
+  id: 'FND-parity-1',
+  summary: 'Detection coverage gap',
+  name: '',
+  description: '',
+  rootCause: '',
+  remediationActionPlan: '',
+  complianceRequirement: 'GV.SC-04',
+  controlId: 'DE.AE-03 Ex1',
+  linkedArtifacts: ['AWS Config Snapshot', 'IAM Policy'],
+  jiraKey: 'FND-1001',
+  assessmentId: null,
+  remediationOwner: null,
+  dueDate: '',
+  status: 'Not Started',
+  priority: 'Medium',
+  externalUrl: '',
+  createdDate: '2026-04-30T10:48:04.460Z',
+  lastModified: '2026-04-30T10:48:04.460Z'
+};
+
+const openPanel = () => {
+  render(
+    <MemoryRouter initialEntries={['/findings']}>
+      <Findings />
+    </MemoryRouter>
+  );
+  fireEvent.click(screen.getByText('Detection coverage gap'));
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  useAssessmentsStore.setState({ assessments: [], currentAssessmentId: null });
+  useFindingsStore.setState({ findings: [FINDING] });
+});
+
+describe('the three CSV columns that had no panel surface now render', () => {
+  it('shows Control ID with its value', () => {
+    openPanel();
+    expect(screen.getByText('Control ID')).toBeInTheDocument();
+    // The value can also appear in the list row, so assert presence, not count.
+    expect(screen.getAllByText('DE.AE-03 Ex1').length).toBeGreaterThan(0);
+  });
+
+  it('shows Linked Artifacts joined on the same separator the CSV uses', () => {
+    openPanel();
+    expect(screen.getByText('Linked Artifacts')).toBeInTheDocument();
+    expect(screen.getByText('AWS Config Snapshot; IAM Policy')).toBeInTheDocument();
+  });
+
+  it('shows Ticket ID, not the old Jira Key label', () => {
+    openPanel();
+    expect(screen.getByText('Ticket ID')).toBeInTheDocument();
+    expect(screen.getAllByText('FND-1001').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Jira Key')).not.toBeInTheDocument();
+  });
+});
+
+describe('the compliance field is labelled the same as its CSV column', () => {
+  it('reads "Compliance Requirement", not the old "CSF Reference"', () => {
+    openPanel();
+    expect(screen.getByText('Compliance Requirement')).toBeInTheDocument();
+    expect(screen.queryByText('CSF Reference')).not.toBeInTheDocument();
+    // Also rendered in the list's CSF Ref column — presence, not count.
+    expect(screen.getAllByText('GV.SC-04').length).toBeGreaterThan(0);
+  });
+});

--- a/src/stores/findingsCsvUiParity.test.js
+++ b/src/stores/findingsCsvUiParity.test.js
@@ -11,10 +11,68 @@
  * are Jira's own import columns, a foreign contract, not this app's to rename.
  */
 
+import fs from 'fs';
+import path from 'path';
 import useFindingsStore, { FINDING_CSV_HEADERS } from './findingsStore';
 import useUserStore from './userStore';
 
 const resetStore = () => useFindingsStore.setState({ findings: [] });
+
+const PANEL_SOURCE = fs.readFileSync(
+  path.join(__dirname, '..', 'pages', 'Findings.js'),
+  'utf8'
+);
+
+/**
+ * How each CSV column reaches the panel. `label` entries must appear verbatim
+ * in Findings.js; the other kinds are surfaces that have no text label (the
+ * record header, the title, the two badges) or whose label is computed at
+ * runtime from the assessment's tracking config.
+ *
+ * Adding a column to FINDING_CSV_HEADERS without adding it here fails the
+ * suite — that is the point. The previous version of this file hard-coded a
+ * copy of the panel's field list, so a column could be added to the sheet with
+ * no panel surface and nothing complained. Control ID, Linked Artifacts and
+ * the ticket key all drifted that way.
+ */
+const PANEL_SURFACE = {
+  'Finding ID': { kind: 'record-header' },
+  'Summary': { kind: 'record-title' },
+  'Status': { kind: 'badge' },
+  'Priority': { kind: 'badge' },
+  'External URL': { kind: 'computed-label' }, // externalUrlLabel(tracking, ...)
+  'Name': { kind: 'label', label: 'Name' },
+  'Description': { kind: 'label', label: 'Description' },
+  'Root Cause': { kind: 'label', label: 'Root Cause' },
+  'Remediation Action Plan': { kind: 'label', label: 'Remediation Action Plan' },
+  'Assessment ID': { kind: 'label', label: 'Assessment' },
+  'Compliance Requirement': { kind: 'label', label: 'Compliance Requirement' },
+  'Remediation Owner': { kind: 'label', label: 'Remediation Owner' },
+  'Due Date': { kind: 'label', label: 'Due Date' },
+  'Created Date': { kind: 'label', label: 'Created' },
+  'Last Modified': { kind: 'label', label: 'Last Modified' },
+  'Control ID': { kind: 'label', label: 'Control ID' },
+  'Linked Artifacts': { kind: 'label', label: 'Linked Artifacts' },
+  'Ticket ID': { kind: 'label', label: 'Ticket ID' }
+};
+
+/** Panel rows that deliberately have no column: derived, not stored. */
+const PANEL_ONLY_LABELS = ['Linked Controls'];
+
+/** Pull every Details-row label out of the real panel source. */
+const detailsSectionLabels = () => {
+  const start = PANEL_SOURCE.indexOf('{/* Details section */}');
+  if (start === -1) throw new Error('Details section marker moved — update this probe');
+  const body = PANEL_SOURCE.slice(start);
+  const labels = [];
+  const re = /className="text-sm text-gray-500[^"]*">([\s\S]*?)<\/span>/g;
+  let m;
+  while ((m = re.exec(body)) !== null) {
+    const text = m[1].replace(/<[^>]*\/>/g, '').replace(/\s+/g, ' ').trim();
+    if (text && /^[A-Z]/.test(text) && !text.includes('{')) labels.push(text);
+  }
+  return labels;
+};
 
 const captureCSV = (run) => {
   const captured = [];
@@ -41,14 +99,37 @@ describe('FINDING_CSV_HEADERS is the single canonical column list', () => {
     expect(descAt).toBe(nameAt + 1);
   });
 
-  it('carries every field the detail panel shows', () => {
-    // Panel surfaces, in panel order
-    ['Finding ID', 'Summary', 'Status', 'Priority', 'External URL', 'Name',
-      'Description', 'Root Cause', 'Remediation Action Plan', 'Assessment ID',
-      'Compliance Requirement', 'Remediation Owner', 'Due Date', 'Created Date',
-      'Last Modified'].forEach((header) => {
-      expect(FINDING_CSV_HEADERS).toContain(header);
-    });
+  it('declares a panel surface for every column', () => {
+    const undeclared = FINDING_CSV_HEADERS.filter(h => !PANEL_SURFACE[h]);
+    expect(undeclared).toEqual([]);
+  });
+
+  it('has no declared surface for a column that no longer exists', () => {
+    const orphaned = Object.keys(PANEL_SURFACE).filter(h => !FINDING_CSV_HEADERS.includes(h));
+    expect(orphaned).toEqual([]);
+  });
+
+  it('renders each labelled column as a literal label in the panel source', () => {
+    // Details rows render as >Label</span>; the prose sections render as an
+    // <h3> with an icon, putting the label on its own line.
+    const rendersLabel = (label) =>
+      PANEL_SOURCE.includes(`>${label}</`) ||
+      PANEL_SOURCE.split('\n').some(line => line.trim() === label);
+
+    const missing = Object.entries(PANEL_SURFACE)
+      .filter(([, s]) => s.kind === 'label')
+      .filter(([, s]) => !rendersLabel(s.label))
+      .map(([header]) => header);
+    expect(missing).toEqual([]);
+  });
+
+  it('has no Details row that the CSV does not carry', () => {
+    const mapped = Object.values(PANEL_SURFACE)
+      .filter(s => s.kind === 'label')
+      .map(s => s.label);
+    const unexported = detailsSectionLabels()
+      .filter(l => !mapped.includes(l) && !PANEL_ONLY_LABELS.includes(l));
+    expect(unexported).toEqual([]);
   });
 
   it('no longer carries Evaluation ID — no UI surface and no seeded data', () => {
@@ -122,6 +203,40 @@ describe('round trip: export → import preserves the new columns', () => {
     expect(restored.description).toBe('No out-of-band verification on payment changes.');
     expect(restored.externalUrl).toBe('https://example.com/ticket/9');
     expect(restored.priority).toBe('Critical');
+  });
+
+  it('restores the three columns that had no panel surface before 2026-08-05', () => {
+    useFindingsStore.getState().createFinding({
+      summary: 'Detection gap',
+      controlId: 'DE.AE-03 Ex1',
+      linkedArtifacts: ['AWS Config Snapshot', 'IAM Policy'],
+      jiraKey: 'FND-1001'
+    });
+
+    const csv = captureCSV(() => useFindingsStore.getState().exportFindingsCSV(useUserStore));
+    expect(headerLine(csv)).toContain('Ticket ID');
+    expect(headerLine(csv)).not.toContain('Jira Key');
+
+    return useFindingsStore.getState().importFindingsCSV(
+      (resetStore(), csv), useUserStore
+    ).then(() => {
+      const [restored] = useFindingsStore.getState().findings;
+      expect(restored.controlId).toBe('DE.AE-03 Ex1');
+      expect(restored.linkedArtifacts).toEqual(['AWS Config Snapshot', 'IAM Policy']);
+      expect(restored.jiraKey).toBe('FND-1001');
+    });
+  });
+
+  it('still imports a sheet written when the column was called Jira Key', async () => {
+    const legacy = [
+      FINDING_CSV_HEADERS.join(',').replace('Ticket ID', 'Jira Key'),
+      ['FND-legacy', 'Old sheet', 'Not Started', 'Medium', '', '', '', '', '',
+        '', '', '', '', '', '', '', '', 'FND-9999'].join(',')
+    ].join('\n');
+
+    await useFindingsStore.getState().importFindingsCSV(legacy, useUserStore);
+    const [restored] = useFindingsStore.getState().findings;
+    expect(restored.jiraKey).toBe('FND-9999');
   });
 
   it('does not accumulate quote characters on an apostrophe (csvFormulaGuard, not escapeCSVValue)', async () => {

--- a/src/stores/findingsStore.js
+++ b/src/stores/findingsStore.js
@@ -49,6 +49,18 @@ const LEGACY_DEMO_FINDING_IDS = new Set(['FND-1', 'FND-2', 'FND-3', 'FND-4']);
  *  - KEPT without a panel surface: `Control ID` and `Linked Artifacts` carry
  *    live seeded data and are reachable from other pages, so dropping them
  *    would destroy state the sheet is supposed to carry.
+ *
+ * What changed (2026-08-05):
+ *  - The three CSV-only columns now have panel rows. `Control ID` (242/243
+ *    rows populated), `Linked Artifacts` (241/243) and the ticket key (242/243)
+ *    were exported but invisible and uneditable in the UI, so the sheet carried
+ *    state the panel could neither show nor correct. Parity is now both ways:
+ *    every column here has a panel surface, and every panel surface has a
+ *    column.
+ *  - RENAMED: `Jira Key` -> `Ticket ID`. The field was never Jira-specific
+ *    (externalUrl already points at Jira/ServiceNow/anything). The importer
+ *    still accepts `Jira Key` and Jira's own `Issue key`, so CSVs exported by
+ *    earlier versions load unchanged.
  */
 export const FINDING_CSV_HEADERS = [
   'Finding ID',
@@ -68,7 +80,7 @@ export const FINDING_CSV_HEADERS = [
   'Last Modified',
   'Control ID',
   'Linked Artifacts',
-  'Jira Key'
+  'Ticket ID'
 ];
 
 /**
@@ -334,7 +346,7 @@ const useFindingsStore = create(
           'Last Modified': csvFormulaGuard(f.lastModified || ''),
           'Control ID': csvFormulaGuard(f.controlId || ''),
           'Linked Artifacts': csvFormulaGuard((f.linkedArtifacts || []).join('; ')),
-          'Jira Key': csvFormulaGuard(f.jiraKey || '')
+          'Ticket ID': csvFormulaGuard(f.jiraKey || '')
         }));
 
         const csv = Papa.unparse(csvData, { columns: FINDING_CSV_HEADERS });
@@ -464,7 +476,10 @@ const useFindingsStore = create(
                   // importer's 'Last Updated' handling.
                   lastModified: (row['Last Modified'] || row['Updated'] || '').trim() || new Date().toISOString(),
                   externalUrl: row['External URL'] || '',
-                  jiraKey: row['Issue key'] || row['Jira Key'] || null,
+                  // 'Ticket ID' is the current column name; 'Jira Key' is what
+                  // this app exported before 2026-08-05 and 'Issue key' is
+                  // Jira's own export header. All three still load.
+                  jiraKey: row['Ticket ID'] || row['Issue key'] || row['Jira Key'] || null,
                   linkedArtifacts: (row['Linked Artifacts'] || '')
                     .split(';').map(s => s.trim()).filter(Boolean)
                 };


### PR DESCRIPTION
Control ID, Linked Artifacts and the ticket key were exported to CSV but had no panel surface — invisible and uneditable despite being populated on ~242/243 real rows. All three are now editable panel rows ordered to match the CSV tail.

Also renames the panel's CSF Reference label to Compliance Requirement (CSV header untouched), and renames the Jira Key column to Ticket ID. The importer accepts Ticket ID, Jira Key and Jira's own Issue key, so previously exported sheets still load.

Root cause: the parity test hand-copied the panel's field list, so a column with no panel surface could never fail it. It now derives from the panel source and checks both directions; mutation-tested to confirm it fails on drift.

1450 tests pass (up 9), lint clean.