### PR TITLE
Add external ticket links to Controls and Artifacts

### DIFF
--- a/src/pages/Artifacts.js
+++ b/src/pages/Artifacts.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { Edit, Trash2, Save, X, Plus, Link as LinkIcon, Upload, Download, ChevronRight, User, Shield, FileArchive, FileSpreadsheet } from 'lucide-react';
+import { Edit, Trash2, Save, X, Plus, Link as LinkIcon, ExternalLink, Upload, Download, ChevronRight, User, Shield, FileArchive, FileSpreadsheet } from 'lucide-react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import useCSFStore from '../stores/csfStore';
@@ -47,6 +47,8 @@ const Artifacts = () => {
     name: '',
     description: '',
     link: '',
+    externalUrl: '',
+    jiraKey: '',
     type: 'Document',
     status: 'ACTIVE',
     health: '',
@@ -177,7 +179,8 @@ const Artifacts = () => {
       'Priority': 'Medium',
       'Control ID': 'PR.AA-05 Ex1',
       'Assessment ID': '',
-      'Link': 'https://example.sharepoint.com/evidence/access-review-q1.pdf',
+      'Artifact Link': 'https://example.sharepoint.com/evidence/access-review-q1.pdf',
+      'External Ticket Link': 'https://example.atlassian.net/browse/EV-42',
       'Description': 'Signed quarterly privileged access review covering all production systems.',
       'Linked Subcategories': 'PR.AA-05; PR.AA-01',
       'Assignee': 'Owner Name <owner@example.com>',
@@ -186,7 +189,7 @@ const Artifacts = () => {
       'Last Updated': '',
       'Linked Evaluation IDs': '',
       'Compliance Requirement': '',
-      'Jira Key': ''
+      'Ticket ID': 'EV-42'
     };
 
     const csv = [
@@ -316,6 +319,8 @@ const Artifacts = () => {
       name: '',
       description: '',
       link: '',
+      externalUrl: '',
+      jiraKey: '',
       type: 'Document',
       status: 'ACTIVE',
       health: '',
@@ -834,9 +839,11 @@ const Artifacts = () => {
                   )}
                 </div>
 
-                {/* Link */}
+                {/* Artifact Link — points at the evidence itself. Distinct
+                    from External Ticket Link below, which points at the ticket
+                    tracking this artifact in Jira/ServiceNow. */}
                 <div className="mb-4">
-                  <label className="text-sm text-gray-500 dark:text-gray-400 block mb-1">Link</label>
+                  <label className="text-sm text-gray-500 dark:text-gray-400 block mb-1">Artifact Link</label>
                   {editMode ? (
                     <input
                       type="text"
@@ -865,6 +872,59 @@ const Artifacts = () => {
                     )
                   ) : (
                     <p className="text-sm text-gray-400 dark:text-gray-500">No link provided</p>
+                  )}
+                </div>
+
+                {/* External Ticket Link */}
+                <div className="mb-4">
+                  <label className="text-sm text-gray-500 dark:text-gray-400 block mb-1">External Ticket Link</label>
+                  {editMode ? (
+                    <input
+                      type="url"
+                      name="externalUrl"
+                      value={formData.externalUrl || ''}
+                      onChange={handleChange}
+                      className="w-full p-2 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white"
+                      placeholder="https://... (ticket in Jira, ServiceNow, etc.)"
+                    />
+                  ) : selectedArtifact?.externalUrl ? (
+                    sanitizeExternalUrl(selectedArtifact.externalUrl) ? (
+                      <a
+                        href={sanitizeExternalUrl(selectedArtifact.externalUrl)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1 break-all"
+                      >
+                        <ExternalLink size={14} />
+                        {selectedArtifact.externalUrl}
+                      </a>
+                    ) : (
+                      <p className="text-sm text-gray-700 dark:text-gray-300 break-all">
+                        {selectedArtifact.externalUrl}
+                        <span className="text-xs text-gray-400 ml-1">(only http/https URLs render as links)</span>
+                      </p>
+                    )
+                  ) : (
+                    <p className="text-sm text-gray-400 dark:text-gray-500">No external ticket linked</p>
+                  )}
+                </div>
+
+                {/* Ticket ID */}
+                <div className="mb-4">
+                  <label className="text-sm text-gray-500 dark:text-gray-400 block mb-1">Ticket ID</label>
+                  {editMode ? (
+                    <input
+                      type="text"
+                      name="jiraKey"
+                      value={formData.jiraKey || ''}
+                      onChange={handleChange}
+                      className="w-full p-2 text-sm border dark:border-gray-600 rounded bg-white dark:bg-gray-700 dark:text-white"
+                      placeholder="e.g., EV-42"
+                    />
+                  ) : (
+                    <p className="text-sm text-gray-700 dark:text-gray-300">
+                      {selectedArtifact?.jiraKey || '-'}
+                    </p>
                   )}
                 </div>
 

--- a/src/pages/UserControls.js
+++ b/src/pages/UserControls.js
@@ -461,6 +461,7 @@ const UserControls = () => {
         'Tests': 'Sample 25 accounts per quarter; confirm reviewer sign-off in the ticket.',
         'Frameworks': 'NIST CSF 2.0; SOC 2',
         'Control Implementation Description': 'Example control description',
+        'External Ticket Link': 'https://example.atlassian.net/browse/CTL-1',
         'Control Owner ID': 'Owner Name <owner@example.com>',
         'Stakeholder IDs': 'Person One <person1@example.com>; Person Two <person2@example.com>',
         'Linked Requirements': 'GV.OC-01-01; GV.OC-01-02'
@@ -474,6 +475,7 @@ const UserControls = () => {
       'Tests',
       'Frameworks',
       'Control Implementation Description',
+      'External Ticket Link',
       'Control Owner ID',
       'Stakeholder IDs',
       'Linked Requirements'
@@ -1037,6 +1039,42 @@ const UserControls = () => {
                             {currentControl.implementationDescription || 'No description'}
                           </Markdown>
                         </div>
+                      )}
+                    </div>
+
+                    {/* External Ticket Link — controls is already an
+                        EXTERNAL_LINK_TYPE and the record already stored
+                        externalUrl; this is the surface that was missing. */}
+                    <div>
+                      <label className="text-sm font-medium text-gray-500">External Ticket Link</label>
+                      {editMode || isCreating ? (
+                        <input
+                          type="url"
+                          value={currentControl.externalUrl || ''}
+                          onChange={(e) => handleFieldChange('externalUrl', e.target.value)}
+                          className="mt-1 w-full p-2 border rounded"
+                          placeholder="https://... (ticket in Jira, ServiceNow, etc.)"
+                        />
+                      ) : currentControl.externalUrl ? (
+                        sanitizeExternalUrl(currentControl.externalUrl) ? (
+                          <p className="mt-1">
+                            <a
+                              href={sanitizeExternalUrl(currentControl.externalUrl)}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-sm text-blue-600 dark:text-blue-400 hover:underline break-all"
+                            >
+                              {currentControl.externalUrl}
+                            </a>
+                          </p>
+                        ) : (
+                          <p className="mt-1 text-sm break-all">
+                            {currentControl.externalUrl}
+                            <span className="text-xs text-gray-400 ml-1">(only http/https URLs render as links)</span>
+                          </p>
+                        )
+                      ) : (
+                        <p className="mt-1 text-sm text-gray-400">No external ticket linked</p>
                       )}
                     </div>
 

--- a/src/stores/artifactStore.js
+++ b/src/stores/artifactStore.js
@@ -86,7 +86,8 @@ export const ARTIFACT_CSV_HEADERS = [
   'Priority',
   'Control ID',
   'Assessment ID',
-  'Link',
+  'Artifact Link',
+  'External Ticket Link',
   'Description',
   'Linked Subcategories',
   'Assignee',
@@ -95,7 +96,7 @@ export const ARTIFACT_CSV_HEADERS = [
   'Last Updated',
   'Linked Evaluation IDs',
   'Compliance Requirement',
-  'Jira Key'
+  'Ticket ID'
 ];
 
 /**
@@ -147,7 +148,11 @@ const useArtifactStore = create(
           artifactId: artifact.artifactId || `AR-${uuidv4()}`,
           name: artifact.name || '',
           description: artifact.description || '',
-          link: artifact.link || '', // URL to external evidence
+          link: artifact.link || '', // URL to the evidence itself
+          // Separate from `link`: where this artifact is tracked in an external
+          // system (Jira, ServiceNow). `link` points at the evidence, this
+          // points at the ticket about it.
+          externalUrl: artifact.externalUrl || '',
 
           // Primary link: Control (general evidence for a control)
           controlId: artifact.controlId || null,
@@ -395,7 +400,8 @@ const useArtifactStore = create(
           'Priority': csvFormulaGuard(a.priority || 'Medium'),
           'Control ID': csvFormulaGuard(a.controlId || ''),
           'Assessment ID': csvFormulaGuard(a.assessmentId || ''),
-          'Link': csvFormulaGuard(a.link || ''),
+          'Artifact Link': csvFormulaGuard(a.link || ''),
+          'External Ticket Link': csvFormulaGuard(a.externalUrl || ''),
           'Description': csvFormulaGuard(a.description),
           'Linked Subcategories': csvFormulaGuard((a.linkedSubcategoryIds || []).join('; ')), // Deprecated
           'Assignee': csvFormulaGuard(serializeArtifactUser(a.assigneeId, users)),
@@ -408,7 +414,7 @@ const useArtifactStore = create(
           'Last Updated': csvFormulaGuard(a.lastModified || ''),
           'Linked Evaluation IDs': csvFormulaGuard((a.linkedEvaluationIds || []).join('; ')),
           'Compliance Requirement': csvFormulaGuard(a.complianceRequirement || ''), // Deprecated
-          'Jira Key': csvFormulaGuard(a.jiraKey || '')
+          'Ticket ID': csvFormulaGuard(a.jiraKey || '')
         }));
 
         const csv = Papa.unparse(csvData, { columns: ARTIFACT_CSV_HEADERS });
@@ -494,7 +500,10 @@ const useArtifactStore = create(
                     // the Jira AR column. All three still land here.
                     name: row['Artifact Name'] || row['Name'] || row['Summary'] || '',
                     description: row['Description'] || '',
-                    link: row['Link'] || row['Custom field (Link)'] || '',
+                    // 'Artifact Link' is the current name; 'Link' is what this
+                    // app exported before 2026-08-05. Both still load.
+                    link: row['Artifact Link'] || row['Link'] || row['Custom field (Link)'] || '',
+                    externalUrl: row['External Ticket Link'] || '',
                     type: row['Type'] || row['Custom field (Artifact Type)'] || 'Document',
 
                     // Primary link
@@ -523,7 +532,7 @@ const useArtifactStore = create(
                     // Without the column this is a brand new local record, so
                     // "now" is the honest answer.
                     lastModified: (row['Last Updated'] || '').trim() || new Date().toISOString(),
-                    jiraKey: row['Issue key'] || row['Jira Key'] || null,
+                    jiraKey: row['Ticket ID'] || row['Issue key'] || row['Jira Key'] || null,
                     // Panel-editable and list-visible since #306, but absent
                     // from the sheet until the 2026-08-04 parity pass — an
                     // export → import round-trip used to erase both.

--- a/src/stores/artifactsCsvUiParity.test.js
+++ b/src/stores/artifactsCsvUiParity.test.js
@@ -39,8 +39,9 @@ const headerLine = (csv) => csv.split('\n')[0].replace(/\r$/, '');
 describe('ARTIFACT_CSV_HEADERS is the single canonical column list', () => {
   it('carries every field the Key details / Details panel shows', () => {
     ['Artifact ID', 'Artifact Name', 'Type', 'Status', 'Health', 'Priority',
-      'Control ID', 'Assessment ID', 'Link', 'Description',
-      'Linked Subcategories', 'Assignee', 'Reporter', 'Last Updated'
+      'Control ID', 'Assessment ID', 'Artifact Link', 'External Ticket Link',
+      'Ticket ID', 'Description', 'Linked Subcategories', 'Assignee',
+      'Reporter', 'Last Updated'
     ].forEach((header) => {
       expect(ARTIFACT_CSV_HEADERS).toContain(header);
     });

--- a/src/stores/controlsStore.js
+++ b/src/stores/controlsStore.js
@@ -432,6 +432,7 @@ const useControlsStore = create(
                   tests: row['Tests'] || row.tests || '',
                   frameworks: row['Frameworks'] || row.frameworks || '',
                   implementationDescription: sanitizeInput(row['Control Implementation Description'] || row.implementationDescription || ''),
+                  externalUrl: row['External Ticket Link'] || row.externalUrl || '',
                   ownerId,
                   stakeholderIds,
                   linkedRequirementIds: row['Linked Requirements']
@@ -473,6 +474,9 @@ const useControlsStore = create(
           'Tests': csvFormulaGuard(c.tests || ''),
           'Frameworks': csvFormulaGuard(c.frameworks || ''),
           'Control Implementation Description': csvFormulaGuard(c.implementationDescription),
+          // Where this control is tracked in an external system (#284 pattern,
+          // already stored on the record and already a known EXTERNAL_LINK_TYPE).
+          'External Ticket Link': csvFormulaGuard(c.externalUrl || ''),
           'Control Owner': csvFormulaGuard(getUserName(c.ownerId)),
           'Control Owner ID': csvFormulaGuard(c.ownerId || ''),
           'Stakeholder(s)': csvFormulaGuard((c.stakeholderIds || []).map(id => getUserName(id)).join('; ')),

--- a/src/utils/__snapshots__/dataExportGolden.test.js.snap
+++ b/src/utils/__snapshots__/dataExportGolden.test.js.snap
@@ -545,6 +545,7 @@ Object {
         "controlId": "CTRL-1",
         "createdDate": "2026-01-01",
         "description": "Quarterly evidence",
+        "externalUrl": "",
         "health": "Healthy",
         "id": "AR-row-1",
         "jiraKey": "AJ-1",

--- a/src/utils/shareRegistry.js
+++ b/src/utils/shareRegistry.js
@@ -314,6 +314,9 @@ const ARTIFACT = struct({
   name: SHARE,
   description: SHARE,
   link: { default: EMPTY_STRING, includePrivate: SHARE }, // #284
+  // Same class as findings.externalUrl: a URL the user typed pointing at their
+  // own tracker. Rides shares like `link` does.
+  externalUrl: { default: EMPTY_STRING, includePrivate: SHARE },
   controlId: SHARE,
   assessmentId: SHARE,
   linkedEvaluationIds: SHARE,


### PR DESCRIPTION
Controls: adds the External Ticket Link panel field plus template, export and import columns. The field was already stored on the record and 'controls' was already a registered EXTERNAL_LINK_TYPE — only the surfaces were missing.

Artifacts: renames Link to Artifact Link, adds a new External Ticket Link field (artifacts had no externalUrl at all), and renames Jira Key to Ticket ID for consistency with Findings.

Both renames keep the old column names loadable (Link, Jira Key, Issue key), so previously exported CSVs still import.

The new artifact externalUrl is declared SHARE in the share registry, same class as link. Golden envelope snapshot updated — diff is exactly one line.

1450 tests pass, 0 lint errors.